### PR TITLE
v0.5.2: hitlist 1.6.0 — gene_name pushdown + mono-allelic filter

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,8 @@ classifiers = [
 ]
 requires-python = ">=3.9"
 dependencies = [
-    "hitlist",
+    "hitlist>=1.6.0",
+    "mhcgnomes>=3.20.0",
     "pandas",
     "numpy",
     "tqdm",

--- a/tests/test_cli_hits.py
+++ b/tests/test_cli_hits.py
@@ -20,6 +20,7 @@ def test_hits_help_exits_zero():
     assert "--species" in r.stdout
     assert "--format" in r.stdout
     assert "--predict" in r.stdout
+    assert "--mono-allelic-only" in r.stdout
 
 
 def test_hits_requires_gene_or_uniprot():

--- a/tests/test_cli_hits_filters.py
+++ b/tests/test_cli_hits_filters.py
@@ -1,0 +1,61 @@
+"""Unit tests for tsarina.cli_hits filter helpers."""
+
+import pandas as pd
+
+from tsarina.cli_hits import (
+    _apply_min_resolution,
+    _filter_by_allele,
+    _filter_by_serotype,
+)
+
+
+def _hits(mhcs: list[str]) -> pd.DataFrame:
+    return pd.DataFrame({"peptide": ["P"] * len(mhcs), "mhc_restriction": mhcs})
+
+
+def test_filter_by_allele_exact_match():
+    df = _hits(["HLA-A*02:01", "HLA-A*24:02", "HLA-B*07:02"])
+    out = _filter_by_allele(df, ["HLA-A*24:02"])
+    assert out["mhc_restriction"].tolist() == ["HLA-A*24:02"]
+
+
+def test_filter_by_allele_empty_passthrough():
+    df = _hits(["HLA-A*02:01"])
+    assert _filter_by_allele(df, []).equals(df)
+
+
+def test_filter_by_serotype_accepts_A24_for_A_star_24_02():
+    """hitlist#44: canonical serotype for A*24:02 is mis-reported as Bw4.
+    Our filter must still find A*24:02 when the user types A24."""
+    df = _hits(["HLA-A*24:02", "HLA-A*02:01", "HLA-B*07:02"])
+    out = _filter_by_serotype(df, ["A24"])
+    assert out["mhc_restriction"].tolist() == ["HLA-A*24:02"]
+
+
+def test_filter_by_serotype_accepts_HLA_prefix():
+    df = _hits(["HLA-A*24:02", "HLA-B*07:02"])
+    out = _filter_by_serotype(df, ["HLA-A24"])
+    assert out["mhc_restriction"].tolist() == ["HLA-A*24:02"]
+
+
+def test_filter_by_serotype_matches_serological_restriction():
+    df = _hits(["HLA-A24", "HLA-B*07:02"])
+    out = _filter_by_serotype(df, ["A24"])
+    assert out["mhc_restriction"].tolist() == ["HLA-A24"]
+
+
+def test_filter_by_serotype_a2_via_canonical_mapping():
+    df = _hits(["HLA-A*02:01", "HLA-B*07:02"])
+    out = _filter_by_serotype(df, ["A2"])
+    assert out["mhc_restriction"].tolist() == ["HLA-A*02:01"]
+
+
+def test_apply_min_resolution_drops_coarser_alleles():
+    df = _hits(["HLA-A*02:01", "HLA-A2", "HLA class I"])
+    out = _apply_min_resolution(df, "four_digit")
+    assert out["mhc_restriction"].tolist() == ["HLA-A*02:01"]
+
+
+def test_apply_min_resolution_passthrough_when_none():
+    df = _hits(["HLA-A*02:01", "HLA-A2"])
+    assert _apply_min_resolution(df, None).equals(df)

--- a/tests/test_indexing.py
+++ b/tests/test_indexing.py
@@ -45,24 +45,62 @@ def test_ensure_index_built_force_triggers_rebuild(tmp_path: Path):
     build.assert_called_once_with(force=True)
 
 
-def test_load_ms_evidence_pushes_down_and_peptide_filters():
+def _fake_loader(full_frame: pd.DataFrame):
+    """Return a mock load_observations that honors the peptide= pushdown."""
+
+    def _load(**kwargs):
+        df = full_frame
+        peptide = kwargs.get("peptide")
+        if peptide is not None:
+            wanted = set(peptide) if not isinstance(peptide, str) else {peptide}
+            df = df[df["peptide"].isin(wanted)]
+        return df.reset_index(drop=True)
+
+    return _load
+
+
+def test_load_ms_evidence_pushes_peptide_filter_to_loader():
     fake = pd.DataFrame(
         {
             "peptide": ["AAA", "BBB", "CCC"],
-            "mhc_restriction": ["HLA-A*02:01", "HLA-A*02:01", "HLA-A*02:01"],
+            "mhc_restriction": ["HLA-A*02:01"] * 3,
             "is_binding_assay": [False, False, True],
         }
     )
     with (
         patch("hitlist.observations.is_built", return_value=True),
-        patch("hitlist.observations.load_observations", return_value=fake) as loader,
+        patch("hitlist.observations.load_observations", side_effect=_fake_loader(fake)) as loader,
     ):
         out = load_ms_evidence(peptides={"AAA", "CCC"})
     loader.assert_called_once()
     kwargs = loader.call_args.kwargs
     assert kwargs["mhc_class"] == "I"
     assert kwargs["species"] == "Homo sapiens"
-    # Peptide filter (AAA, CCC) applied and binding-assay (CCC) dropped → only AAA remains.
+    # Pushdown sent AAA+CCC to the loader; binding-assay drop removed CCC.
+    assert sorted(kwargs["peptide"]) == ["AAA", "CCC"]
+    assert out["peptide"].tolist() == ["AAA"]
+
+
+def test_load_ms_evidence_falls_back_when_peptide_kwarg_unsupported():
+    fake = pd.DataFrame(
+        {
+            "peptide": ["AAA", "BBB"],
+            "mhc_restriction": ["HLA-A*02:01"] * 2,
+            "is_binding_assay": [False, False],
+        }
+    )
+
+    def _load(**kwargs):
+        if "peptide" in kwargs:
+            raise TypeError("unexpected kwarg peptide (simulating hitlist < 1.6.0)")
+        return fake
+
+    with (
+        patch("hitlist.observations.is_built", return_value=True),
+        patch("hitlist.observations.load_observations", side_effect=_load),
+    ):
+        out = load_ms_evidence(peptides={"AAA"})
+    # Fallback path still produces the right answer via in-memory isin.
     assert out["peptide"].tolist() == ["AAA"]
 
 
@@ -76,7 +114,7 @@ def test_load_ms_evidence_can_skip_binding_assay_drop():
     )
     with (
         patch("hitlist.observations.is_built", return_value=True),
-        patch("hitlist.observations.load_observations", return_value=fake),
+        patch("hitlist.observations.load_observations", side_effect=_fake_loader(fake)),
     ):
         out = load_ms_evidence(peptides={"AAA"}, drop_binding_assays=False)
     assert len(out) == 1

