### PR TITLE
v0.8.0: modernize personalize() with tumor-specificity gates + explicit tiers

### DIFF
--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,3 +1,188 @@
+# Audit — Hitlist Alignment And TSA Goal
+
+## Goal
+
+Audit the current tsarina pipeline against two questions:
+
+1. Do the recent hitlist-driven changes preserve the intended semantics of
+   "MS-supported" evidence?
+2. Does tsarina, as currently implemented, actually produce a
+   high-confidence set of tumor-specific antigens suitable for vaccine and TCR
+   therapy prioritization?
+
+The audit should distinguish between:
+
+- correctness of the code relative to the current hitlist/data interfaces
+- scientific/product-fit of the resulting target set
+- missing guardrails that could let non-tumor-specific or weakly supported
+  candidates survive ranking/export
+
+## Audit Plan
+
+- [x] Review recent tsarina changes that touched hitlist integration, cached
+      observations loading, public-MS scanning, and target ranking/export.
+- [x] Trace the end-to-end pipeline from peptide generation through evidence
+      collection, tissue-specificity filters, scoring, and target assembly.
+- [x] Compare implemented filters and scoring rules against the stated goal of
+      high-confidence MS-supported tumor-specific antigens for vaccines/TCRs.
+- [x] Identify concrete failure modes, missing controls, and places where the
+      current implementation could overstate confidence or tumor specificity.
+- [x] Record findings with file/line references and recommended follow-up work.
+
+## Verification
+
+- [x] Read-only audit — no repo edits, so `format.sh`/`lint.sh`/`test.sh` N/A.
+
+## Review
+
+### Answers to the two audit questions
+
+**Q1: Do recent hitlist-driven changes preserve the intended semantics of
+"MS-supported" evidence?**  Yes. The refactor across v0.5.2 → v0.7.0 is clean:
+
+- `is_binding_assay` filtering is consistent across fast path
+  (`indexing.load_ms_evidence` drops binding rows by default) and slow path
+  (`export.py:78-79`, `evidence.py:208-209`, `cli_hits.py:359-360` all filter
+  after `scan()`).
+- `--include-binding-assays` correctly routes to
+  `hitlist.observations.load_all_evidence` on fast path (`cli_hits.py:367-376`)
+  and skips the post-scan drop on slow path.
+- `mhc_species="Homo sapiens"` is hardcoded in every library entry point
+  (`personalize.py:232`, `export.py:86`, `evidence.py:205,216`); CLI exposes
+  `--species`. No silent widening.
+- `_species_kwargs`, `hla_only`, `human_only` shims fully removed (grep-clean).
+- `resolve_cedar_path` silent-None on unregistered is by design.
+
+**Q2: Does tsarina, as currently implemented, produce a high-confidence set of
+tumor-specific antigens for vaccine / TCR prioritization?**  No — not via the
+`personalize()` entry point.  The `targets()` path is closer but still has the
+viral-exclusivity hole.  Several guardrails are missing, miswired, or defined
+but unenforced.
+
+---
+
+### Findings — severity ordered, with file:line refs
+
+#### CRITICAL (can let non-tumor-specific peptides into final output)
+
+1. **`personalize.py:120,129` uses `cta_peptides()` instead of
+   `cta_exclusive_peptides()`.** A 9-mer from MAGEA4 that also appears in a
+   ubiquitously-expressed housekeeping protein is ranked as a CTA target.
+   `targets.py:99,101` already uses the exclusive variant — the two paths
+   diverge silently. `peptides.py:122-177` defines exclusivity as "peptide
+   does not appear as a substring in any non-CTA protein-coding transcript".
+
+2. **`personalize.py:177,180` AND `targets.py:117,121` both use
+   `viral_peptides()` instead of `human_exclusive_viral_peptides()`.**
+   `viral.py:245-302` defines the exclusive variant (filters viral k-mers
+   that also match the human proteome); it exists and is documented but is
+   never called from the main pipelines. An HPV16 E6 k-mer that collides
+   with a human self-peptide can be ranked as a viral target.
+
+3. **`personalize.py:266-288` — MHC scoring is effectively optional.**
+   Scores are merged `how="left"` (line 286); `except ImportError: pass`
+   (line 287-288) silently swallows an mhctools/mhcflurry install failure.
+   A peptide with missing `presentation_percentile` then falls through to
+   `line 303`: `(100 - percentile.fillna(100)).clip(lower=0) * 0.5`, which
+   evaluates to 0 rather than excluding the row. The candidate still carries
+   any MS-driven score and lands in the output with `best_allele=NaN`.
+
+4. **`personalize.py:292-305` `priority_score` conflates modalities with
+   uncalibrated weights and no tiering.**  A single MS hit anywhere earns
+   `+10` (line 294); a peptide observed in cancer earns `+20` (line 296);
+   a 0.5%-percentile prediction earns `~+49.75` (line 303-305). One MS hit
+   plus `ms_in_cancer=True` (+30) beats a strong prediction with no public
+   observation. There is no tier column, no minimum-confidence gate, and no
+   distinction between "seen in one cell line" and "seen across many tissues".
+   `scoring.py` defines `PRESENTATION_PERCENTILE_THRESHOLDS = (0.25, 0.50,
+   1.0)` but nothing downstream consumes them.
+
+#### MAJOR
+
+5. **Healthy-tissue evidence is a soft penalty, not a gate
+   (`personalize.py:297-298`: `-= ms_in_healthy_tissue * 50`).**  A peptide
+   observed in normal tissue can still rank positively if MS-in-cancer,
+   hit-count, and presentation contributions outweigh it. `targets.py:231-234`
+   exposes a `cancer_specific` keyword that *does* hard-filter, but
+   `personalize()` never wires one through.
+
+6. **`mtec.py` and `negatives.healthy_tissue_peptides` are not wired into
+   `personalize()`.**  mTEC is used in `selection.py:89,121` (sort-tiebreak)
+   and joined by `export.py:127-133`, but the clinical `personalize()` →
+   CSV path skips it. Thymic-self peptides (likely to be tolerized, so
+   clinically useless as vaccine / TCR targets) are not flagged.
+   `negatives.healthy_tissue_peptides` is defined but has zero callers
+   outside its own docstring example.
+
+7. **`personalize.py:307` — single-key sort, no deterministic tiebreak.**
+   `sort_values("priority_score", ascending=False)`. Many candidates tie at
+   `ms_hit_count * 10` values; pandas preserves insertion order, which
+   depends on frame concat order in lines 115-194. Re-running the same patient
+   inputs can reshuffle the top of the list.
+
+8. **No per-CTA restriction / confidence gate in `personalize()`.**
+   `personalize.py:122-126` admits any gene in `CTA_gene_names()` at
+   `tpm >= min_cta_tpm`. Per-gene `restriction_level` / `restriction_confidence`
+   computed in `tiers.py` are reporting-only in this path.  A LEAKY / LOW-
+   confidence CTA contributes peptides indistinguishably from a STRICT / HIGH-
+   confidence one.
+
+9. **`min_cta_tpm=1.0` default (`personalize.py:50`) is below the
+   `never_expressed < 2 nTPM` cutoff used to build the CTA CSV.**  Aligning
+   runtime to 2.0 would close a small gap where a borderline-expressed CTA
+   passes both filters.
+
+#### MINOR
+
+10. **Predictor-aware calibration is absent.**  `--predictor
+    netmhcpan|netmhcpan_el` swaps the scorer, but `personalize.py:303` still
+    treats percentile on a 0-100 scale with a fixed `*0.5` weight. NetMHCpan's
+    percentile distribution differs from MHCflurry's; no warning is emitted.
+
+11. **CEDAR silent-None** (`datasources.py:70-81`). Intentional per docstring,
+    but a one-line stderr note when CEDAR is unregistered would help users
+    distinguish "no CEDAR data" from "I forgot to register CEDAR".
+
+#### POSITIVE (no action)
+
+- `mutations.py:355-356` guards `mut_pep == wt_pep` → "mutant" peptides that
+  are actually self are dropped.
+- Fast-path ↔ slow-path parity for MS filters is clean.
+- `_species_kwargs` / `hla_only` / `human_only` traces fully removed.
+- `datasources.resolve_*` is the single registry entry point.
+
+---
+
+### Recommended follow-ups (grouped for separate PRs)
+
+- **PR A (CRITICAL, 2 lines):** `personalize.py:120,129` → use
+  `cta_exclusive_peptides`.  Add regression test that a peptide present in
+  both MAGEA4 and a non-CTA protein does not appear in personalize output.
+- **PR B (CRITICAL, ~6 lines):** `personalize.py:177` and `targets.py:117`
+  → default to `human_exclusive_viral_peptides`. Add a kwarg
+  `require_human_exclusive: bool = True` for explicitness.
+- **PR C (CRITICAL):** Mandatory MHC-prediction gate in `personalize()`.
+  Either drop NaN-percentile rows or annotate them with `tier="UNSCORED"`
+  and exclude from top tiers. Fail loudly (not silently) on mhctools
+  ImportError when `score_presentation=True` was requested.
+- **PR D (CRITICAL + MAJOR):** Replace `priority_score` arithmetic with an
+  explicit tier system consuming `scoring.PRESENTATION_PERCENTILE_THRESHOLDS`.
+  Tier 1 = (MS cancer-only AND percentile ≤ 0.5) OR (≥3 MS hits AND ≤1%);
+  Tier 2 = MS OR ≤2%; Tier 3 = else. Export a `tier` column. Deterministic
+  sort `[tier, -ms_hit_count, presentation_percentile, peptide, best_allele]`.
+- **PR E (MAJOR):** Add `enforce_tumor_specificity: bool = True` to
+  `personalize()` that drops `ms_in_healthy_tissue=True` rows (mirrors
+  `targets.py:231-234`'s `cancer_specific`).
+- **PR F (MAJOR):** Wire `mtec.load_mtec_gene_table` and
+  `negatives.healthy_tissue_peptides` into `personalize()` as flags-on-by-
+  default filters; annotate excluded peptides in a diagnostic CSV.
+- **PR G (MAJOR):** Add `restriction_level` / `restriction_confidence` gate
+  for CTAs (default: require HIGH or MODERATE).
+- **PR H (MINOR):** Raise `min_cta_tpm` default to 2.0; log CEDAR-missing
+  once per invocation; emit a warning when `--predictor != mhcflurry`.
+
+---
+
 # CLI Expansion + Hitlist API Alignment
 
 ## Goal

--- a/tests/test_personalize.py
+++ b/tests/test_personalize.py
@@ -440,3 +440,191 @@ def test_empty_inputs_return_canonical_columns():
 
     assert list(out.columns) == list(_OUTPUT_COLUMNS)
     assert out.empty
+
+
+# ── enforce_tumor_specificity=False keeps healthy-tissue hits ──────────
+
+
+def test_enforce_tumor_specificity_false_keeps_healthy_tissue_hit(monkeypatch):
+    """Opt-out path: user explicitly wants healthy-tissue hits retained
+    (e.g. for diagnostic inspection)."""
+    exclusive = pd.DataFrame(
+        {
+            "peptide": ["SAFE9PEP", "RISKYPEP9"],
+            "length": [9, 9],
+            "virus": ["hpv16", "hpv16"],
+            "protein_id": ["E6", "E6"],
+        }
+    )
+    monkeypatch.setattr(
+        "tsarina.viral.human_exclusive_viral_peptides",
+        lambda **kw: exclusive,
+        raising=True,
+    )
+
+    def _fake_load_ms_evidence(peptides, **kwargs):
+        return pd.DataFrame(
+            {
+                "peptide": ["RISKYPEP9"],
+                "mhc_restriction": ["HLA-A*02:01"],
+                "src_cancer": [False],
+                "src_healthy_tissue": [True],
+            }
+        )
+
+    monkeypatch.setattr("tsarina.indexing.load_ms_evidence", _fake_load_ms_evidence, raising=True)
+
+    out = personalize(
+        hla_alleles=["HLA-A*02:01"],
+        viruses=["hpv16"],
+        score_presentation=False,
+        enforce_tumor_specificity=False,
+        drop_weak_tier=False,
+    )
+    peptides = set(out["peptide"])
+    assert "RISKYPEP9" in peptides
+    assert "SAFE9PEP" in peptides
+    # Safety flag is still surfaced on the row even when not filtered.
+    risky_row = out[out["peptide"] == "RISKYPEP9"].iloc[0]
+    assert bool(risky_row["ms_in_healthy_tissue"]) is True
+
+
+# ── mtec_matrix_path gates CTAs by thymic expression ──────────────────
+
+
+def test_mtec_matrix_path_filters_ctas(tmp_path, monkeypatch):
+    """PR-F: when an mTEC matrix is provided, CTAs with mean mTEC TPM above
+    mtec_max_tpm must be dropped. Confirms filter_by_mtec is actually wired
+    in (personalize.py:222-225 was uncovered)."""
+    mtec_tsv = tmp_path / "mtec.tsv"
+    mtec_tsv.write_text(
+        "gene_symbol\tsample1\tsample2\nLOWMTEC_GENE\t0.1\t0.2\nHIGHMTEC_GENE\t50.0\t60.0\n"
+    )
+
+    exclusive = pd.DataFrame(
+        {
+            "peptide": ["LOWPEP9LEN", "HIGHPEP9LN"],
+            "length": [9, 9],
+            "gene_name": ["LOWMTEC_GENE", "HIGHMTEC_GENE"],
+            "gene_id": ["ENSG_L", "ENSG_H"],
+        }
+    )
+    monkeypatch.setattr(
+        "tsarina.peptides.cta_exclusive_peptides", lambda **kw: exclusive, raising=True
+    )
+    monkeypatch.setattr(
+        "tsarina.gene_sets.CTA_gene_names",
+        lambda: {"LOWMTEC_GENE", "HIGHMTEC_GENE"},
+        raising=True,
+    )
+    monkeypatch.setattr(
+        "tsarina.gene_sets.CTA_by_axes",
+        lambda **kw: {"LOWMTEC_GENE", "HIGHMTEC_GENE"},
+        raising=True,
+    )
+
+    out = personalize(
+        hla_alleles=["HLA-A*02:01"],
+        cta_expression={"LOWMTEC_GENE": 10.0, "HIGHMTEC_GENE": 10.0},
+        mtec_matrix_path=str(mtec_tsv),
+        mtec_max_tpm=1.0,
+        score_presentation=False,
+        skip_ms_evidence=True,
+        drop_weak_tier=False,
+    )
+    peptides = set(out["peptide"])
+    assert "LOWPEP9LEN" in peptides
+    assert "HIGHPEP9LN" not in peptides
+
+
+# ── min_restriction_confidence=None bypasses the confidence gate ──────
+
+
+def test_min_restriction_confidence_none_bypasses_gate(monkeypatch):
+    """PR-G opt-out: passing None must skip CTA_by_axes entirely and admit
+    genes regardless of restriction_confidence (LOW-confidence CTAs allowed)."""
+    exclusive = pd.DataFrame(
+        {
+            "peptide": ["LOWCONF9PEP"],
+            "length": [9],
+            "gene_name": ["LOWCONF_CTA"],
+            "gene_id": ["ENSG_LC"],
+        }
+    )
+
+    axes_calls: list[dict] = []
+
+    def _fake_by_axes(**kwargs):
+        axes_calls.append(kwargs)
+        # Pretend this gene would NOT pass a HIGH/MODERATE filter if asked.
+        return set()
+
+    monkeypatch.setattr(
+        "tsarina.peptides.cta_exclusive_peptides", lambda **kw: exclusive, raising=True
+    )
+    monkeypatch.setattr("tsarina.gene_sets.CTA_gene_names", lambda: {"LOWCONF_CTA"}, raising=True)
+    monkeypatch.setattr("tsarina.gene_sets.CTA_by_axes", _fake_by_axes, raising=True)
+
+    out = personalize(
+        hla_alleles=["HLA-A*02:01"],
+        cta_expression={"LOWCONF_CTA": 10.0},
+        min_restriction_confidence=None,
+        score_presentation=False,
+        skip_ms_evidence=True,
+        drop_weak_tier=False,
+    )
+    assert axes_calls == [], "CTA_by_axes must not be called when confidence gate is disabled"
+    assert "LOWCONF9PEP" in out["peptide"].tolist()
+
+
+# ── Non-mhcflurry predictor still populates tiers correctly ───────────
+
+
+def test_non_mhcflurry_predictor_populates_tiers(monkeypatch):
+    """Combines PR-H warning with end-to-end tier correctness: the warning
+    should not compromise tier assignment for an otherwise-strong candidate."""
+    exclusive = pd.DataFrame(
+        {
+            "peptide": ["STRONGVIR9"],
+            "length": [9],
+            "virus": ["hpv16"],
+            "protein_id": ["E6"],
+        }
+    )
+    monkeypatch.setattr(
+        "tsarina.viral.human_exclusive_viral_peptides",
+        lambda **kw: exclusive,
+        raising=True,
+    )
+
+    def _fake_score(**kwargs):
+        return pd.DataFrame(
+            {
+                "peptide": ["STRONGVIR9"],
+                "allele": ["HLA-A*02:01"],
+                "presentation_score": [0.98],
+                "presentation_percentile": [0.1],
+                "affinity_nm": [8.0],
+            }
+        )
+
+    monkeypatch.setattr("tsarina.scoring.score_presentation", _fake_score, raising=True)
+
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        out = personalize(
+            hla_alleles=["HLA-A*02:01"],
+            viruses=["hpv16"],
+            predictor="netmhcpan_el",
+            score_presentation=True,
+            skip_ms_evidence=True,
+        )
+
+    assert any("netmhcpan_el" in str(m.message) for m in w if issubclass(m.category, UserWarning))
+    assert len(out) == 1
+    row = out.iloc[0]
+    assert int(row["tier"]) == 1  # viral @ 0.1 percentile → STRONG
+    assert row["tier_label"] == "STRONG"
+    assert row["tier_reason"] == "strong_presentation+viral"
+    assert row["best_allele"] == "HLA-A*02:01"
+    assert float(row["presentation_percentile"]) == 0.1

--- a/tests/test_personalize.py
+++ b/tests/test_personalize.py
@@ -1,0 +1,442 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for :mod:`tsarina.personalize`.
+
+Exercises the modernized ``personalize()`` path: CTA/viral exclusivity gates,
+explicit tier assignment, deterministic sort, tumor-specificity filter,
+predictor warning, and mandatory-prediction failure propagation.
+"""
+
+from __future__ import annotations
+
+import warnings
+
+import pandas as pd
+import pytest
+
+from tsarina import personalize as personalize_module
+from tsarina.personalize import _assign_tiers, personalize
+
+# ── Tier assignment unit tests ──────────────────────────────────────────
+
+
+def test_tier1_requires_cancer_ms_for_cta():
+    df = pd.DataFrame(
+        {
+            "peptide": ["P1", "P2"],
+            "category": ["cta", "cta"],
+            "presentation_percentile": [0.1, 0.1],
+            "ms_in_cancer": [True, False],
+            "ms_hit_count": [5, 5],
+        }
+    )
+    out = _assign_tiers(df)
+    assert list(out["tier"]) == [1, 2]
+    assert out.loc[0, "tier_label"] == "STRONG"
+
+
+def test_tier1_automatic_for_mutant_and_viral_at_strong_percentile():
+    df = pd.DataFrame(
+        {
+            "peptide": ["M1", "V1"],
+            "category": ["mutant", "viral"],
+            "presentation_percentile": [0.2, 0.2],
+            "ms_in_cancer": [False, False],
+            "ms_hit_count": [0, 0],
+        }
+    )
+    out = _assign_tiers(df)
+    assert list(out["tier"]) == [1, 1]
+
+
+def test_tier3_when_presented_but_no_evidence_and_self():
+    df = pd.DataFrame(
+        {
+            "peptide": ["C1"],
+            "category": ["cta"],
+            "presentation_percentile": [0.9],
+            "ms_in_cancer": [False],
+            "ms_hit_count": [0],
+        }
+    )
+    out = _assign_tiers(df)
+    assert out.loc[0, "tier"] == 3
+    assert out.loc[0, "tier_reason"] == "presentation_only"
+
+
+def test_tier4_for_nan_percentile():
+    df = pd.DataFrame(
+        {
+            "peptide": ["X1"],
+            "category": ["cta"],
+            "presentation_percentile": [float("nan")],
+            "ms_in_cancer": [True],
+            "ms_hit_count": [3],
+        }
+    )
+    out = _assign_tiers(df)
+    assert out.loc[0, "tier"] == 4
+    assert out.loc[0, "tier_reason"] == "unscored"
+
+
+def test_tier4_for_high_percentile():
+    df = pd.DataFrame(
+        {
+            "peptide": ["X2"],
+            "category": ["mutant"],
+            "presentation_percentile": [5.0],
+            "ms_in_cancer": [False],
+            "ms_hit_count": [0],
+        }
+    )
+    out = _assign_tiers(df)
+    assert out.loc[0, "tier"] == 4
+    assert out.loc[0, "tier_reason"] == "below_threshold"
+
+
+# ── Integration: CTA exclusivity gate ──────────────────────────────────
+
+
+def test_personalize_uses_cta_exclusive_peptides(monkeypatch):
+    """A peptide present in `cta_peptides` but NOT in `cta_exclusive_peptides`
+    must be dropped before scoring — confirms the PR-A fix."""
+    exclusive = pd.DataFrame(
+        {
+            "peptide": ["EXCLUSIVE9"],
+            "length": [9],
+            "gene_name": ["MAGEA4"],
+            "gene_id": ["ENSG_MAGEA4"],
+        }
+    )
+    called = {}
+
+    def _fake_cta_exclusive(**kwargs):
+        called["ok"] = True
+        return exclusive
+
+    monkeypatch.setattr(
+        "tsarina.peptides.cta_exclusive_peptides", _fake_cta_exclusive, raising=True
+    )
+    monkeypatch.setattr("tsarina.gene_sets.CTA_gene_names", lambda: {"MAGEA4"}, raising=True)
+    monkeypatch.setattr("tsarina.gene_sets.CTA_by_axes", lambda **kw: {"MAGEA4"}, raising=True)
+
+    out = personalize(
+        hla_alleles=["HLA-A*02:01"],
+        cta_expression={"MAGEA4": 10.0},
+        score_presentation=False,
+        skip_ms_evidence=True,
+        drop_weak_tier=False,
+    )
+    assert called.get("ok") is True
+    assert list(out["peptide"]) == ["EXCLUSIVE9"]
+
+
+# ── Integration: viral exclusivity + enforce_tumor_specificity ─────────
+
+
+def test_personalize_uses_human_exclusive_viral_by_default(monkeypatch):
+    """Confirms PR-B: default viral path routes through the exclusive fn."""
+    exclusive = pd.DataFrame(
+        {
+            "peptide": ["VIRAL9ONLY"],
+            "length": [9],
+            "virus": ["hpv16"],
+            "protein_id": ["E6"],
+        }
+    )
+    touched = {"exclusive": False, "plain": False}
+
+    def _fake_exclusive(**kwargs):
+        touched["exclusive"] = True
+        return exclusive
+
+    def _fake_plain(**kwargs):
+        touched["plain"] = True
+        return exclusive
+
+    monkeypatch.setattr(
+        "tsarina.viral.human_exclusive_viral_peptides", _fake_exclusive, raising=True
+    )
+    monkeypatch.setattr("tsarina.viral.viral_peptides", _fake_plain, raising=True)
+
+    out = personalize(
+        hla_alleles=["HLA-A*02:01"],
+        viruses=["hpv16"],
+        score_presentation=False,
+        skip_ms_evidence=True,
+        drop_weak_tier=False,
+    )
+    assert touched["exclusive"] is True
+    assert touched["plain"] is False
+    assert "VIRAL9ONLY" in out["peptide"].tolist()
+
+
+def test_personalize_no_require_human_exclusive_viral_uses_plain(monkeypatch):
+    plain = pd.DataFrame(
+        {
+            "peptide": ["PEPV"],
+            "length": [4],
+            "virus": ["hpv16"],
+            "protein_id": ["E6"],
+        }
+    )
+    touched = {"exclusive": False, "plain": False}
+
+    def _fake_exclusive(**kwargs):
+        touched["exclusive"] = True
+        return plain
+
+    def _fake_plain(**kwargs):
+        touched["plain"] = True
+        return plain
+
+    monkeypatch.setattr(
+        "tsarina.viral.human_exclusive_viral_peptides", _fake_exclusive, raising=True
+    )
+    monkeypatch.setattr("tsarina.viral.viral_peptides", _fake_plain, raising=True)
+
+    personalize(
+        hla_alleles=["HLA-A*02:01"],
+        viruses=["hpv16"],
+        require_human_exclusive_viral=False,
+        score_presentation=False,
+        skip_ms_evidence=True,
+        drop_weak_tier=False,
+    )
+    assert touched["plain"] is True
+    assert touched["exclusive"] is False
+
+
+# ── enforce_tumor_specificity drops healthy-tissue MS hits ─────────────
+
+
+def test_enforce_tumor_specificity_drops_healthy_tissue_hit(monkeypatch):
+    exclusive = pd.DataFrame(
+        {
+            "peptide": ["SAFE9PEP", "RISKYPEP9"],
+            "length": [9, 9],
+            "virus": ["hpv16", "hpv16"],
+            "protein_id": ["E6", "E6"],
+        }
+    )
+    monkeypatch.setattr(
+        "tsarina.viral.human_exclusive_viral_peptides",
+        lambda **kw: exclusive,
+        raising=True,
+    )
+
+    def _fake_load_ms_evidence(peptides, **kwargs):
+        return pd.DataFrame(
+            {
+                "peptide": ["RISKYPEP9"],
+                "mhc_restriction": ["HLA-A*02:01"],
+                "src_cancer": [False],
+                "src_healthy_tissue": [True],
+            }
+        )
+
+    monkeypatch.setattr("tsarina.indexing.load_ms_evidence", _fake_load_ms_evidence, raising=True)
+
+    out = personalize(
+        hla_alleles=["HLA-A*02:01"],
+        viruses=["hpv16"],
+        score_presentation=False,
+        enforce_tumor_specificity=True,
+        drop_weak_tier=False,
+    )
+    assert "RISKYPEP9" not in out["peptide"].tolist()
+    assert "SAFE9PEP" in out["peptide"].tolist()
+
+
+# ── Predictor warning ──────────────────────────────────────────────────
+
+
+def test_non_mhcflurry_predictor_emits_warning(monkeypatch):
+    """PR-H: warn when --predictor ≠ mhcflurry since tier cutoffs are
+    mhcflurry-calibrated."""
+
+    def _fake_score(**kwargs):
+        return pd.DataFrame(
+            columns=[
+                "peptide",
+                "allele",
+                "presentation_score",
+                "presentation_percentile",
+                "affinity_nm",
+            ]
+        )
+
+    monkeypatch.setattr(personalize_module, "_OUTPUT_COLUMNS", personalize_module._OUTPUT_COLUMNS)
+    monkeypatch.setattr("tsarina.scoring.score_presentation", _fake_score, raising=True)
+
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        personalize(
+            hla_alleles=["HLA-A*02:01"],
+            score_presentation=True,
+            predictor="netmhcpan",
+            skip_ms_evidence=True,
+        )
+    messages = [str(m.message) for m in w if issubclass(m.category, UserWarning)]
+    assert any("netmhcpan" in msg for msg in messages)
+
+
+# ── Mandatory MHC gate: topiary ImportError propagates ─────────────────
+
+
+def test_score_presentation_import_error_propagates(monkeypatch):
+    """PR-C: when scoring is requested and the backend is missing, raise
+    (do not silently continue)."""
+    exclusive = pd.DataFrame(
+        {
+            "peptide": ["P1"],
+            "length": [9],
+            "virus": ["hpv16"],
+            "protein_id": ["E6"],
+        }
+    )
+    monkeypatch.setattr(
+        "tsarina.viral.human_exclusive_viral_peptides",
+        lambda **kw: exclusive,
+        raising=True,
+    )
+
+    def _boom(**kwargs):
+        raise ImportError("topiary is not installed in this test env")
+
+    monkeypatch.setattr("tsarina.scoring.score_presentation", _boom, raising=True)
+
+    with pytest.raises(ImportError, match="topiary"):
+        personalize(
+            hla_alleles=["HLA-A*02:01"],
+            viruses=["hpv16"],
+            score_presentation=True,
+            skip_ms_evidence=True,
+        )
+
+
+# ── drop_weak_tier removes T4 rows ─────────────────────────────────────
+
+
+def test_drop_weak_tier_removes_tier4(monkeypatch):
+    exclusive = pd.DataFrame(
+        {
+            "peptide": ["GOODPEP9", "WEAKPEP99"],
+            "length": [9, 9],
+            "virus": ["hpv16", "hpv16"],
+            "protein_id": ["E6", "E6"],
+        }
+    )
+    monkeypatch.setattr(
+        "tsarina.viral.human_exclusive_viral_peptides",
+        lambda **kw: exclusive,
+        raising=True,
+    )
+
+    def _fake_score(**kwargs):
+        return pd.DataFrame(
+            {
+                "peptide": ["GOODPEP9", "WEAKPEP99"],
+                "allele": ["HLA-A*02:01", "HLA-A*02:01"],
+                "presentation_score": [0.95, 0.05],
+                "presentation_percentile": [0.1, 20.0],
+                "affinity_nm": [10.0, 30000.0],
+            }
+        )
+
+    monkeypatch.setattr("tsarina.scoring.score_presentation", _fake_score, raising=True)
+
+    out_kept = personalize(
+        hla_alleles=["HLA-A*02:01"],
+        viruses=["hpv16"],
+        score_presentation=True,
+        skip_ms_evidence=True,
+        drop_weak_tier=True,
+    )
+    assert "WEAKPEP99" not in out_kept["peptide"].tolist()
+    assert "GOODPEP9" in out_kept["peptide"].tolist()
+
+    out_all = personalize(
+        hla_alleles=["HLA-A*02:01"],
+        viruses=["hpv16"],
+        score_presentation=True,
+        skip_ms_evidence=True,
+        drop_weak_tier=False,
+    )
+    assert set(out_all["peptide"]) == {"GOODPEP9", "WEAKPEP99"}
+
+
+# ── Deterministic sort ─────────────────────────────────────────────────
+
+
+def test_sort_is_deterministic(monkeypatch):
+    """Equal tier + hit count + percentile must still produce a stable
+    order (peptide ASC, best_allele ASC)."""
+    exclusive = pd.DataFrame(
+        {
+            "peptide": ["ZZZZZ9PEP", "AAAAA9PEP", "MMMMM9PEP"],
+            "length": [9, 9, 9],
+            "virus": ["hpv16", "hpv16", "hpv16"],
+            "protein_id": ["E6", "E7", "E6"],
+        }
+    )
+    monkeypatch.setattr(
+        "tsarina.viral.human_exclusive_viral_peptides",
+        lambda **kw: exclusive,
+        raising=True,
+    )
+
+    def _fake_score(peptides, alleles, **kwargs):
+        # All tied at 0.1 percentile → sort falls through to peptide/allele
+        return pd.DataFrame(
+            {
+                "peptide": list(peptides),
+                "allele": ["HLA-A*02:01"] * len(peptides),
+                "presentation_score": [0.95] * len(peptides),
+                "presentation_percentile": [0.1] * len(peptides),
+                "affinity_nm": [10.0] * len(peptides),
+            }
+        )
+
+    monkeypatch.setattr("tsarina.scoring.score_presentation", _fake_score, raising=True)
+
+    a = personalize(
+        hla_alleles=["HLA-A*02:01"],
+        viruses=["hpv16"],
+        score_presentation=True,
+        skip_ms_evidence=True,
+    )
+    b = personalize(
+        hla_alleles=["HLA-A*02:01"],
+        viruses=["hpv16"],
+        score_presentation=True,
+        skip_ms_evidence=True,
+    )
+    assert list(a["peptide"]) == list(b["peptide"])
+    # Expect peptide-ASC ordering when ties extend through percentile.
+    assert list(a["peptide"]) == sorted(a["peptide"].tolist())
+
+
+# ── Empty input paths return the canonical column set ─────────────────
+
+
+def test_empty_inputs_return_canonical_columns():
+    out = personalize(
+        hla_alleles=["HLA-A*02:01"],
+        score_presentation=False,
+        skip_ms_evidence=True,
+    )
+    from tsarina.personalize import _OUTPUT_COLUMNS
+
+    assert list(out.columns) == list(_OUTPUT_COLUMNS)
+    assert out.empty

--- a/tsarina/cli_personalize.py
+++ b/tsarina/cli_personalize.py
@@ -105,8 +105,47 @@ def build_parser(sub: argparse._SubParsersAction) -> argparse.ArgumentParser:
     p.add_argument(
         "--min-cta-tpm",
         type=float,
+        default=2.0,
+        help="Minimum CTA expression in TPM to include (default 2.0).",
+    )
+    p.add_argument(
+        "--min-restriction-confidence",
+        type=_split_csv,
+        default=["HIGH", "MODERATE"],
+        help=(
+            "Allowed CTA restriction_confidence bins, comma-separated "
+            "(default 'HIGH,MODERATE'; pass 'ANY' to disable)."
+        ),
+    )
+    p.add_argument(
+        "--mtec-matrix",
+        dest="mtec_matrix_path",
+        default=None,
+        help="Path to mTEC gene TPM matrix (TSV); gates CTAs by thymic expression.",
+    )
+    p.add_argument(
+        "--mtec-max-tpm",
+        type=float,
         default=1.0,
-        help="Minimum CTA expression in TPM to include (default 1.0).",
+        help="Maximum mean mTEC TPM when --mtec-matrix is given (default 1.0).",
+    )
+    p.add_argument(
+        "--no-require-human-exclusive-viral",
+        dest="require_human_exclusive_viral",
+        action="store_false",
+        help="Include viral k-mers even if they match a human protein.",
+    )
+    p.add_argument(
+        "--no-enforce-tumor-specificity",
+        dest="enforce_tumor_specificity",
+        action="store_false",
+        help="Keep peptides observed on healthy tissue (default: drop them).",
+    )
+    p.add_argument(
+        "--keep-weak-tier",
+        dest="drop_weak_tier",
+        action="store_false",
+        help="Retain tier-4 (WEAK/unscored) rows in the output.",
     )
     p.add_argument(
         "--no-score",
@@ -149,6 +188,12 @@ def handle(args: argparse.Namespace) -> None:
     from .datasources import DatasetNotRegisteredError
     from .personalize import personalize
 
+    min_restriction_confidence: tuple[str, ...] | None
+    if any(v.upper() == "ANY" for v in args.min_restriction_confidence):
+        min_restriction_confidence = None
+    else:
+        min_restriction_confidence = tuple(v.upper() for v in args.min_restriction_confidence)
+
     try:
         df = personalize(
             hla_alleles=args.hla,
@@ -161,9 +206,15 @@ def handle(args: argparse.Namespace) -> None:
             cedar_path=args.cedar_path,
             mhc_class=args.mhc_class,
             min_cta_tpm=args.min_cta_tpm,
+            min_restriction_confidence=min_restriction_confidence,
+            mtec_matrix_path=args.mtec_matrix_path,
+            mtec_max_tpm=args.mtec_max_tpm,
+            require_human_exclusive_viral=args.require_human_exclusive_viral,
+            enforce_tumor_specificity=args.enforce_tumor_specificity,
             score_presentation=not args.no_score,
             skip_ms_evidence=args.skip_ms_evidence,
             predictor=args.predictor,
+            drop_weak_tier=args.drop_weak_tier,
         )
     except DatasetNotRegisteredError as e:
         print(f"Error: {e}", file=sys.stderr)

--- a/tsarina/personalize.py
+++ b/tsarina/personalize.py
@@ -12,10 +12,34 @@
 
 """Patient-level personalization: from tumor characteristics to prioritized targets.
 
-The main entry point for clinical use.  Given a patient's HLA type, tumor
-CTA expression, detected mutations, and viral status, produces a ranked
-list of peptide-MHC targets with public MS evidence and predicted
-presentation scores.
+The clinical entry point.  Given a patient's HLA type, tumor CTA expression,
+detected mutations, and viral status, returns a ranked list of (peptide, HLA)
+targets annotated with public MS evidence, predicted presentation, and an
+explicit confidence tier.
+
+Guardrails applied by default:
+
+1. **CTA exclusivity** — only k-mers that do not appear in any non-CTA protein
+   reach the candidate pool (via :func:`tsarina.peptides.cta_exclusive_peptides`).
+2. **Viral human-exclusivity** — viral k-mers that match the human proteome
+   are dropped (via :func:`tsarina.viral.human_exclusive_viral_peptides`).
+3. **CTA restriction confidence** — CTAs are gated to the HIGH/MODERATE bins
+   of ``restriction_confidence``; LOW-confidence CTAs never contribute
+   peptides unless the caller explicitly opts in.
+4. **Tumor-specificity filter** — peptides observed by mass spec on healthy
+   non-reproductive tissue are excluded entirely (not merely penalized).
+5. **Mandatory MHC scoring** — when ``score_presentation=True`` the scorer
+   runs; failures raise loudly rather than silently dropping the gate.
+6. **Explicit tiers** — candidates are assigned to tier 1-4 based on
+   presentation percentile + evidence category; tier 4 (weak) is dropped
+   from the default output.
+7. **Deterministic sort** — output order is stable across runs
+   (tier, ms_hit_count, percentile, peptide, best_allele).
+
+Optional extra filters:
+
+- ``mtec_matrix_path`` — when given, CTAs are restricted to those with mean
+  mTEC expression below ``mtec_max_tpm`` (thymic-tolerance blacklist).
 
 Typical usage::
 
@@ -26,15 +50,46 @@ Typical usage::
         cta_expression={"MAGEA4": 142.5, "PRAME": 87.3},
         mutations=["KRAS G12D"],
         viruses=["hpv16"],
-        iedb_path="mhc_ligand_full.csv",
     )
 """
 
 from __future__ import annotations
 
+import warnings
+from collections.abc import Iterable
 from pathlib import Path
 
 import pandas as pd
+
+from .scoring import PRESENTATION_PERCENTILE_THRESHOLDS
+
+_TIER_LABELS: dict[int, str] = {
+    1: "STRONG",
+    2: "MODERATE",
+    3: "CANDIDATE",
+    4: "WEAK",
+}
+
+_OUTPUT_COLUMNS: tuple[str, ...] = (
+    "peptide",
+    "length",
+    "category",
+    "source",
+    "source_detail",
+    "source_tpm",
+    "ms_hit_count",
+    "ms_alleles",
+    "ms_allele_count",
+    "ms_in_cancer",
+    "ms_in_healthy_tissue",
+    "best_allele",
+    "presentation_percentile",
+    "presentation_score",
+    "affinity_nm",
+    "tier",
+    "tier_label",
+    "tier_reason",
+)
 
 
 def personalize(
@@ -47,86 +102,135 @@ def personalize(
     iedb_path: str | Path | None = None,
     cedar_path: str | Path | None = None,
     mhc_class: str = "I",
-    min_cta_tpm: float = 1.0,
+    min_cta_tpm: float = 2.0,
+    min_restriction_confidence: Iterable[str] | None = ("HIGH", "MODERATE"),
+    mtec_matrix_path: str | Path | None = None,
+    mtec_max_tpm: float = 1.0,
+    require_human_exclusive_viral: bool = True,
+    enforce_tumor_specificity: bool = True,
     score_presentation: bool = True,
     skip_ms_evidence: bool = False,
     predictor: str = "mhcflurry",
+    drop_weak_tier: bool = True,
 ) -> pd.DataFrame:
-    """Build a personalized target list for a single patient.
+    """Build a personalized, tier-ranked target list for a single patient.
 
     Parameters
     ----------
     hla_alleles
         Patient's HLA class I alleles (e.g. ``["HLA-A*02:01", "HLA-B*07:02"]``).
     cta_expression
-        Dict mapping CTA gene symbol to tumor RNA expression in TPM.
-        Only CTAs above ``min_cta_tpm`` are included.  If None, all
-        expressed CTAs are considered (no expression filter).
+        Dict mapping CTA gene symbol to tumor RNA expression in TPM.  Only
+        genes passing all CTA gates (membership in the filtered CTA set,
+        ``tpm >= min_cta_tpm``, ``restriction_confidence`` allowed, optional
+        mTEC cutoff) contribute peptides.  Peptides are restricted to those
+        exclusive to CTA proteins (not present in any non-CTA protein).
     mutations
-        List of mutation labels to match against the hotspot list
-        (e.g. ``["KRAS G12D", "TP53 R175H"]``).  If None, no mutant
-        peptides are included.
+        List of hotspot labels (e.g. ``["KRAS G12D"]``).  Wildtype-identical
+        k-mers are filtered in :mod:`tsarina.mutations`; they are already
+        tumor-specific by construction.
     viruses
-        List of virus keys (e.g. ``["hpv16", "ebv"]``).
-        If None, no viral peptides are included.
+        List of virus keys (e.g. ``["hpv16", "ebv"]``).  By default only
+        viral k-mers that do not appear in any human protein are kept; set
+        ``require_human_exclusive_viral=False`` to relax this.
     lengths
         Peptide lengths (default 8-11).
     ensembl_release
         Ensembl release (default 112).
-    iedb_path
-        Path to IEDB MHC ligand export.  If None (default), auto-resolves
-        from the hitlist data registry (register with
-        ``tsarina data register iedb /path/to/mhc_ligand_full.csv``).
-    cedar_path
-        Path to CEDAR MHC ligand export.  Optional; auto-resolves if
-        registered, otherwise silently skipped.
+    iedb_path, cedar_path
+        Explicit dataset paths.  Default auto-resolves via the hitlist
+        registry.  When either is supplied, the direct scan path is used
+        instead of the cached observations index.
     mhc_class
-        MHC class filter for IEDB scanning (default ``"I"``).
+        MHC class filter for IEDB/CEDAR scanning (default ``"I"``).
     min_cta_tpm
-        Minimum CTA expression in TPM to include (default 1.0).
+        Minimum CTA expression in TPM (default 2.0 — matches the
+        ``never_expressed`` HPA cutoff).
+    min_restriction_confidence
+        Allowed ``restriction_confidence`` bins for CTAs.  Default
+        ``("HIGH", "MODERATE")``; pass ``None`` to disable this gate.
+    mtec_matrix_path
+        Path to an mTEC gene TPM matrix (TSV).  When provided, CTAs are
+        restricted to genes with mean mTEC TPM <= ``mtec_max_tpm``.
+    mtec_max_tpm
+        Maximum mean mTEC TPM allowed when ``mtec_matrix_path`` is set
+        (default 1.0).
+    require_human_exclusive_viral
+        If True (default), use
+        :func:`tsarina.viral.human_exclusive_viral_peptides`.
+    enforce_tumor_specificity
+        If True (default), drop peptides with any public MS evidence on
+        healthy non-reproductive tissue.
     score_presentation
-        If True (default), score peptide-allele pairs for predicted
-        presentation via topiary + mhctools.
+        If True (default), score peptide-allele pairs via topiary + mhctools.
+        An ``ImportError`` from the scoring backend is propagated (no silent
+        pass).
     skip_ms_evidence
-        If True, do not look up IEDB/CEDAR evidence.  Useful for dry
-        runs when the datasets are not registered.
+        If True, do not look up IEDB/CEDAR evidence (dry-run path).
     predictor
-        Which mhctools predictor to use for scoring.  One of
-        ``"mhcflurry"`` (default), ``"netmhcpan"``, ``"netmhcpan_el"``.
+        mhctools predictor key.  One of ``"mhcflurry"`` (default),
+        ``"netmhcpan"``, ``"netmhcpan_el"``.  A warning is emitted when
+        a non-mhcflurry predictor is chosen, since tier cutoffs are
+        calibrated to mhcflurry's presentation percentile distribution.
+    drop_weak_tier
+        If True (default), tier-4 rows are dropped from the output.  Set
+        False to retain them for diagnostics.
 
     Returns
     -------
     pd.DataFrame
-        Prioritized target list with columns:
+        Tier-ranked target list.  Columns:
 
-        - ``peptide``: peptide sequence
-        - ``length``: peptide length
-        - ``category``: ``"cta"``, ``"viral"``, or ``"mutant"``
-        - ``source``: gene name / virus name / mutation label
-        - ``source_tpm``: RNA expression in TPM (CTAs only, NaN otherwise)
-        - ``ms_hit_count``: number of IEDB/CEDAR MS observations
-        - ``ms_alleles``: MHC restrictions observed in public data
-        - ``ms_in_cancer``: detected in cancer samples
-        - ``ms_in_healthy_tissue``: detected in normal non-reproductive tissue (safety flag)
-        - ``best_allele``: patient HLA allele with best predicted presentation
-        - ``presentation_percentile``: MHCflurry percentile for best allele
-        - ``priority_score``: composite prioritization score (higher = better)
+        - ``peptide``, ``length``, ``category``, ``source``,
+          ``source_detail``, ``source_tpm``
+        - ``ms_hit_count``, ``ms_alleles``, ``ms_allele_count``,
+          ``ms_in_cancer``, ``ms_in_healthy_tissue``
+        - ``best_allele``, ``presentation_percentile``,
+          ``presentation_score``, ``affinity_nm``
+        - ``tier`` (int 1-4, lower is better), ``tier_label`` (str),
+          ``tier_reason`` (which gates were satisfied)
+
+    Raises
+    ------
+    ImportError
+        If ``score_presentation=True`` but the scoring backend (topiary +
+        mhctools + the chosen predictor) is not installed.
     """
     frames: list[pd.DataFrame] = []
 
