### PR TITLE
v0.6.1: warn when --include-binding-assays is a no-op on the cached path

### DIFF
--- a/tests/test_cli_hits.py
+++ b/tests/test_cli_hits.py
@@ -1,5 +1,9 @@
+import argparse
 import subprocess
 import sys
+from unittest.mock import patch
+
+import pandas as pd
 
 
 def _run_cli(*args: str, check: bool = True) -> subprocess.CompletedProcess:
@@ -23,6 +27,18 @@ def test_hits_help_exits_zero():
     assert "--mono-allelic-only" in r.stdout
 
 
+def test_hits_help_warns_about_include_binding_assays_cached_noop():
+    """tsarina#4 part 1: the flag is a no-op on the cached path (hitlist
+    purges binding rows at build time).  Help text must say so explicitly
+    — otherwise users silently get MS-only output when they asked for both."""
+    r = _run_cli("hits", "--help")
+    assert r.returncode == 0
+    assert "--include-binding-assays" in r.stdout
+    # Must mention both the limitation and the escape hatch.
+    assert "no-op" in r.stdout
+    assert "--iedb" in r.stdout
+
+
 def test_hits_requires_gene_or_uniprot():
     r = _run_cli("hits", check=False)
     assert r.returncode != 0
@@ -40,3 +56,47 @@ def test_hits_gene_and_uniprot_are_mutually_exclusive():
         check=False,
     )
     assert r.returncode != 0
+
+
+def test_include_binding_assays_on_cached_path_warns(capsys, tmp_path):
+    """Calling handle() with --include-binding-assays on the default cached
+    path must emit a stderr warning, not silently succeed.  Tracks tsarina#4
+    until hitlist#47 ships a separate binding-assay index."""
+    from tsarina import cli_hits
+
+    args = argparse.Namespace(
+        gene="PRAME",
+        uniprot=None,
+        allele=[],
+        serotype=[],
+        species="Homo sapiens",
+        mhc_class="I",
+        min_resolution=None,
+        lengths=(8, 9, 10, 11),
+        ensembl_release=112,
+        include_binding_assays=True,
+        mono_allelic_only=False,
+        format="pmhc",
+        predict=False,
+        predictor="mhcflurry",
+        iedb_path=None,
+        cedar_path=None,
+        skip_ms_evidence=False,
+        output=str(tmp_path / "out.csv"),
+    )
+    empty = pd.DataFrame(
+        {
+            "peptide": pd.Series(dtype=str),
+            "mhc_restriction": pd.Series(dtype=str),
+            "is_binding_assay": pd.Series(dtype=bool),
+        }
+    )
+    with (
+        patch("tsarina.indexing.ensure_index_built"),
+        patch("hitlist.observations.load_observations", return_value=empty),
+    ):
+        cli_hits.handle(args)
+    err = capsys.readouterr().err
+    assert "--include-binding-assays" in err
+    assert "cached" in err
+    assert "--iedb" in err

--- a/tsarina/cli_hits.py
+++ b/tsarina/cli_hits.py
@@ -110,7 +110,13 @@ def build_parser(sub: argparse._SubParsersAction) -> argparse.ArgumentParser:
     p.add_argument(
         "--include-binding-assays",
         action="store_true",
-        help="Keep IEDB binding-assay rows (default: MS only).",
+        help=(
+            "Keep IEDB binding-assay rows (default: MS only).  Only effective "
+            "on the raw-CSV override path (--iedb / --cedar); the cached "
+            "observations index purges binding-assay rows at hitlist build "
+            "time, so this flag is a no-op there and will warn.  Tracked in "
+            "hitlist#47 / tsarina#4."
+        ),
     )
     p.add_argument(
         "--mono-allelic-only",
@@ -359,6 +365,21 @@ def handle(args: argparse.Namespace) -> None:
 
         ensure_index_built()
         from hitlist.observations import load_observations
+
+        if args.include_binding_assays:
+            # The cached observations.parquet is built with binding-assay rows
+            # already purged (hitlist builder.py), so there is nothing to
+            # include here.  Warn explicitly rather than silently no-op; the
+            # user can reach binding rows via --iedb / --cedar (raw-CSV scan)
+            # until hitlist#47 ships a separate binding-assay index.
+            print(
+                "warning: --include-binding-assays has no effect on the "
+                "cached observations index; binding-assay rows are dropped "
+                "at hitlist build time (see hitlist#47).  Pass --iedb "
+                "(and optionally --cedar) to scan the raw CSVs, which do "
+                "include binding rows.",
+                file=sys.stderr,
+            )
 
         hits = load_observations(
             gene_name=gene,

--- a/tsarina/version.py
+++ b/tsarina/version.py
@@ -10,4 +10,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.6.0"
+__version__ = "0.6.1"


### PR DESCRIPTION
Partial fix for #4. Does not close the issue — the real fix lands when hitlist#47 ships a separate binding-assay index; until then this PR replaces silent wrong behavior with a loud warning and honest help text.

## Problem

`tsarina hits --include-binding-assays` on the default cached path silently dropped binding-assay rows (hitlist purges them at build time — `hitlist/builder.py`). The guard at `cli_hits.py:368` looked like it did something, but `is_binding_assay` was always `False` in the parquet, so the filter was always a no-op. Users who expected binding rows got MS-only output with no indication.

Found originally during the PRAME × HLA-A\*24:02 audit (2 binding-assay rows on PMID 36165170 were visible on the raw-CSV path but invisible on the cached path).

## Fix

- Passing `--include-binding-assays` on the cached path now emits an explicit stderr warning:
  ```
  warning: --include-binding-assays has no effect on the cached observations
  index; binding-assay rows are dropped at hitlist build time (see hitlist#47).
  Pass --iedb (and optionally --cedar) to scan the raw CSVs, which do include
  binding rows.
  ```
- `--help` text on the flag now states the limitation up front and points at the escape hatch.
- Override path (`--iedb` / `--cedar`) unchanged — `--include-binding-assays` has always worked correctly there.

## Why not auto-fall-back to raw-CSV?

Option considered in tsarina#4. Rejected: raw-CSV scan of IEDB takes minutes and loads ~7GB; doing it silently when the user passed a flag that *sounded* cheap would be a surprising perf cliff. Explicit escape hatch is honest; the user asks for binding rows and gets a clear "use --iedb" pointer.

## Follow-up

When hitlist#47 ships (`binding_assays.parquet` + `load_all_evidence()`), this path will switch to the union helper and the warning goes away. Issue #4 stays open until then.

## Test plan

- [x] `./format.sh` — clean.
- [x] `./lint.sh` — clean.
- [x] `./test.sh` — 148 passed (was 146; +2 new tests: `--help` text assertion + in-process handler call verifying the warning fires via capsys with mocked hitlist).

## Post-merge

Per AGENTS.md rule #3: `./deploy.sh` from clean main to push 0.6.1 to PyPI.