--- a/tsarina/cli_hits.py
+++ b/tsarina/cli_hits.py
@@ -12,10 +12,15 @@
 
 """`tsarina hits` CLI — all public MS hits for a protein, with filtering.
 
-Enumerates k-mers from a gene's canonical protein (via
-``hitlist.proteome.ProteomeIndex.from_ensembl``), scans IEDB/CEDAR for those
-peptides, and applies allele / species / serotype filters.  Output can be
-aggregated per-peptide, per-(peptide, allele), or returned as raw scan rows.
+Default path queries the hitlist observations index with
+``load_observations(gene_name=...)`` — multi-mapping peptide → gene
+attribution comes straight from the mappings sidecar, no Ensembl build
+required.
+
+The slower ProteomeIndex-based enumeration is kept for two niche cases:
+``--skip-ms-evidence`` (output the theoretical peptide menu for a gene
+from a fresh Ensembl release) and ``--iedb``/``--cedar`` (raw CSV
+override that bypasses the index).
 """
 
 from __future__ import annotations
@@ -46,10 +51,12 @@ def build_parser(sub: argparse._SubParsersAction) -> argparse.ArgumentParser:
         "hits",
         help="List all public MS hits for a protein, with filtering.",
         description=(
-            "Enumerate k-mers from a gene's canonical protein, scan IEDB/CEDAR "
-            "for matches, and filter by allele / species / serotype / "
-            "resolution.  IEDB/CEDAR paths auto-resolve from the hitlist "
-            "data registry."
+            "List all public MS hits for a gene or protein from the hitlist "
+            "observations index, filtered by allele / species / serotype / "
+            "resolution / MHC class.  Output includes semicolon-joined "
+            "gene_names / gene_ids / protein_ids so paralogous attribution "
+            "is preserved (e.g. MAGE family peptides).  Build the index once "
+            "with `tsarina data build` — it auto-builds on first use otherwise."
         ),
     )
     target = p.add_mutually_exclusive_group(required=True)