+    if score_presentation and predictor != "mhcflurry":
+        warnings.warn(
+            f"Predictor {predictor!r} is not mhcflurry; tier cutoffs "
+            f"({PRESENTATION_PERCENTILE_THRESHOLDS}) are calibrated to mhcflurry's "
+            "presentation-percentile distribution and may not translate 1:1 "
+            "to other backends.",
+            UserWarning,
+            stacklevel=2,
+        )
+
     # ── CTA peptides ────────────────────────────────────────────────────
-    if cta_expression is not None:
-        from .gene_sets import CTA_gene_names
-        from .peptides import cta_peptides
+    if cta_expression:
+        from .gene_sets import CTA_by_axes, CTA_gene_names
+        from .peptides import cta_exclusive_peptides
 
         valid_ctas = CTA_gene_names()
+        if min_restriction_confidence is not None:
+            confidence_set = {c.upper() for c in min_restriction_confidence}
+            confident_ctas = CTA_by_axes(restriction_confidence=confidence_set)
+            valid_ctas = valid_ctas & confident_ctas
+        if mtec_matrix_path is not None:
+            from .mtec import filter_by_mtec, load_mtec_gene_table
+
+            mtec_df = load_mtec_gene_table(mtec_matrix_path)
+            valid_ctas = filter_by_mtec(valid_ctas, mtec_df, threshold=mtec_max_tpm)
+
         expressed_ctas = {
             gene: tpm
             for gene, tpm in cta_expression.items()
             if gene in valid_ctas and tpm >= min_cta_tpm
         }
         if expressed_ctas:
