### PR TITLE
v0.7.0: --include-binding-assays actually works (closes #4)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
 ]
 requires-python = ">=3.9"
 dependencies = [
-    "hitlist>=1.9.0",
+    "hitlist>=1.10.0",
     "mhcgnomes>=3.20.0",
     "pandas",
     "numpy",

--- a/tests/test_cli_hits.py
+++ b/tests/test_cli_hits.py
@@ -27,16 +27,14 @@ def test_hits_help_exits_zero():
     assert "--mono-allelic-only" in r.stdout
 
 
-def test_hits_help_warns_about_include_binding_assays_cached_noop():
-    """tsarina#4 part 1: the flag is a no-op on the cached path (hitlist
-    purges binding rows at build time).  Help text must say so explicitly
-    — otherwise users silently get MS-only output when they asked for both."""
+def test_hits_help_describes_include_binding_assays_union():
+    """tsarina#4 closed: cached path now routes through hitlist's
+    load_all_evidence() union; help text should describe the UNION
+    behavior and the evidence_kind tagging, not the old no-op limitation."""
     r = _run_cli("hits", "--help")
     assert r.returncode == 0
     assert "--include-binding-assays" in r.stdout
-    # Must mention both the limitation and the escape hatch.
-    assert "no-op" in r.stdout
-    assert "--iedb" in r.stdout
+    assert "evidence_kind" in r.stdout
 
 
 def test_hits_requires_gene_or_uniprot():
@@ -58,10 +56,11 @@ def test_hits_gene_and_uniprot_are_mutually_exclusive():
     assert r.returncode != 0
 
 
-def test_include_binding_assays_on_cached_path_warns(capsys, tmp_path):
-    """Calling handle() with --include-binding-assays on the default cached
-    path must emit a stderr warning, not silently succeed.  Tracks tsarina#4
-    until hitlist#47 ships a separate binding-assay index."""
+def test_include_binding_assays_routes_to_load_all_evidence(tmp_path):
+    """tsarina#4 closed via hitlist 1.10.0: --include-binding-assays on the
+    cached path must call load_all_evidence (union of MS + binding), not
+    load_observations (MS-only).  This is the contract that makes the flag
+    actually honor its name."""
     from tsarina import cli_hits
 
     args = argparse.Namespace(
@@ -88,15 +87,50 @@ def test_include_binding_assays_on_cached_path_warns(capsys, tmp_path):
         {
             "peptide": pd.Series(dtype=str),
             "mhc_restriction": pd.Series(dtype=str),
-            "is_binding_assay": pd.Series(dtype=bool),
+            "evidence_kind": pd.Series(dtype=str),
         }
     )
     with (
         patch("tsarina.indexing.ensure_index_built"),
-        patch("hitlist.observations.load_observations", return_value=empty),
+        patch("hitlist.observations.load_all_evidence", return_value=empty) as all_ev,
+        patch("hitlist.observations.load_observations") as ms_only,
     ):
         cli_hits.handle(args)
-    err = capsys.readouterr().err
-    assert "--include-binding-assays" in err
-    assert "cached" in err
-    assert "--iedb" in err
+    all_ev.assert_called_once()
+    ms_only.assert_not_called()
+
+
+def test_default_cached_path_uses_load_observations_not_union(tmp_path):
+    """Regression guard: without --include-binding-assays, the cached path
+    must still use load_observations (MS-only), not the union."""
+    from tsarina import cli_hits
+
+    args = argparse.Namespace(
+        gene="PRAME",
+        uniprot=None,
+        allele=[],
+        serotype=[],
+        species="Homo sapiens",
+        mhc_class="I",
+        min_resolution=None,
+        lengths=(8, 9, 10, 11),
+        ensembl_release=112,
+        include_binding_assays=False,
+        mono_allelic_only=False,
+        format="pmhc",
+        predict=False,
+        predictor="mhcflurry",
+        iedb_path=None,
+        cedar_path=None,
+        skip_ms_evidence=False,
+        output=str(tmp_path / "out.csv"),
+    )
+    empty = pd.DataFrame({"peptide": pd.Series(dtype=str), "mhc_restriction": pd.Series(dtype=str)})
+    with (
+        patch("tsarina.indexing.ensure_index_built"),
+        patch("hitlist.observations.load_observations", return_value=empty) as ms_only,
+        patch("hitlist.observations.load_all_evidence") as all_ev,
+    ):
+        cli_hits.handle(args)
+    ms_only.assert_called_once()
+    all_ev.assert_not_called()

--- a/tsarina/cli_hits.py
+++ b/tsarina/cli_hits.py
@@ -111,11 +111,10 @@ def build_parser(sub: argparse._SubParsersAction) -> argparse.ArgumentParser:
         "--include-binding-assays",
         action="store_true",
         help=(
-            "Keep IEDB binding-assay rows (default: MS only).  Only effective "
-            "on the raw-CSV override path (--iedb / --cedar); the cached "
-            "observations index purges binding-assay rows at hitlist build "
-            "time, so this flag is a no-op there and will warn.  Tracked in "
-            "hitlist#47 / tsarina#4."
+            "Include IEDB/CEDAR binding-assay rows in addition to MS "
+            "observations (default: MS only).  On the cached-index path this "
+            "routes through hitlist's load_all_evidence() union; rows are "
+            "tagged with an evidence_kind column ('ms' vs 'binding')."
         ),
     )
     p.add_argument(
@@ -364,30 +363,25 @@ def handle(args: argparse.Namespace) -> None:
         from .indexing import ensure_index_built
 
         ensure_index_built()
-        from hitlist.observations import load_observations
 
         if args.include_binding_assays:
-            # The cached observations.parquet is built with binding-assay rows
-            # already purged (hitlist builder.py), so there is nothing to
-            # include here.  Warn explicitly rather than silently no-op; the
-            # user can reach binding rows via --iedb / --cedar (raw-CSV scan)
-            # until hitlist#47 ships a separate binding-assay index.
-            print(
-                "warning: --include-binding-assays has no effect on the "
-                "cached observations index; binding-assay rows are dropped "
-                "at hitlist build time (see hitlist#47).  Pass --iedb "
-                "(and optionally --cedar) to scan the raw CSVs, which do "
-                "include binding rows.",
-                file=sys.stderr,
-            )
+            # hitlist 1.10.0+ exposes load_all_evidence() — UNION of MS
+            # observations + binding-assay rows, tagged with evidence_kind.
+            from hitlist.observations import load_all_evidence
 
-        hits = load_observations(
-            gene_name=gene,
-            mhc_class=args.mhc_class,
-            species=mhc_species,
-        )
-        if not args.include_binding_assays and "is_binding_assay" in hits.columns:
-            hits = hits[~hits["is_binding_assay"]].copy()
+            hits = load_all_evidence(
+                gene_name=gene,
+                mhc_class=args.mhc_class,
+                species=mhc_species,
+            )
+        else:
+            from hitlist.observations import load_observations
+
+            hits = load_observations(
+                gene_name=gene,
+                mhc_class=args.mhc_class,
+                species=mhc_species,
+            )
         hits = _apply_min_resolution(hits, args.min_resolution)
 
     hits = _filter_by_allele(hits, args.allele)

--- a/tsarina/version.py
+++ b/tsarina/version.py
@@ -10,4 +10,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.6.2"
+__version__ = "0.7.0"


### PR DESCRIPTION
Closes #4.

[hitlist 1.10.0](https://pypi.org/project/hitlist/1.10.0/) shipped `load_all_evidence()` — a union of `observations.parquet` + `binding.parquet` with an `evidence_kind` column. This PR wires tsarina's cached path through it, so `tsarina hits --include-binding-assays` stops being a warn-and-noop and actually returns binding rows.

## Changes

- **`cli_hits.py`** — when `--include-binding-assays` is set on the cached path, call `load_all_evidence(gene_name=..., mhc_class=..., species=...)`; otherwise stay on `load_observations()`. The old "warn and drop" branch (from v0.6.1, blocked on hitlist#47) is removed.
- **`cli_hits.py`** — `--help` text for `--include-binding-assays` rewritten: describes the union + `evidence_kind` tagging. No more "no-op" language.
- **`pyproject.toml`** — hitlist pin `>=1.9.0` → `>=1.10.0` (required for `load_all_evidence`).
- **`version.py`** — 0.6.2 → 0.7.0. Minor bump because this is a user-visible behavior change for a flag that was silently wrong.

## Before vs after

| Scenario | v0.6.2 | v0.7.0 |
|---|---|---|
| `tsarina hits --gene PRAME --allele "HLA-A*24:02"` (cached, default) | `load_observations()` → MS only | Same — `load_observations()` (unchanged) |
| `tsarina hits --gene PRAME --allele "HLA-A*24:02" --include-binding-assays` (cached) | Warns; silently returns MS only | `load_all_evidence()` → MS + binding rows, tagged via `evidence_kind` column |
| `tsarina hits --gene PRAME --iedb /path.csv --include-binding-assays` (raw-CSV override) | Works (unchanged — `scan()` sees binding rows) | Works (unchanged) |

## Tests

- `test_hits_help_describes_include_binding_assays_union` — replaces the old no-op help-text assertion. Help text must mention `evidence_kind`.
- `test_include_binding_assays_routes_to_load_all_evidence` — mocks both loaders; when flag is set, asserts `load_all_evidence` is called once and `load_observations` is not.
- `test_default_cached_path_uses_load_observations_not_union` — regression guard for the default path: without the flag, `load_observations` is called and `load_all_evidence` is not.

**146 passing** (was 148; the old help-no-op test and the old warning test are replaced by these three, net similar coverage).

## Test plan

- [x] `./format.sh` — clean.
- [x] `./lint.sh` — clean.
- [x] `./test.sh` — 146 passed.
- [x] Manual: local `hitlist==1.10.0` installed, `from hitlist.observations import load_all_evidence` imports successfully.

## Post-merge

Per AGENTS.md rule #3: `./deploy.sh` from clean main to push 0.7.0 to PyPI.
