### PR TITLE
Fix curation audit issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The core insight is that many cancer-targetable peptides are **shared across pat
 Perseus combines curated shared targets with per-patient tumor data to produce a prioritized list of peptide-MHC complexes.
 
 **Shared targets** (curated once, reused across patients):
-- **CTA genes** — 358 curated from 5 databases, 257 after HPA tissue-restriction filtering
+- **CTA genes** — 358 curated from 5 databases, 257 after HPA tissue expression filtering
 - **Viral proteomes** — 9 oncogenic viruses (HPV, EBV, HBV, HCV, HTLV-1, HIV, HHV-8, MCPyV, MCV)
 - **Hotspot mutations** — 19 recurrent mutations across 8 driver genes
 
@@ -50,7 +50,7 @@ pip install tsarina[all]
 
 Proteins normally restricted to reproductive tissues (testis, ovary, placenta) that become aberrantly expressed in tumors. Their tissue restriction means immune responses against them should not damage normal somatic tissues. Thymus expression is expected (AIRE-mediated central tolerance) and excluded from restriction checks.
 
-**358 genes** from 5 source databases, systematically filtered using Human Protein Atlas v23 tissue expression data to **257 expressed, reproductive-restricted CTAs**.
+**358 genes** from 5 source databases, systematically filtered using Human Protein Atlas v23 tissue expression data to **257 expressed CTAs** with predominantly reproductive-restricted expression (some pass the adaptive filter with minor somatic RNA signal).
 
 ```python
 from tsarina import CTA_gene_names, CTA_gene_ids, CTA_evidence

--- a/tasks/curation_tissue_logic_report.md
+++ b/tasks/curation_tissue_logic_report.md
@@ -1,0 +1,185 @@
+# Curation And Tissue Logic Audit Report
+
+Date: 2026-04-04
+
+Scope:
+- `tsarina` CTA curation, restriction synthesis, and gene-set helpers
+- `hitlist` source classification, tissue categories, and PMID override handling
+
+Method:
+- Read the relevant code and docs.
+- Queried the shipped `CTA_evidence()` table for internal inconsistencies.
+- Ran small synthetic calls against `hitlist.curation.classify_ms_row()` to verify override behavior.
+
+## Findings
+
+### 1. High: `tsarina`'s local IEDB wrapper drops `hitlist` curation inputs, so curated adjacent/healthy calls are wrong
+
+Code path:
+- `tsarina/iedb.py:301-304`
+- `tsarina/iedb.py:381-382`
+- `hitlist/hitlist/curation.py:218-245`
+- `hitlist/hitlist/data/pmid_overrides.yaml:37-70`
+
+What is happening:
+- `tsarina.iedb.scan_public_ms()` and `tsarina.iedb.profile_dataset()` call `hitlist.curation.classify_ms_row(...)`, but they do not pass `pmid` or `mhc_restriction`.
+- `hitlist` needs `pmid` to apply study-specific overrides and `mhc_restriction` for mono-allelic detection.
+- As a result, `tsarina` does not actually use the full `hitlist` curation logic even though the package says MS curation is delegated to `hitlist`.
+
+Concrete example:
+- `classify_ms_row("No immunization", "healthy", "Direct Ex Vivo", "Lung", pmid=35051231)` returns `src_adjacent_to_tumor=True`.
+- The same call without the PMID returns `src_healthy_tissue=True`.
+- `tsarina` currently behaves like the second case, because it omits the PMID.
+
+Impact:
+- `target_peptides(..., cancer_specific=True)` can treat curated tumor-adjacent samples as healthy tissue or vice versa.
+- `healthy_tissue_peptides()` and `healthy_tissue_peptide_details()` can build the wrong negative set.
+- The behavior of `tsarina` and `hitlist` diverges for the same underlying IEDB rows.
+
+Recommendation:
+- Stop reimplementing scanning in `tsarina/iedb.py`; call `hitlist.scanner.scan()` directly.
+- If the wrapper stays, pass through `pmid`, `submission_id`, `mhc_restriction`, and host fields exactly as `hitlist.scanner` does.
+
+### 2. High: `hitlist` defines a `healthy` override type, but the classifier never applies it
+
+Code path:
+- `hitlist/hitlist/curation.py:247-276`
+- `hitlist/hitlist/data/pmid_overrides.yaml:10-16`
+- `hitlist/hitlist/data/pmid_overrides.yaml:26-40`
+- `hitlist/hitlist/data/pmid_overrides.yaml:83-100`
+- `hitlist/docs/pmid-curation.md:7-13`
+
+What is happening:
+- YAML and docs define `healthy` as a valid override.
+- `classify_ms_row()` has branches for `cancer_patient`, `adjacent`, `activated_apc`, and `cell_line`, but not for `healthy`.
+- Any `healthy` override therefore falls through to the default structured-field logic.
+
+Concrete example:
+- `classify_ms_row("Occurrence of cancer", "melanoma", "Direct Ex Vivo", "Liver", pmid=33858848)` still returns `src_cancer=True` even though PMID `33858848` is declared `override: healthy`.
+- The same failure happens for rule-level `healthy` overrides such as PMID `36589698`.
+
+Impact:
+- Any study that actually needs a `healthy` override to correct bad IEDB fields will still be misclassified.
+- The YAML gives a false sense that these studies are protected by curation when they are not.
+
+Recommendation:
+- Add an explicit `healthy` branch that forces the row into the healthy-donor path.
+- Add a regression test using a deliberately misannotated row plus a `healthy` PMID override.
+
+### 3. Medium: `hitlist` claims submission-ID override support, but the code does not implement it
+
+Code path:
+- `hitlist/hitlist/data/pmid_overrides.yaml:21-22`
+- `hitlist/hitlist/scanner.py:239`
+- `hitlist/hitlist/scanner.py:256-266`
+- `hitlist/hitlist/curation.py:150-158`
+- `hitlist/hitlist/curation.py:196-244`
+
+What is happening:
+- The override YAML says studies without PMIDs can use `submission_id`, and that the curation code checks both.
+- `scanner.py` reads `submission_id`, but `classify_ms_row()` has no `submission_id` parameter and only looks up integer PMIDs.
+
+Impact:
+- Any dataset rows keyed only by submission ID cannot be curated despite the docs and YAML comment saying they can.
+- This is currently a silent capability gap.
+
+Recommendation:
+- Either implement `submission_id` lookup end-to-end or remove the claim from the YAML/docs.
+
+### 4. High: `tsarina` axis-based CTA helpers leak filtered-out genes back into the public sets
+
+Code path:
+- `tsarina/gene_sets.py:139-147`
+- `tsarina/gene_sets.py:150-223`
+
+What is happening:
+- `_axis_filter()` and `CTA_by_axes()` operate on the full 358-row CTA universe.
+- They do not restrict to `filtered == True`.
+- The helper names and docs read like they return CTA subsets, but they currently return filtered plus excluded candidates.
+
+Concrete evidence from the shipped table:
+- `CTA_testis_restricted_gene_names()` returns 245 genes, including 18 filtered-out genes:
+  `ACRBP, CABYR, CTAG2, EPPIN, GAGE2E, GAPDHS, GOLGA6B, GOLGA6C, GPX5, MAEL, MAGEA11, MAGEB3, PATE1, PATE4, ROPN1B, SKA3, TEX15, XAGE1B`
+- `CTA_by_axes(restriction="REPRODUCTIVE")` includes 4 filtered-out genes:
+  `BSPH1, CSN3, LALBA, SPAG11A`
+
+Impact:
+- Downstream users can accidentally resurrect genes that were explicitly excluded from the curated CTA set.
+- README counts are now misleading because the helper outputs no longer match the curated population they describe.
+
+Recommendation:
+- Make axis helpers filtered-by-default.
+- If access to the unfiltered universe is needed, add an explicit `filtered_only=False` knob instead of the current silent behavior.
+
+### 5. High: the default CTA set is described as “reproductive-restricted”, but 16 shipped default genes are synthesized as `SOMATIC`
+
+Code path:
+- `README.md:51-54`
+- `README.md:101-113`
+- `tsarina/tiers.py:158-214`
+
+What is happening:
+- `CTA_gene_names()` returns 257 “expressed CTAs”.
+- The README describes these as “257 expressed, reproductive-restricted CTAs”.
+- In the shipped `CTA_evidence()` table, 16 genes in that default set have `restriction == "SOMATIC"` and no protein evidence, meaning the synthesized restriction logic itself says they are somatic rather than reproductive-only.
+
+Examples from the shipped table:
+
+| Symbol | Max somatic tissue | Max somatic nTPM | Somatic tissues detected |
+|---|---|---:|---:|
+| `RNF148` | cerebellum | 9.9 | 2 |
+| `TULP2` | cerebral cortex | 8.4 | 15 |
+| `SPATA22` | white matter | 4.4 | 9 |
+| `XAGE1A` | liver | 1.5 | 1 |
+| `MEIOB` | kidney | 1.0 | 1 |
+
+Interpretation:
+- This comes from the current “deflated fraction >= 0.99” rule for no-protein genes.
+- A gene can therefore pass the CTA filter even when `rna_restriction` is `SOMATIC`, as long as testis-heavy expression keeps the fraction above 0.99.
+
+Impact:
+- The public description of the default CTA set overstates how clean the restriction filter currently is.
+- Users relying on the helper name alone would assume these genes have no meaningful somatic RNA evidence, which is false.
+
+Recommendation:
+- Decide which claim is correct:
+  - If the biological intent is truly “reproductive-restricted”, require `rna_reproductive == True` when protein data is missing/unreliable.
+  - If the intent is “reproductive-dominant but not necessarily exclusive”, rename the filter/set/docs accordingly.
+
+### 6. Low: public annotations/docs are stale relative to the shipped restriction schema
+
+Code path:
+- `README.md:64-71`
+- `README.md:167-179`
+- `tsarina/evidence.py:74-101`
+- `tsarina/__init__.py:53-86`
+
+What is happening:
+- Docs still advertise `OVARIAN` restriction values and old source flags like `src_healthy`, `src_reproductive`, and `src_thymus`.
+- The shipped CSV actually uses:
+  - `TESTIS`, `PLACENTAL`, `REPRODUCTIVE`, `SOMATIC`, `NO_DATA`
+  - `src_healthy_tissue`, `src_healthy_reproductive`, `src_healthy_thymus`
+- `tsarina.__all__` still exports `CTA_ovarian_restricted_gene_ids` and `CTA_ovarian_restricted_gene_names`, but those symbols do not exist. `from tsarina import *` raises `AttributeError`.
+
+Impact:
+- Public-facing documentation and exports no longer describe the actual annotation schema.
+- This is easy to trip over during exploratory analysis.
+
+Recommendation:
+- Update the docs/docstrings to match the real columns and values.
+- Remove or implement the stale ovarian exports.
+
+## Overall Assessment
+
+The biggest practical risk is not the tissue vocabulary itself; it is curation drift between the packages:
+- `hitlist` has override machinery that is partially nonfunctional (`healthy`, `submission_id`).
+- `tsarina` bypasses part of that machinery anyway by using its own scanner wrapper.
+
+On the CTA side, the most important issue is semantic drift:
+- the default/public CTA sets are described as reproductive-restricted,
+- but the shipped table and exported helpers do not consistently enforce that meaning.
+
+If I were fixing this next, I would do it in this order:
+1. Make `tsarina` use `hitlist.scanner.scan()` directly.
+2. Fix `healthy` override handling in `hitlist`.
+3. Decide whether CTA filtering is meant to be exclusive or merely dominant, then align the data, helpers, and docs to that decision.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,0 +1,21 @@
+# Curation And Tissue Logic Audit
+
+## Spec
+
+- [x] Read project instructions in `AGENTS.md`.
+- [x] Check for prior lessons in `tasks/lessons.md`.
+  Result: file does not exist yet.
+- [x] Inspect `tsarina` CTA curation and tissue restriction code paths.
+  Focus: reproductive tissue sets, HPA thresholding, CTA evidence/tier annotations, and any documentation or test mismatches.
+- [x] Inspect `hitlist` source classification code as used by `tsarina`.
+  Focus: tissue category loading, healthy/reproductive/thymus labeling, cancer-specific classification, and potential annotation drift.
+- [x] Cross-check implementation against tests and exposed docs.
+  Focus: places where code behavior differs from README/docs wording or expected curation semantics.
+- [x] Write a report with concrete findings.
+  Deliverable: a markdown report with severity, evidence, and recommended fixes.
+
+## Review
+
+- Report written to `tasks/curation_tissue_logic_report.md`.
+- Highest-risk finding: `tsarina/iedb.py` bypasses key `hitlist` curation inputs, so PMID overrides are not applied in `tsarina` scans.
+- Highest-risk CTA finding: the default CTA set includes 16 genes whose shipped synthesized restriction is `SOMATIC`.

--- a/tests/test_gene_sets.py
+++ b/tests/test_gene_sets.py
@@ -99,9 +99,8 @@ def test_testis_restricted_nonempty():
     assert len(CTA_testis_restricted_gene_names()) >= 200
 
 
-def test_testis_restricted_includes_expressed():
-    # Synthesized TESTIS includes filtered + unfiltered genes
-    assert len(CTA_testis_restricted_gene_names() & CTA_gene_names()) > 200
+def test_testis_restricted_is_subset_of_filtered():
+    assert CTA_testis_restricted_gene_names() <= CTA_filtered_gene_names()
 
 
 def test_testis_restricted_ids_match_names():
@@ -119,8 +118,16 @@ def test_by_axes_restriction_testis():
     assert CTA_by_axes(restriction="TESTIS") == CTA_testis_restricted_gene_names()
 
 
-def test_by_axes_all_restrictions_covers_all_genes():
+def test_by_axes_all_restrictions_covers_filtered():
     all_r = CTA_by_axes(restriction={"TESTIS", "PLACENTAL", "REPRODUCTIVE", "SOMATIC", "NO_DATA"})
+    assert all_r == CTA_filtered_gene_names()
+
+
+def test_by_axes_unfiltered_covers_all():
+    all_r = CTA_by_axes(
+        restriction={"TESTIS", "PLACENTAL", "REPRODUCTIVE", "SOMATIC", "NO_DATA"},
+        filtered_only=False,
+    )
     assert all_r == CTA_unfiltered_gene_names()
 
 

--- a/tests/test_tiers.py
+++ b/tests/test_tiers.py
@@ -128,7 +128,7 @@ def test_synthesized_restriction_covers_all_genes():
 
 
 def test_synthesized_restriction_expressed_have_tissue():
-    """Expressed genes all have a non-NO_DATA restriction."""
+    """Expressed (filtered + not never_expressed) genes all have a tissue."""
     df = CTA_evidence()
     filt = df["filtered"].astype(str).str.lower() == "true"
     ne = df["never_expressed"].astype(str).str.lower() == "true"

--- a/tsarina/__init__.py
+++ b/tsarina/__init__.py
@@ -72,8 +72,6 @@ __all__ = [
     "CTA_gene_names",
     "CTA_never_expressed_gene_ids",
     "CTA_never_expressed_gene_names",
-    "CTA_ovarian_restricted_gene_ids",
-    "CTA_ovarian_restricted_gene_names",
     "CTA_placental_restricted_gene_ids",
     "CTA_placental_restricted_gene_names",
     "CTA_testis_restricted_gene_ids",

--- a/tsarina/evidence.py
+++ b/tsarina/evidence.py
@@ -73,13 +73,13 @@ def CTA_evidence() -> pd.DataFrame:
         True if no HPA protein data AND maximum RNA nTPM < 2.
     protein_restriction : str
         Protein-based tissue restriction: ``TESTIS``, ``PLACENTAL``,
-        ``OVARIAN``, or empty (no protein data).
+        or ``NO_DATA`` (no protein data).
     protein_testis, protein_ovary, protein_placenta : str
         Per-tissue IHC detection: ``"True"`` / ``"False"`` if protein
         data exists, empty string if no protein data.
     rna_restriction : str
         RNA-based tissue restriction: ``TESTIS``, ``PLACENTAL``,
-        ``OVARIAN``, ``REPRODUCTIVE``, or empty.
+        ``REPRODUCTIVE``, or ``NO_DATA``.
     rna_restriction_level : str
         RNA restriction quality: ``STRICT`` / ``MODERATE`` / ``PERMISSIVE``
         or empty.
@@ -96,7 +96,7 @@ def CTA_evidence() -> pd.DataFrame:
         runtime by :func:`CTA_detailed_evidence` when IEDB data available.
     restriction : str
         Synthesized restriction integrating protein + RNA + MS:
-        ``TESTIS`` / ``PLACENTAL`` / ``OVARIAN`` / ``REPRODUCTIVE`` / empty.
+        ``TESTIS`` / ``PLACENTAL`` / ``REPRODUCTIVE`` / ``SOMATIC`` / ``NO_DATA``.
     restriction_confidence : str
         Cross-modality confidence: ``HIGH`` / ``MODERATE`` / ``LOW`` / empty.
     """

--- a/tsarina/gene_sets.py
+++ b/tsarina/gene_sets.py
@@ -136,7 +136,9 @@ def CTA_excluded_gene_ids() -> set[str]:
 # ── Axis-based gene set functions ──────────────────────────────────────────
 
 
-def _axis_filter(column: str, axis_col: str, values: str | set[str]) -> set[str]:
+def _axis_filter(
+    column: str, axis_col: str, values: str | set[str], filtered_only: bool = True
+) -> set[str]:
     """Internal: filter genes by a single axis column value(s)."""
     df = cta_dataframe()
     if axis_col not in df.columns:
@@ -144,6 +146,8 @@ def _axis_filter(column: str, axis_col: str, values: str | set[str]) -> set[str]
     if isinstance(values, str):
         values = {values}
     mask = df[axis_col].isin(values)
+    if filtered_only and "filtered" in df.columns:
+        mask = mask & (df["filtered"].astype(str).str.lower() == "true")
     return _extract_values(df[mask], column)
 
 
@@ -183,6 +187,7 @@ def CTA_by_axes(
     ms_restriction: str | set[str] | None = None,
     restriction_confidence: str | set[str] | None = None,
     column: str = "Symbol",
+    filtered_only: bool = True,
 ) -> set[str]:
     """Return CTA gene identifiers matching specified axis values.
 
@@ -202,9 +207,15 @@ def CTA_by_axes(
         Synthesized confidence: HIGH / MODERATE / LOW (None = any).
     column
         Column to return (``"Symbol"`` or ``"Ensembl_Gene_ID"``).
+    filtered_only
+        If True (default), restrict to genes passing the HPA filter.
+        Set to False to query the full 358-gene CTA universe.
     """
     df = cta_dataframe()
     mask = True
+
+    if filtered_only and "filtered" in df.columns:
+        mask = df["filtered"].astype(str).str.lower() == "true"
 
     for axis_col, values in [
         ("restriction", restriction),

--- a/tsarina/iedb.py
+++ b/tsarina/iedb.py
@@ -300,7 +300,13 @@ def scan_public_ms(
                 record["culture_condition"] = culture_condition
                 record.update(
                     classify_ms_row(
-                        process_type, disease, culture_condition, source_tissue, cell_name
+                        process_type,
+                        disease,
+                        culture_condition,
+                        source_tissue,
+                        cell_name,
+                        pmid=pmid,
+                        mhc_restriction=mhc_restriction,
                     )
                 )
 
@@ -365,10 +371,20 @@ def profile_dataset(
             process_type = _safe_col(row, c["process_type"])
             disease = _safe_col(row, c["disease"])
             culture_condition = _safe_col(row, c["culture_condition"])
+            mhc_restriction = _safe_col(row, c["mhc_restriction"])
+
+            raw_pmid = _safe_col(row, c["pmid"]).strip()
+            pmid: str | int = ""
+            if raw_pmid:
+                try:
+                    pmid = int(raw_pmid)
+                except ValueError:
+                    pmid = raw_pmid
 
             record = {
                 "peptide": _safe_col(row, c["epitope_name"]),
-                "mhc_restriction": _safe_col(row, c["mhc_restriction"]),
+                "pmid": pmid,
+                "mhc_restriction": mhc_restriction,
                 "mhc_class": _safe_col(row, c["mhc_class"]),
                 "process_type": process_type,
                 "disease": disease,
@@ -379,7 +395,15 @@ def profile_dataset(
                 "species": species,
             }
             record.update(
-                classify_ms_row(process_type, disease, culture_condition, source_tissue, cell_name)
+                classify_ms_row(
+                    process_type,
+                    disease,
+                    culture_condition,
+                    source_tissue,
+                    cell_name,
+                    pmid=pmid,
+                    mhc_restriction=mhc_restriction,
+                )
             )
             rows.append(record)
 

--- a/tsarina/version.py
+++ b/tsarina/version.py
@@ -10,4 +10,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.4.0"
+__version__ = "0.4.1"


### PR DESCRIPTION
## Summary

Fixes from `tasks/curation_tissue_logic_report.md` audit:

- **#1 (High)**: `tsarina/iedb.py` now passes `pmid` and `mhc_restriction` to `hitlist.classify_ms_row()`, enabling PMID-level curation overrides (adjacent tissue, healthy donor reclassification)
- **#4 (High)**: Axis helpers (`CTA_testis_restricted_gene_names`, `CTA_by_axes`) now gate on `filtered=True` by default — previously leaked 18+ unfiltered genes into results. Opt out with `filtered_only=False`
- **#5 (High)**: README updated from "reproductive-restricted" to "predominantly reproductive-restricted" — 16 expressed CTAs have `restriction=SOMATIC` due to minor somatic RNA signal
- **#6 (Low)**: Removed stale `CTA_ovarian_restricted_*` exports from `__all__`, updated `evidence.py` docstrings to match shipped schema (OVARIAN folded into REPRODUCTIVE)

Also fixes hitlist healthy override (separate commit pushed to pirl-unc/hitlist).

## Test plan
- [x] `./format.sh` passes
- [x] `./lint.sh` passes
- [x] `./test.sh` — 116 passed, 1 skipped
- [x] `CTA_gene_names()` still returns 257
- [x] `CTA_testis_restricted_gene_names()` now returns only filtered genes