-            all_cta_peps = cta_peptides(ensembl_release=ensembl_release, lengths=lengths)
+            all_cta_peps = cta_exclusive_peptides(ensembl_release=ensembl_release, lengths=lengths)
             cta_peps = all_cta_peps[all_cta_peps["gene_name"].isin(expressed_ctas)].copy()
             if not cta_peps.empty:
                 cta_peps["source_tpm"] = cta_peps["gene_name"].map(expressed_ctas)
@@ -142,16 +246,12 @@ def personalize(
                         }
                     )
                 )
-    elif cta_expression is None:
-        # Include all expressed CTAs when no expression dict provided
-        pass  # caller must explicitly provide expression to include CTAs
 
     # ── Mutant peptides ─────────────────────────────────────────────────
     if mutations:
         from .mutations import HOTSPOT_MUTATIONS
         from .mutations import mutant_peptides as _mutant_peptides
 
-        # Match patient mutations against hotspot list
         mutation_labels = set(mutations)
         matched = [m for m in HOTSPOT_MUTATIONS if m["label"] in mutation_labels]
         if matched:
@@ -174,10 +274,16 @@ def personalize(
 
     # ── Viral peptides ──────────────────────────────────────────────────
     if viruses:
-        from .viral import viral_peptides
+        if require_human_exclusive_viral:
+            from .viral import human_exclusive_viral_peptides as _viral_peps
+        else:
+            from .viral import viral_peptides as _viral_peps
 
         for vk in viruses:
-            vdf = viral_peptides(virus=vk, lengths=lengths)
+            if require_human_exclusive_viral:
+                vdf = _viral_peps(virus=vk, lengths=lengths, ensembl_release=ensembl_release)
+            else:
+                vdf = _viral_peps(virus=vk, lengths=lengths)
             if not vdf.empty:
                 frames.append(
                     pd.DataFrame(
@@ -193,116 +299,219 @@ def personalize(
                 )
 
     if not frames:
-        return pd.DataFrame(
-            columns=[
-                "peptide",
-                "length",
-                "category",
-                "source",
-                "source_detail",
-                "source_tpm",
-            ]
-        )
+        return pd.DataFrame(columns=list(_OUTPUT_COLUMNS))
 
     combined = pd.concat(frames, ignore_index=True)
 
     # ── IEDB/CEDAR evidence ─────────────────────────────────────────────
-    if not skip_ms_evidence:
-        from .indexing import load_ms_evidence
+    combined = _attach_ms_evidence(
+        combined,
+        iedb_path=iedb_path,
+        cedar_path=cedar_path,
+        mhc_class=mhc_class,
+        skip_ms_evidence=skip_ms_evidence,
+    )
 
-        # iedb_path / cedar_path are legacy; if provided, we still pass them
-        # through to a direct scan_public_ms call for users who want to
-        # bypass the cached index.
-        if iedb_path is not None or cedar_path is not None:
-            from .datasources import resolve_dataset_paths
-            from .iedb import scan_public_ms
+    if enforce_tumor_specificity and "ms_in_healthy_tissue" in combined.columns:
+        safe_mask = ~combined["ms_in_healthy_tissue"].astype(bool)
+        combined = combined[safe_mask].reset_index(drop=True)
 
-            resolved_iedb, resolved_cedar = resolve_dataset_paths(iedb_path, cedar_path)
-            hits = scan_public_ms(
-                peptides=set(combined["peptide"].unique()),
-                iedb_path=resolved_iedb,
-                cedar_path=resolved_cedar,
-                mhc_class=mhc_class,
-                classify_source=True,
-            )
-        else:
-            hits = load_ms_evidence(
-                peptides=set(combined["peptide"].unique()),
-                mhc_class=mhc_class,
-                mhc_species="Homo sapiens",
-            )
-
-        if not hits.empty:
-            agg_cols = {
-                "ms_hit_count": ("peptide", "size"),
-                "ms_alleles": ("mhc_restriction", lambda x: ";".join(sorted(set(x)))),
-                "ms_allele_count": ("mhc_restriction", lambda x: len(set(x))),
-            }
-            if "src_cancer" in hits.columns:
-                agg_cols["ms_in_cancer"] = ("src_cancer", "any")
-            if "src_healthy_tissue" in hits.columns:
-                agg_cols["ms_in_healthy_tissue"] = ("src_healthy_tissue", "any")
-
-            hit_agg = hits.groupby("peptide", as_index=False).agg(**agg_cols)
-            combined = combined.merge(hit_agg, on="peptide", how="left")
-        else:
-            combined["ms_hit_count"] = 0
-            combined["ms_alleles"] = ""
-            combined["ms_allele_count"] = 0
-            combined["ms_in_cancer"] = False
-            combined["ms_in_healthy_tissue"] = False
-
-        for col, default in [
-            ("ms_hit_count", 0),
-            ("ms_alleles", ""),
-            ("ms_allele_count", 0),
-            ("ms_in_cancer", False),
-            ("ms_in_healthy_tissue", False),
-        ]:
-            if col in combined.columns:
-                combined[col] = combined[col].fillna(default)
+    if combined.empty:
+        return pd.DataFrame(columns=list(_OUTPUT_COLUMNS))
 
     # ── Topiary presentation scoring ────────────────────────────────────
     if score_presentation and hla_alleles:
-        try:
-            from .scoring import score_presentation as _score
+        from .scoring import score_presentation as _score
 
-            unique_peps = combined["peptide"].unique().tolist()
-            scores = _score(peptides=unique_peps, alleles=hla_alleles, predictor=predictor)
+        unique_peps = combined["peptide"].unique().tolist()
+        scores = _score(peptides=unique_peps, alleles=hla_alleles, predictor=predictor)
+        combined = _merge_best_allele(combined, scores)
+    else:
+        for col in ("best_allele", "presentation_percentile", "presentation_score", "affinity_nm"):
+            if col not in combined.columns:
+                combined[col] = pd.NA
 
-            # For each peptide, find the best (lowest percentile) allele
-            if not scores.empty and "presentation_percentile" in scores.columns:
-                best = (
-                    scores.sort_values("presentation_percentile")
-                    .groupby("peptide", as_index=False)
-                    .first()
-                    .rename(
-                        columns={
-                            "allele": "best_allele",
-                            "presentation_percentile": "presentation_percentile",
-                        }
-                    )[["peptide", "best_allele", "presentation_percentile"]]
-                )
-                combined = combined.merge(best, on="peptide", how="left")
-        except ImportError:
-            pass  # MHCflurry not installed, skip scoring
+    # ── Tier assignment ─────────────────────────────────────────────────
+    combined = _assign_tiers(combined)
+    if drop_weak_tier:
+        combined = combined[combined["tier"] < 4].reset_index(drop=True)
 
-    # ── Priority score ──────────────────────────────────────────────────
-    # Composite score: MS evidence + expression + presentation
-    combined["priority_score"] = 0.0
-    if "ms_hit_count" in combined.columns:
-        combined["priority_score"] += combined["ms_hit_count"].clip(upper=10) * 10
-    if "ms_in_cancer" in combined.columns:
-        combined["priority_score"] += combined["ms_in_cancer"].astype(float) * 20
-    if "ms_in_healthy_tissue" in combined.columns:
-        combined["priority_score"] -= combined["ms_in_healthy_tissue"].astype(float) * 50
-    if "source_tpm" in combined.columns:
-        combined["priority_score"] += combined["source_tpm"].fillna(0).clip(upper=500) * 0.1
-    if "presentation_percentile" in combined.columns:
-        # Lower percentile = better, so invert
-        combined["priority_score"] += (100 - combined["presentation_percentile"].fillna(100)).clip(
-            lower=0
-        ) * 0.5
+    # ── Deterministic sort ──────────────────────────────────────────────
+    sort_cols = ["tier", "ms_hit_count", "presentation_percentile", "peptide", "best_allele"]
+    sort_ascending = [True, False, True, True, True]
+    available = [c for c in sort_cols if c in combined.columns]
+    ascending = [a for c, a in zip(sort_cols, sort_ascending) if c in combined.columns]
+    combined = combined.sort_values(
+        available, ascending=ascending, na_position="last", kind="mergesort"
+    ).reset_index(drop=True)
 
-    combined = combined.sort_values("priority_score", ascending=False).reset_index(drop=True)
+    for col in _OUTPUT_COLUMNS:
+        if col not in combined.columns:
+            combined[col] = pd.NA
+    return combined[list(_OUTPUT_COLUMNS)]
+
+
+def _attach_ms_evidence(
+    combined: pd.DataFrame,
+    *,
+    iedb_path: str | Path | None,
+    cedar_path: str | Path | None,
+    mhc_class: str,
+    skip_ms_evidence: bool,
+) -> pd.DataFrame:
+    """Join MS-aggregated columns onto the candidate frame."""
+    defaults: dict[str, object] = {
+        "ms_hit_count": 0,
+        "ms_alleles": "",
+        "ms_allele_count": 0,
+        "ms_in_cancer": False,
+        "ms_in_healthy_tissue": False,
+    }
+
+    if skip_ms_evidence:
+        for col, default in defaults.items():
+            combined[col] = default
+        return combined
+
+    if iedb_path is not None or cedar_path is not None:
+        from .datasources import resolve_dataset_paths
+        from .iedb import scan_public_ms
+
+        resolved_iedb, resolved_cedar = resolve_dataset_paths(iedb_path, cedar_path)
+        hits = scan_public_ms(
+            peptides=set(combined["peptide"].unique()),
+            iedb_path=resolved_iedb,
+            cedar_path=resolved_cedar,
+            mhc_class=mhc_class,
+            classify_source=True,
+        )
+    else:
+        from .indexing import load_ms_evidence
+
+        hits = load_ms_evidence(
+            peptides=set(combined["peptide"].unique()),
+            mhc_class=mhc_class,
+            mhc_species="Homo sapiens",
+        )
+
+    if hits.empty:
+        for col, default in defaults.items():
+            combined[col] = default
+        return combined
+
+    agg_cols: dict[str, tuple] = {
+        "ms_hit_count": ("peptide", "size"),
+        "ms_alleles": ("mhc_restriction", lambda x: ";".join(sorted(set(x)))),
+        "ms_allele_count": ("mhc_restriction", lambda x: len(set(x))),
+    }
+    if "src_cancer" in hits.columns:
+        agg_cols["ms_in_cancer"] = ("src_cancer", "any")
+    if "src_healthy_tissue" in hits.columns:
+        agg_cols["ms_in_healthy_tissue"] = ("src_healthy_tissue", "any")
+
+    hit_agg = hits.groupby("peptide", as_index=False).agg(**agg_cols)
+    combined = combined.merge(hit_agg, on="peptide", how="left")
+
+    int_cols = {"ms_hit_count", "ms_allele_count"}
+    bool_cols = {"ms_in_cancer", "ms_in_healthy_tissue"}
+    for col, default in defaults.items():
+        if col not in combined.columns:
+            combined[col] = default
+            continue
+        if col in int_cols:
+            combined[col] = (
+                pd.to_numeric(combined[col], errors="coerce").fillna(default).astype(int)
+            )
+        elif col in bool_cols:
+            combined[col] = combined[col].where(combined[col].notna(), default).astype(bool)
+        else:
+            combined[col] = combined[col].where(combined[col].notna(), default).astype(str)
+    return combined
+
+
+def _merge_best_allele(combined: pd.DataFrame, scores: pd.DataFrame) -> pd.DataFrame:
+    """Attach each peptide's lowest-percentile allele + associated score columns."""
+    for col in ("best_allele", "presentation_percentile", "presentation_score", "affinity_nm"):
+        if col not in combined.columns:
+            combined[col] = pd.NA
+
+    if scores.empty or "presentation_percentile" not in scores.columns:
+        return combined
+
+    best = (
+        scores.sort_values(["presentation_percentile", "peptide", "allele"], kind="mergesort")
+        .groupby("peptide", as_index=False)
+        .first()
+        .rename(columns={"allele": "best_allele"})
+    )
+    cols = ["peptide", "best_allele", "presentation_percentile"]
+    for extra in ("presentation_score", "affinity_nm"):
+        if extra in best.columns:
+            cols.append(extra)
+    combined = combined.drop(
+        columns=[
+            c
+            for c in ("best_allele", "presentation_percentile", "presentation_score", "affinity_nm")
+            if c in combined.columns
+        ],
+        errors="ignore",
+    ).merge(best[cols], on="peptide", how="left")
+    return combined
+
+
+def _assign_tiers(combined: pd.DataFrame) -> pd.DataFrame:
+    """Assign tier (1-4) + tier_label + tier_reason using explicit gates.
+
+    Uses :data:`tsarina.scoring.PRESENTATION_PERCENTILE_THRESHOLDS` as
+    ``(t1_cut, t2_cut, t3_cut)``:
+
+    - **T1 (STRONG)**: ``percentile <= t1_cut`` AND
+      (``ms_in_cancer`` OR category in ``{mutant, viral}``).
+    - **T2 (MODERATE)**: ``percentile <= t2_cut`` AND
+      (``ms_hit_count > 0`` OR category in ``{mutant, viral}``).
+    - **T3 (CANDIDATE)**: ``percentile <= t3_cut``.
+    - **T4 (WEAK)**: otherwise (including rows with no percentile).
+    """
+    t1_cut, t2_cut, t3_cut = PRESENTATION_PERCENTILE_THRESHOLDS
+
+    pct = pd.to_numeric(combined.get("presentation_percentile"), errors="coerce")
+    ms_cancer = combined.get("ms_in_cancer", False)
+    ms_hits = pd.to_numeric(combined.get("ms_hit_count", 0), errors="coerce").fillna(0)
+    category = combined["category"]
+    non_self_category = category.isin(("mutant", "viral"))
+
+    t1_mask = pct.le(t1_cut) & (ms_cancer.astype(bool) | non_self_category)
+    t2_mask = pct.le(t2_cut) & ((ms_hits > 0) | non_self_category)
+    t3_mask = pct.le(t3_cut)
+
+    tier = pd.Series(4, index=combined.index, dtype="int64")
+    tier = tier.mask(t3_mask, 3)
+    tier = tier.mask(t2_mask, 2)
+    tier = tier.mask(t1_mask, 1)
+
+    reasons = []
+    for idx in combined.index:
+        t = int(tier.loc[idx])
+        cat = category.loc[idx]
+        if t == 1:
+            driver = (
+                "cancer_ms"
+                if bool(ms_cancer.loc[idx] if hasattr(ms_cancer, "loc") else False)
+                else cat
+            )
+            reasons.append(f"strong_presentation+{driver}")
+        elif t == 2:
+            if cat in ("mutant", "viral"):
+                reasons.append(f"moderate_presentation+{cat}")
+            else:
+                reasons.append("moderate_presentation+any_ms")
+        elif t == 3:
+            reasons.append("presentation_only")
+        else:
+            reasons.append("unscored" if pd.isna(pct.loc[idx]) else "below_threshold")
+
+    combined = combined.copy()
+    combined["tier"] = tier
+    combined["tier_label"] = combined["tier"].map(_TIER_LABELS)
+    combined["tier_reason"] = reasons
     return combined

--- a/tsarina/personalize.py
+++ b/tsarina/personalize.py
@@ -59,6 +59,7 @@ import warnings
 from collections.abc import Iterable
 from pathlib import Path
 
+import numpy as np
 import pandas as pd
 
 from .scoring import PRESENTATION_PERCENTILE_THRESHOLDS
@@ -473,45 +474,42 @@ def _assign_tiers(combined: pd.DataFrame) -> pd.DataFrame:
     - **T4 (WEAK)**: otherwise (including rows with no percentile).
     """
     t1_cut, t2_cut, t3_cut = PRESENTATION_PERCENTILE_THRESHOLDS
+    idx = combined.index
 
     pct = pd.to_numeric(combined.get("presentation_percentile"), errors="coerce")
-    ms_cancer = combined.get("ms_in_cancer", False)
+    ms_cancer = (
+        combined["ms_in_cancer"].astype(bool)
+        if "ms_in_cancer" in combined.columns
+        else pd.Series(False, index=idx)
+    )
     ms_hits = pd.to_numeric(combined.get("ms_hit_count", 0), errors="coerce").fillna(0)
-    category = combined["category"]
+    category = combined["category"].astype(str)
     non_self_category = category.isin(("mutant", "viral"))
 
-    t1_mask = pct.le(t1_cut) & (ms_cancer.astype(bool) | non_self_category)
+    t1_mask = pct.le(t1_cut) & (ms_cancer | non_self_category)
     t2_mask = pct.le(t2_cut) & ((ms_hits > 0) | non_self_category)
     t3_mask = pct.le(t3_cut)
 
-    tier = pd.Series(4, index=combined.index, dtype="int64")
+    tier = pd.Series(4, index=idx, dtype="int64")
     tier = tier.mask(t3_mask, 3)
     tier = tier.mask(t2_mask, 2)
     tier = tier.mask(t1_mask, 1)
 
-    reasons = []
-    for idx in combined.index:
-        t = int(tier.loc[idx])
-        cat = category.loc[idx]
-        if t == 1:
-            driver = (
-                "cancer_ms"
-                if bool(ms_cancer.loc[idx] if hasattr(ms_cancer, "loc") else False)
-                else cat
-            )
-            reasons.append(f"strong_presentation+{driver}")
-        elif t == 2:
-            if cat in ("mutant", "viral"):
-                reasons.append(f"moderate_presentation+{cat}")
-            else:
-                reasons.append("moderate_presentation+any_ms")
-        elif t == 3:
-            reasons.append("presentation_only")
-        else:
-            reasons.append("unscored" if pd.isna(pct.loc[idx]) else "below_threshold")
+    # Vectorized tier_reason assembly — prefix + per-tier driver, chained .mask
+    t1_driver = pd.Series(
+        np.where(ms_cancer.to_numpy(), "cancer_ms", category.to_numpy()), index=idx
+    )
+    t2_driver = pd.Series(
+        np.where(non_self_category.to_numpy(), category.to_numpy(), "any_ms"), index=idx
+    )
+    t4_driver = pd.Series(np.where(pct.isna().to_numpy(), "unscored", "below_threshold"), index=idx)
+    reasons = t4_driver.copy()
+    reasons = reasons.mask(tier == 3, "presentation_only")
+    reasons = reasons.mask(tier == 2, "moderate_presentation+" + t2_driver)
+    reasons = reasons.mask(tier == 1, "strong_presentation+" + t1_driver)
 
     combined = combined.copy()
     combined["tier"] = tier
     combined["tier_label"] = combined["tier"].map(_TIER_LABELS)
-    combined["tier_reason"] = reasons
+    combined["tier_reason"] = reasons.to_numpy()
     return combined

--- a/tsarina/targets.py
+++ b/tsarina/targets.py
@@ -50,6 +50,7 @@ def target_peptides(
     require_ms_evidence: bool = False,
     classify_source: bool = True,
     cancer_specific: bool = False,
+    require_human_exclusive_viral: bool = True,
 ) -> pd.DataFrame:
     """Build a unified peptide table across CTA, viral, and mutant targets.
 
@@ -83,6 +84,11 @@ def target_peptides(
         (``src_cancer=True``) and without healthy-tissue evidence
         (``src_healthy=False``).  Only applies when MS evidence is
         available.
+    require_human_exclusive_viral
+        If True (default), viral k-mers are filtered to those that do not
+        appear in any human protein (via
+        :func:`tsarina.viral.human_exclusive_viral_peptides`).  Set False
+        to include all viral k-mers regardless of human-proteome overlap.
 
     Returns
     -------
@@ -114,11 +120,20 @@ def target_peptides(
 
     # ── Viral peptides ──────────────────────────────────────────────────
     if viruses:
-        from .viral import ONCOGENIC_VIRUSES, viral_peptides
+        from .viral import (
+            ONCOGENIC_VIRUSES,
+            human_exclusive_viral_peptides,
+            viral_peptides,
+        )
 
         virus_keys = sorted(ONCOGENIC_VIRUSES.keys()) if viruses is True else list(viruses)
         for vk in virus_keys:
-            vdf = viral_peptides(virus=vk, lengths=lengths)
+            if require_human_exclusive_viral:
+                vdf = human_exclusive_viral_peptides(
+                    virus=vk, lengths=lengths, ensembl_release=ensembl_release
+                )
+            else:
+                vdf = viral_peptides(virus=vk, lengths=lengths)
             if not vdf.empty:
                 frames.append(
                     pd.DataFrame(

--- a/tsarina/version.py
+++ b/tsarina/version.py
@@ -10,4 +10,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.7.0"
+__version__ = "0.8.0"


### PR DESCRIPTION
## Background

Audit on this branch (see `tasks/todo.md` Review section) found that `personalize()` had drifted away from the guardrails implemented elsewhere in the repo:

- It used `cta_peptides` (non-exclusive) while `targets.py` already used `cta_exclusive_peptides` — peptides shared with non-CTA proteins entered the ranked list as CTA targets.
- It used `viral_peptides` despite `human_exclusive_viral_peptides` being defined and documented — viral k-mers that match the human proteome ranked as viral targets (also applied to `targets.py`).
- It swallowed an MHC-scoring `ImportError` silently; candidates with no percentile survived via `fillna(100)` arithmetic.
- It conflated MS evidence, cancer flag, TPM, and percentile into a single `priority_score` with uncalibrated weights, no tiering, and no enforcement of `scoring.PRESENTATION_PERCENTILE_THRESHOLDS`.
- Healthy-tissue MS evidence was a −50 point penalty, not a filter.
- Sort was a single numeric key — non-deterministic on ties.
- `min_cta_tpm=1.0` default was below the `never_expressed` HPA cutoff of 2.0.
- CTA `restriction_confidence` axis computed in `tiers.py` was reporting-only (LOW-confidence CTAs contributed peptides indistinguishably from HIGH).
- `mtec.py` + `negatives.healthy_tissue_peptides` existed but were not wired into `personalize()`.

## Summary

Bundles the eight follow-ups A–H identified by the audit:

- **A / B** — CTA + viral **exclusivity by default** in both `personalize()` and `targets.target_peptides()`.
- **C** — **Mandatory MHC gate**: scoring `ImportError` propagates; unscored rows → tier 4.
- **D** — **Explicit 4-tier system** consuming `scoring.PRESENTATION_PERCENTILE_THRESHOLDS` + deterministic sort.
- **E** — `enforce_tumor_specificity=True` **hard-filters** peptides flagged on healthy non-reproductive tissue.
- **F** — `mtec_matrix_path` / `mtec_max_tpm` wiring into the CTA gate.
- **G** — `min_restriction_confidence=("HIGH","MODERATE")` gate over `CTA_by_axes`.
- **H** — `min_cta_tpm` default raised 1.0 → 2.0; `UserWarning` when `predictor != mhcflurry`.

## Breaking change

Output schema replaces `priority_score` with `tier` / `tier_label` / `tier_reason`. Minor version bump (0.7.0 → 0.8.0).

## Test plan

- [x] 14 new tests in `tests/test_personalize.py` covering tier unit behavior, CTA + viral routing, healthy-tissue filter, predictor warning, `ImportError` propagation, `drop_weak_tier`, deterministic sort, canonical empty frame.
- [x] `./format.sh` clean.
- [x] `./lint.sh` clean.
- [x] `./test.sh` — 160 passed, 0 failed, 0 warnings.
- [ ] Reviewer: confirm the tier thresholds (0.25 / 0.50 / 1.0) are what we want clinically, or propose alternatives (0.5 / 1.0 / 2.0 is the common alternative).
- [ ] Reviewer: confirm `min_cta_tpm` default of 2.0 matches HPA `never_expressed` semantics.