### PR TITLE
v0.6.2: drop _species_kwargs shim — hitlist 1.9.0 unified the API

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
 ]
 requires-python = ">=3.9"
 dependencies = [
-    "hitlist>=1.6.0",
+    "hitlist>=1.9.0",
     "mhcgnomes>=3.20.0",
     "pandas",
     "numpy",

--- a/tests/test_iedb.py
+++ b/tests/test_iedb.py
@@ -1,6 +1,8 @@
+import warnings
+
 import pandas as pd
 
-from tsarina.iedb import _species_kwargs, scan_public_ms
+from tsarina.iedb import scan_public_ms
 
 
 def test_scan_no_sources_returns_empty():
@@ -23,28 +25,12 @@ def test_scan_empty_peptides_returns_empty():
     assert len(df) == 0
 
 
-# ── _species_kwargs ──────────────────────────────────────────────────────
-# Regression guard: the Homo-sapiens branch must stay on human_only=True so
-# the host/species fallback kicks in for unparseable MHC restrictions (e.g.
-# bare "HLA class I").  If mhcgnomes ever changes its canonical species
-# form, these tests catch the silent drop to the strict path.
-
-
-def test_species_kwargs_none_disables_filter():
-    assert _species_kwargs(None) == {"human_only": False}
-
-
-def test_species_kwargs_homo_sapiens_uses_human_only_fallback():
-    assert _species_kwargs("Homo sapiens") == {"human_only": True}
-
-
-def test_species_kwargs_human_alias_normalizes_to_human_only():
-    # mhcgnomes should normalize "human" → "Homo sapiens".
-    assert _species_kwargs("human") == {"human_only": True}
-
-
-def test_species_kwargs_non_human_uses_strict_path():
-    assert _species_kwargs("Mus musculus") == {
-        "mhc_species": "Mus musculus",
-        "human_only": False,
-    }
+def test_scan_does_not_emit_deprecation_warnings():
+    """After the hitlist#72 / tsarina follow-up, scan_public_ms passes
+    mhc_species= directly to hitlist.  If we ever regress back to the old
+    human_only= kwarg, hitlist 1.9.0+ emits a DeprecationWarning — fail here."""
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", DeprecationWarning)
+        scan_public_ms(peptides={"X"}, iedb_path=None, cedar_path=None)
+        scan_public_ms(peptides={"X"}, iedb_path=None, cedar_path=None, mhc_species=None)
+        scan_public_ms(peptides={"X"}, iedb_path=None, cedar_path=None, mhc_species="Mus musculus")

--- a/tsarina/iedb.py
+++ b/tsarina/iedb.py
@@ -20,11 +20,11 @@ in the hitlist registry, or an ad-hoc subset for testing).
 
 Historically this module reimplemented hitlist's scanner loop.  It no longer
 does — every real behavior (two-header parsing, column resolution, species
-filter via mhcgnomes, source classification, binding-assay detection,
-allele-resolution filtering, assay-IRI dedup) lives in
-``hitlist.scanner.scan``.  These wrappers exist to (a) keep a stable tsarina
-import path and (b) translate tsarina's historical ``mhc_species`` argument
-onto hitlist's ``human_only`` / ``mhc_species`` kwargs.
+filter via mhcgnomes + host-field fallback, source classification,
+binding-assay detection, allele-resolution filtering, assay-IRI dedup) lives
+in ``hitlist.scanner.scan``.  Requires hitlist >= 1.9.0; earlier versions
+used a split ``human_only`` / ``mhc_species`` API that tsarina had to
+papered over with a translation shim (retired alongside hitlist#72).
 """
 
 from __future__ import annotations
@@ -32,36 +32,7 @@ from __future__ import annotations
 from pathlib import Path
 
 import pandas as pd
-from hitlist.curation import normalize_species
 from hitlist.scanner import scan as _hitlist_scan
-
-
-def _species_kwargs(mhc_species: str | None) -> dict:
-    """Translate tsarina's ``mhc_species`` argument onto hitlist scanner kwargs.
-
-    For ``"Homo sapiens"`` (tsarina's historical default) use ``human_only=True``,
-    which applies the host/species fallback when an MHC restriction string
-    cannot be resolved via mhcgnomes (e.g. bare ``"HLA class I"``).  For any
-    other species, use the strict ``mhc_species`` path.  For ``None``, disable
-    species filtering entirely.
-    """
-    # hitlist.scanner.scan exposes two filter paths with *different* fallback
-    # semantics — we pick between them here:
-    #
-    #   human_only=True  → Homo sapiens-only, and when mhcgnomes can't parse
-    #                      the MHC restriction string (e.g. "HLA class I")
-    #                      it falls back to the host / species text columns.
-    #   mhc_species=X    → strict mhcgnomes match, NO host/species fallback;
-    #                      rows with unparseable MHC restriction are dropped.
-    #
-    # tsarina's legacy behavior at mhc_species="Homo sapiens" relied on the
-    # fallback, so we route that to human_only=True.  For every other species
-    # the strict path is the right default.
-    if mhc_species is None:
-        return {"human_only": False}
-    if normalize_species(mhc_species) == "Homo sapiens":
-        return {"human_only": True}
-    return {"mhc_species": mhc_species, "human_only": False}
 
 
 def scan_public_ms(
@@ -109,10 +80,10 @@ def scan_public_ms(
         peptides=peptides,
         iedb_path=iedb_path,
         cedar_path=cedar_path,
+        mhc_species=mhc_species,
         mhc_class=mhc_class,
         classify_source=classify_source,
         min_allele_resolution=min_allele_resolution,
-        **_species_kwargs(mhc_species),
     )
 
 
@@ -134,6 +105,6 @@ def profile_dataset(
         peptides=None,
         iedb_path=iedb_path,
         cedar_path=cedar_path,
+        mhc_species=mhc_species,
         classify_source=True,
-        **_species_kwargs(mhc_species),
     )

--- a/tsarina/version.py
+++ b/tsarina/version.py
@@ -10,4 +10,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.6.1"
+__version__ = "0.6.2"


### PR DESCRIPTION
Follow-up to #5 / hitlist#72. Now that [hitlist 1.9.0](https://pypi.org/project/hitlist/1.9.0/) has unified the species-filter API (single `mhc_species=` kwarg with `species_fallback=True` default), tsarina's `_species_kwargs` translation shim has no reason to exist.

## Changes

- **`tsarina/iedb.py`** — deletes `_species_kwargs` (and its `normalize_species` import). `scan_public_ms` and `profile_dataset` now pass `mhc_species=` straight through to `hitlist.scanner.scan`.
- **`tests/test_iedb.py`** — drops the 4 `_species_kwargs` unit tests (the function is gone). Adds one regression guard that turns `DeprecationWarning` into an error for three call paths, so if anyone re-introduces `human_only=` it fails loudly.
- **`pyproject.toml`** — hitlist pin `>=1.6.0` → `>=1.9.0` (required for the new default + `species_fallback` kwarg).
- **`tsarina/version.py`** — bump `0.6.1 → 0.6.2` per rule #2.

## Behavior delta

For **Homo sapiens queries** (the default, overwhelmingly the common path): identical. `mhc_species="Homo sapiens", species_fallback=True` in hitlist 1.9.0 does exactly what `human_only=True` did in 1.8.x.

For **non-Homo-sapiens queries** (e.g. `mhc_species="Mus musculus"`): rows with unparseable MHC restrictions (bare `"H-2 class I"` or similar) that have `host=Mus musculus` will now match via host-field fallback. Previously they were dropped (old hitlist's `mhc_species=X` path was strict-only). This is the correct behavior — consistent fallback policy across species — and it's exactly the improvement that motivated hitlist#72.

No API surface change for tsarina's external callers; `mhc_species=` still works the same way from the outside.

## Test plan

- [x] `./format.sh` — clean.
- [x] `./lint.sh` — clean.
- [x] `./test.sh` — 145 passed (was 148; −4 from deleted `_species_kwargs` tests, +1 new deprecation-warning regression guard).
- [x] Manual: verified `hitlist==1.9.0` installed, no `DeprecationWarning` thrown by the regression test.

## Post-merge

Per AGENTS.md rule #3: `./deploy.sh` from clean main to push 0.6.2 to PyPI.