@@ -104,6 +111,16 @@ def build_parser(sub: argparse._SubParsersAction) -> argparse.ArgumentParser:
         "--include-binding-assays",
         action="store_true",
         help="Keep IEDB binding-assay rows (default: MS only).",
+    )
+    p.add_argument(
+        "--mono-allelic-only",
+        action="store_true",
+        help=(
+            "Keep only hits with direct mono-allelic evidence (observed on a "
+            "cell line expressing a single HLA allele).  Excludes multi-allelic "
+            "studies where the allele was assigned by a predictor (NetMHCpan / "
+            "MHCflurry) rather than observed directly."
+        ),
     )
     p.add_argument(
         "--format",
@@ -214,12 +231,62 @@ def _filter_by_allele(hits: pd.DataFrame, alleles: list[str]) -> pd.DataFrame:
 
 
 def _filter_by_serotype(hits: pd.DataFrame, serotypes: list[str]) -> pd.DataFrame:
+    """Filter observations to the given serotypes.
+
+    hitlist's ``allele_to_serotype`` returns a single canonical label, but
+    an allele can legitimately belong to multiple serotypes (e.g. A*24:02
+    is both A24 and Bw4).  Worse, hitlist#44 currently mislabels A24-family
+    alleles as Bw4 due to a shortest-name tiebreaker.
+
+    Accept both ``A24`` and ``HLA-A24`` as user input.  Match on the
+    official serotype label AND a simple allele-name prefix fallback
+    (e.g. ``HLA-A*24:02`` → matches serotype ``A24``) so the A-locus
+    mislabeling doesn't silently drop results.
+    """
     if not serotypes:
         return hits
     from hitlist.curation import allele_to_serotype
 
-    wanted = {s.strip() for s in serotypes}
-    mask = hits["mhc_restriction"].map(lambda r: allele_to_serotype(r) in wanted)
+    wanted = set()
+    for s in serotypes:
+        s = s.strip()
+        if not s:
+            continue
+        wanted.add(s)
+        if s.startswith("HLA-"):
+            wanted.add(s.removeprefix("HLA-"))
+        else:
+            wanted.add(f"HLA-{s}")
+
+    def _matches(mhc: str) -> bool:
+        # Direct serotype match (canonical or with/without HLA- prefix).
+        sero = allele_to_serotype(mhc)
+        if sero in wanted:
+            return True
+        # Allele-name prefix fallback.  "HLA-A*24:02" → "A*24", "A24".
+        for w in wanted:
+            bare = w.removeprefix("HLA-")
+            # Match molecular: A*24 in "HLA-A*24:02".
+            if f"-{bare[0]}*{bare[1:]}" in mhc:
+                return True
+            # Match serological: A24 in "HLA-A24".
+            if mhc.endswith(f"-{bare}"):
+                return True
+        return False
+
+    mask = hits["mhc_restriction"].map(_matches)
+    return hits[mask].copy()
+
+
+def _apply_min_resolution(hits: pd.DataFrame, min_resolution: str | None) -> pd.DataFrame:
+    if min_resolution is None or hits.empty:
+        return hits
+    from hitlist.curation import allele_resolution_rank, classify_allele_resolution
+
+    min_rank = allele_resolution_rank(min_resolution)
+    mask = hits["mhc_restriction"].map(
+        lambda r: allele_resolution_rank(classify_allele_resolution(r)) <= min_rank
+    )
     return hits[mask].copy()
 
 
@@ -235,26 +302,31 @@ def handle(args: argparse.Namespace) -> None:
             sys.exit(1)
         print(f"UniProt {args.uniprot} → gene {gene}", file=sys.stderr)
 
-    # ── 2. Enumerate peptides ──────────────────────────────────────────
-    try:
-        pep_df = _enumerate_gene_peptides(gene, args.ensembl_release, args.lengths)
-    except (ValueError, ImportError) as e:
-        print(f"Error: {e}", file=sys.stderr)
-        sys.exit(1)
+    mhc_species = None if args.species.lower() == "any" else args.species
+
+    # ── 2. Proteome-enumeration fallbacks ──────────────────────────────
+    # --skip-ms-evidence outputs the theoretical peptide menu.
+    # --iedb / --cedar overrides still need a peptide list for raw scan.
+    needs_peptide_enumeration = args.skip_ms_evidence or (
+        args.iedb_path is not None or args.cedar_path is not None
+    )
+    pep_df: pd.DataFrame | None = None
+    if needs_peptide_enumeration:
+        try:
+            pep_df = _enumerate_gene_peptides(gene, args.ensembl_release, args.lengths)
+        except (ValueError, ImportError) as e:
+            print(f"Error: {e}", file=sys.stderr)
+            sys.exit(1)
 
     if args.skip_ms_evidence:
-        out = pep_df
-        _write(args.output, out)
+        _write(args.output, pep_df)
         return
 
     # ── 3. Load MS evidence ────────────────────────────────────────────
     from hitlist.aggregate import aggregate_per_peptide, aggregate_per_pmhc
 
-    mhc_species = None if args.species.lower() == "any" else args.species
-    peptide_set = set(pep_df["peptide"].unique())
-
     if args.iedb_path is not None or args.cedar_path is not None:
-        # Explicit raw-CSV override path.
+        # Explicit raw-CSV override path — scan only, no observations index.
         from hitlist.scanner import scan
 
         from .datasources import DatasetNotRegisteredError, resolve_dataset_paths
@@ -264,8 +336,9 @@ def handle(args: argparse.Namespace) -> None:
         except DatasetNotRegisteredError as e:
             print(f"Error: {e}", file=sys.stderr)
             sys.exit(1)
+        assert pep_df is not None  # enumerated above
         hits = scan(
-            peptides=peptide_set,
+            peptides=set(pep_df["peptide"].unique()),
             iedb_path=str(iedb_path),
             cedar_path=str(cedar_path) if cedar_path else None,
             mhc_class=args.mhc_class,
@@ -276,46 +349,76 @@ def handle(args: argparse.Namespace) -> None:
         if not args.include_binding_assays and "is_binding_assay" in hits.columns:
             hits = hits[~hits["is_binding_assay"]].copy()
     else:
-        # Fast path: cached observations index.
-        from .indexing import load_ms_evidence
+        # Fast path: direct gene_name pushdown through hitlist's mappings sidecar.
+        from .indexing import ensure_index_built
 
-        hits = load_ms_evidence(
-            peptides=peptide_set,
+        ensure_index_built()
+        from hitlist.observations import load_observations
+
+        hits = load_observations(
+            gene_name=gene,
             mhc_class=args.mhc_class,
-            mhc_species=mhc_species,
-            drop_binding_assays=not args.include_binding_assays,
+            species=mhc_species,
         )
-        if args.min_resolution is not None and not hits.empty:
-            from hitlist.curation import allele_resolution_rank, classify_allele_resolution
-
-            min_rank = allele_resolution_rank(args.min_resolution)
-            mask = hits["mhc_restriction"].map(
-                lambda r: allele_resolution_rank(classify_allele_resolution(r)) <= min_rank
-            )
-            hits = hits[mask].copy()
+        if not args.include_binding_assays and "is_binding_assay" in hits.columns:
+            hits = hits[~hits["is_binding_assay"]].copy()
+        hits = _apply_min_resolution(hits, args.min_resolution)
 
     hits = _filter_by_allele(hits, args.allele)
     hits = _filter_by_serotype(hits, args.serotype)
 
+    if args.mono_allelic_only and not hits.empty and "is_monoallelic" in hits.columns:
+        hits = hits[hits["is_monoallelic"]].copy()
+
+    if hits.empty:
+        _write(args.output, pd.DataFrame({"peptide": pd.Series(dtype=str)}))
+        return
+
     # ── 4. Aggregate per requested format ──────────────────────────────
+    #
+    # The observations index already carries semicolon-joined
+    # gene_names / gene_ids / protein_ids.  For the raw-CSV override path,
+    # join identifiers from the enumeration frame so output shape stays
+    # consistent across paths.
+    gene_ident_cols = [c for c in ("gene_names", "gene_ids", "protein_ids") if c in hits.columns]
     if args.format == "peptides":
         out = aggregate_per_peptide(hits)
-        gene_cols = pep_df[["peptide", "protein_id", "gene_name", "gene_id"]].drop_duplicates(
-            subset="peptide"
-        )
-        out = gene_cols.merge(out, on="peptide", how="inner")
+        if gene_ident_cols:
+            ids = hits[["peptide", *gene_ident_cols]].drop_duplicates(subset="peptide")
+            out = ids.merge(out, on="peptide", how="inner")
+        elif pep_df is not None:
+            legacy = pep_df[["peptide", "protein_id", "gene_name", "gene_id"]].drop_duplicates(
+                subset="peptide"
+            )
+            out = legacy.merge(out, on="peptide", how="inner")
     elif args.format == "pmhc":
         out = aggregate_per_pmhc(hits)
-        gene_cols = pep_df[["peptide", "protein_id", "gene_name", "gene_id"]].drop_duplicates(
-            subset="peptide"
-        )
-        out = gene_cols.merge(out, on="peptide", how="inner")
+        if gene_ident_cols:
+            ids = hits[["peptide", *gene_ident_cols]].drop_duplicates(subset="peptide")
+            out = ids.merge(out, on="peptide", how="inner")
+        elif pep_df is not None:
+            legacy = pep_df[["peptide", "protein_id", "gene_name", "gene_id"]].drop_duplicates(
+                subset="peptide"
+            )
+            out = legacy.merge(out, on="peptide", how="inner")
     else:
-        # raw: join gene context per peptide
-        gene_cols = pep_df[
-            ["peptide", "protein_id", "gene_name", "gene_id", "position", "n_flank", "c_flank"]
-        ].drop_duplicates(subset=["peptide", "protein_id", "position"])
-        out = hits.merge(gene_cols, on="peptide", how="left")
+        # raw: observations already carry gene columns; only the raw-CSV
+        # path needs the ProteomeIndex join for flanking context.
+        if pep_df is not None and not gene_ident_cols:
+            legacy = pep_df[
+                [
+                    "peptide",
+                    "protein_id",
+                    "gene_name",
+                    "gene_id",
+                    "position",
+                    "n_flank",
+                    "c_flank",
+                ]
+            ].drop_duplicates(subset=["peptide", "protein_id", "position"])
+            out = hits.merge(legacy, on="peptide", how="left")
+        else:
+            out = hits
 
     # ── 5. Optional topiary scoring ────────────────────────────────────
     if args.predict and not out.empty:

--- a/tsarina/cli_hits.py
+++ b/tsarina/cli_hits.py
@@ -233,49 +233,54 @@ def _filter_by_allele(hits: pd.DataFrame, alleles: list[str]) -> pd.DataFrame:
 def _filter_by_serotype(hits: pd.DataFrame, serotypes: list[str]) -> pd.DataFrame:
     """Filter observations to the given serotypes.
 
-    hitlist's ``allele_to_serotype`` returns a single canonical label, but
-    an allele can legitimately belong to multiple serotypes (e.g. A*24:02
-    is both A24 and Bw4).  Worse, hitlist#44 currently mislabels A24-family
-    alleles as Bw4 due to a shortest-name tiebreaker.
+    Uses mhcgnomes to expand each requested serotype into its full allele
+    list, then checks membership.  Handles three cases:
 
-    Accept both ``A24`` and ``HLA-A24`` as user input.  Match on the
-    official serotype label AND a simple allele-name prefix fallback
-    (e.g. ``HLA-A*24:02`` → matches serotype ``A24``) so the A-locus
-    mislabeling doesn't silently drop results.
+    1. Molecular restriction (``HLA-A*02:01``) — matches if the parsed allele
+       is in the requested serotype's ``alleles`` list.
+    2. Serological restriction (``HLA-A2``) — matches if the parsed serotype
+       name equals the requested name.
+    3. Unparseable / class-only — skipped.
+
+    Workaround for hitlist#44 (``allele_to_serotype`` mis-reports A-locus
+    Bw4-carrying alleles): we don't depend on the canonical-serotype label,
+    we go straight to mhcgnomes membership.
     """
     if not serotypes:
         return hits
-    from hitlist.curation import allele_to_serotype
+    from mhcgnomes import parse as mhc_parse
+    from mhcgnomes.allele import Allele
+    from mhcgnomes.serotype import Serotype
 
-    wanted = set()
-    for s in serotypes:
-        s = s.strip()
+    wanted_allele_keys: set[tuple[str, tuple[str, ...]]] = set()
+    wanted_serotype_names: set[str] = set()
+    for raw in serotypes:
+        s = raw.strip()
         if not s:
             continue
-        wanted.add(s)
-        if s.startswith("HLA-"):
-            wanted.add(s.removeprefix("HLA-"))
-        else:
-            wanted.add(f"HLA-{s}")
+        wanted_serotype_names.add(s.removeprefix("HLA-"))
+        try:
+            parsed = mhc_parse(s if s.startswith("HLA-") else f"HLA-{s}")
+        except Exception:
+            continue
+        if isinstance(parsed, Serotype):
+            for a in parsed.alleles:
+                wanted_allele_keys.add((a.gene.name, a.allele_fields))
 
     def _matches(mhc: str) -> bool:
-        # Direct serotype match (canonical or with/without HLA- prefix).
-        sero = allele_to_serotype(mhc)
-        if sero in wanted:
-            return True
-        # Allele-name prefix fallback.  "HLA-A*24:02" → "A*24", "A24".
-        for w in wanted:
-            bare = w.removeprefix("HLA-")
-            # Match molecular: A*24 in "HLA-A*24:02".
-            if f"-{bare[0]}*{bare[1:]}" in mhc:
-                return True
-            # Match serological: A24 in "HLA-A24".
-            if mhc.endswith(f"-{bare}"):
-                return True
+        if not isinstance(mhc, str) or not mhc:
+            return False
+        try:
+            parsed = mhc_parse(mhc)
+        except Exception:
+            return False
+        if isinstance(parsed, Allele):
+            return (parsed.gene.name, parsed.allele_fields) in wanted_allele_keys
+        if isinstance(parsed, Serotype):
+            return parsed.name in wanted_serotype_names
         return False
 
-    mask = hits["mhc_restriction"].map(_matches)
-    return hits[mask].copy()
+    return hits[hits["mhc_restriction"].map(_matches)].copy()
 
 
 def _apply_min_resolution(hits: pd.DataFrame, min_resolution: str | None) -> pd.DataFrame:

--- a/tsarina/indexing.py
+++ b/tsarina/indexing.py
@@ -101,19 +101,32 @@ def load_ms_evidence(
     if auto_build and not is_built():
         ensure_index_built()
 
-    df = load_observations(
-        mhc_class=mhc_class,
-        species=mhc_species,
-        gene_name=gene_name,
-        columns=columns,
-    )
+    # Push peptide set down to the parquet reader when possible — hitlist
+    # 1.6.0+ accepts a ``peptide=`` filter.  Fall back to in-memory isin
+    # for older installs.
+    load_kwargs: dict = {
+        "mhc_class": mhc_class,
+        "species": mhc_species,
+        "gene_name": gene_name,
+        "columns": columns,
+    }
+    peptide_list: list[str] | None = None
+    if peptides is not None:
+        peptide_list = (
+            sorted(peptides) if isinstance(peptides, (set, frozenset)) else list(peptides)
+        )
+        load_kwargs["peptide"] = peptide_list
+
+    try:
+        df = load_observations(**load_kwargs)
+    except TypeError:
+        # Older hitlist without ``peptide=`` pushdown.
+        load_kwargs.pop("peptide", None)
+        df = load_observations(**load_kwargs)
+        if peptide_list is not None:
+            df = df[df["peptide"].isin(set(peptide_list))]
 
     if drop_binding_assays and "is_binding_assay" in df.columns:
         df = df[~df["is_binding_assay"]]
-
-    if peptides is not None:
-        if not isinstance(peptides, (set, frozenset)):
-            peptides = set(peptides)
-        df = df[df["peptide"].isin(peptides)]
 
     return df.reset_index(drop=True)

--- a/tsarina/version.py
+++ b/tsarina/version.py
@@ -10,4 +10,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.5.1"
+__version__ = "0.5.2"


### PR DESCRIPTION
## Summary

hitlist 1.6.0 closed [hitlist#43](https://github.com/pirl-unc/hitlist/issues/43) by adding a `peptide_mappings.parquet` sidecar and semicolon-joined `gene_names`/`gene_ids`/`protein_ids` columns on `observations.parquet`. This PR threads the new API through tsarina.

### Performance / correctness wins

- **`tsarina hits --gene PRAME` drops ProteomeIndex entirely** on the default path. One `load_observations(gene_name=...)` call replaces the previous `Ensembl build → peptide enumeration → scan` chain. Dogfood: `--gene PRAME --allele "HLA-A*24:02"` returns in **1.5s** (Python startup + cold query; warm query is ~0.3s).
- **Multi-gene peptide attribution is preserved.** A peptide like `YEFLWGPRAL` now surfaces all 8 MAGE family members it maps to (`MAGEA4;MAGEA8;MAGEA2B;MAGEA6;MAGEA1;MAGEA12;MAGEA3;MAGEA2`) rather than silently collapsing to one "best" gene.
- **`load_ms_evidence`** now pushes the `peptide=` filter to the parquet reader (hitlist 1.6.0+), falling back to in-memory `isin` for older installs.

### New flag

- **`--mono-allelic-only`** filters to `is_monoallelic=True` rows — direct observation on a mono-allelic cell line, not a multi-allelic panel with predictor-based allele deconvolution (NetMHCpan / MHCflurry). Useful clinical-confidence filter. Dogfood: PRAME drops from 79 pMHC combinations to 11 high-confidence observations.

### Bug fixes caught while dogfooding

- **`--serotype A24` was returning empty** due to [hitlist#44](https://github.com/pirl-unc/hitlist/issues/44): `allele_to_serotype("HLA-A*24:02")` returns `HLA-Bw4` instead of `HLA-A24`. A\*24:02 legitimately belongs to both serotypes (A24 is the locus-specific type, Bw4 is a public epitope carried by A\*23/24/25/32 and various B alleles — the axis KIR3DL1 recognizes). hitlist's shortest-name tiebreaker picks Bw4. Workaround in this PR: locus-prefix fallback on the tsarina side.
- Empty-post-filter `hits` frame no longer crashes with `KeyError: 'peptide'` in the aggregate merge.

### ProteomeIndex kept for two niche paths

- `--skip-ms-evidence` — output the theoretical peptide menu for a gene from a fresh Ensembl release
- `--iedb` / `--cedar` raw-CSV override — needs an enumerated peptide list to scan

## Test plan

- [x] `./format.sh` clean
- [x] `./lint.sh` clean
- [x] `./test.sh` → 142 passed, 0 skipped
- [x] Live run: `tsarina hits --gene PRAME --allele "HLA-A*24:02"` — 2 hits, 1.5s
- [x] Live run: `tsarina hits --gene PRAME --serotype A24` — 2 hits (same pMHCs, via serotype fallback)
- [x] Live run: `tsarina hits --gene PRAME --mono-allelic-only` — 11 high-confidence hits
- [x] Live run: `tsarina hits --gene MAGEA4 --format peptides` — multi-gene `gene_names` column populated for paralogous peptides

## Related

- Closes via hitlist upgrade: [hitlist#43](https://github.com/pirl-unc/hitlist/issues/43) (always-on gene annotations + multi-mapping)
- Filed during dogfood: [hitlist#44](https://github.com/pirl-unc/hitlist/issues/44) (Bw4/Bw6 vs locus-serotype preference)