### PR TITLE
v0.9.0: tsarina hits --format refs — per-pMHC ref/tissue breakout

### DIFF
--- a/tests/test_cli_hits_refs.py
+++ b/tests/test_cli_hits_refs.py
@@ -128,3 +128,33 @@ def test_refs_is_in_cli_format_choices():
     from tsarina.cli_hits import _SUPPORTED_FORMATS
 
     assert "refs" in _SUPPORTED_FORMATS
+
+
+def test_refs_pmids_sorted_numerically_not_lexicographically():
+    """PMIDs are integers. Lexicographic sort would place a 9-digit PMID
+    before an 8-digit one (``"1000000000" < "999999999"`` as strings)."""
+    hits = pd.DataFrame(
+        {
+            "peptide": ["SAME9PEP"] * 3,
+            "mhc_restriction": ["HLA-A*02:01"] * 3,
+            "pmid": [999999999, 38000001, 1000000000],
+        }
+    )
+    out = _aggregate_refs(hits)
+    assert out.loc[0, "pmids"] == "38000001;999999999;1000000000"
+    assert int(out.loc[0, "ref_count"]) == 3
+
+
+def test_refs_in_healthy_tissue_true_when_any_row_flagged():
+    """Positive-case coverage for the ``in_healthy_tissue`` aggregation."""
+    hits = pd.DataFrame(
+        {
+            "peptide": ["RISKY9PEP", "RISKY9PEP"],
+            "mhc_restriction": ["HLA-A*02:01", "HLA-A*02:01"],
+            "src_cancer": [True, False],
+            "src_healthy_tissue": [False, True],
+        }
+    )
+    out = _aggregate_refs(hits)
+    assert bool(out.loc[0, "in_cancer"]) is True
+    assert bool(out.loc[0, "in_healthy_tissue"]) is True

--- a/tests/test_cli_hits_refs.py
+++ b/tests/test_cli_hits_refs.py
@@ -1,0 +1,130 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the ``--format refs`` aggregation in ``tsarina hits``."""
+
+from __future__ import annotations
+
+import pandas as pd
+
+from tsarina.cli_hits import _aggregate_refs
+
+
+def _scan_fixture() -> pd.DataFrame:
+    """Two peptides x one allele, with two references for peptide A and
+    mixed cancer / healthy-tissue provenance."""
+    return pd.DataFrame(
+        {
+            "peptide": [
+                "QYIAQFTSQF",
+                "QYIAQFTSQF",
+                "LYVDSLFFL",
+            ],
+            "mhc_restriction": [
+                "HLA-A*24:02",
+                "HLA-A*24:02",
+                "HLA-A*24:02",
+            ],
+            "pmid": [27869121, 38000001, 33858848],
+            "source_tissue": ["Lymph Node", "Skin", "Thymus"],
+            "disease": ["skin melanoma", "skin melanoma", ""],
+            "cell_line_name": ["", "", ""],
+            "src_cancer": [True, True, False],
+            "src_healthy_tissue": [False, False, False],
+            "src_healthy_thymus": [False, False, True],
+            "is_monoallelic": [False, True, False],
+        }
+    )
+
+
+def test_refs_aggregates_per_pmhc_with_counts_and_lists():
+    out = _aggregate_refs(_scan_fixture())
+    assert set(out.columns) >= {
+        "peptide",
+        "length",
+        "mhc_restriction",
+        "hit_count",
+        "ref_count",
+        "pmids",
+        "tissues",
+        "diseases",
+        "in_cancer",
+        "in_healthy_tissue",
+        "mono_allelic_hit_count",
+    }
+    assert len(out) == 2  # two distinct (peptide, allele) rows
+
+    q_row = out[out["peptide"] == "QYIAQFTSQF"].iloc[0]
+    assert int(q_row["length"]) == 10
+    assert int(q_row["hit_count"]) == 2
+    assert int(q_row["ref_count"]) == 2
+    # pmids are sorted strings; both PMIDs appear
+    assert q_row["pmids"] == "27869121;38000001"
+    assert q_row["tissues"] == "Lymph Node;Skin"
+    assert q_row["diseases"] == "skin melanoma"
+    assert bool(q_row["in_cancer"]) is True
+    assert bool(q_row["in_healthy_tissue"]) is False
+    assert int(q_row["mono_allelic_hit_count"]) == 1
+
+    l_row = out[out["peptide"] == "LYVDSLFFL"].iloc[0]
+    assert int(l_row["length"]) == 9
+    assert int(l_row["ref_count"]) == 1
+    assert l_row["pmids"] == "33858848"
+    assert l_row["tissues"] == "Thymus"
+    assert l_row["diseases"] == ""
+    assert bool(l_row["in_cancer"]) is False
+
+
+def test_refs_empty_input_returns_canonical_columns():
+    out = _aggregate_refs(pd.DataFrame(columns=["peptide", "mhc_restriction"]))
+    assert out.empty
+    assert list(out.columns) == [
+        "peptide",
+        "length",
+        "mhc_restriction",
+        "hit_count",
+        "ref_count",
+        "pmids",
+        "tissues",
+        "diseases",
+        "cell_lines",
+        "in_cancer",
+        "in_healthy_tissue",
+        "mono_allelic_hit_count",
+    ]
+
+
+def test_refs_missing_optional_columns_skips_them():
+    """Raw scan vs cached observations produce slightly different column
+    sets. The aggregator must silently skip any optional columns absent
+    from the input rather than crashing."""
+    skinny = pd.DataFrame(
+        {
+            "peptide": ["ABCDEFGHI", "ABCDEFGHI"],
+            "mhc_restriction": ["HLA-A*02:01", "HLA-A*02:01"],
+            # no pmid / source_tissue / src_cancer / is_monoallelic columns
+        }
+    )
+    out = _aggregate_refs(skinny)
+    assert len(out) == 1
+    assert int(out.iloc[0]["hit_count"]) == 2
+    # Optional columns that weren't supplied are absent from the output,
+    # not None / NaN artifacts.
+    assert "pmids" not in out.columns
+    assert "tissues" not in out.columns
+    assert "in_cancer" not in out.columns
+
+
+def test_refs_is_in_cli_format_choices():
+    from tsarina.cli_hits import _SUPPORTED_FORMATS
+
+    assert "refs" in _SUPPORTED_FORMATS

--- a/tsarina/cli_hits.py
+++ b/tsarina/cli_hits.py
@@ -30,7 +30,7 @@ import sys
 
 import pandas as pd
 
-_SUPPORTED_FORMATS = ("peptides", "pmhc", "raw")
+_SUPPORTED_FORMATS = ("peptides", "pmhc", "refs", "raw")
 _SUPPORTED_PREDICTORS = ("mhcflurry", "netmhcpan", "netmhcpan_el")
 _SUPPORTED_RESOLUTIONS = ("four_digit", "two_digit", "serological", "class_only")
 
@@ -131,7 +131,11 @@ def build_parser(sub: argparse._SubParsersAction) -> argparse.ArgumentParser:
         "--format",
         choices=_SUPPORTED_FORMATS,
         default="pmhc",
-        help="Output aggregation (default pmhc).",
+        help=(
+            "Output aggregation (default pmhc). 'refs' adds per-pMHC columns "
+            "for ref_count, pmids, tissues, diseases, cell_lines, and the "
+            "cancer / healthy-tissue source flags."
+        ),
     )
     p.add_argument(
         "--predict",
@@ -288,6 +292,85 @@ def _filter_by_serotype(hits: pd.DataFrame, serotypes: list[str]) -> pd.DataFram
     return hits[hits["mhc_restriction"].map(_matches)].copy()
 
 
+def _aggregate_refs(hits: pd.DataFrame) -> pd.DataFrame:
+    """Per-(peptide, allele) aggregation focused on references + tissues.
+
+    Produces a leaner alternative to :func:`hitlist.aggregate_per_pmhc` that
+    exposes the provenance columns reviewers usually want on a pMHC row:
+    reference count, the actual PMID list, and the distinct tissues /
+    diseases / cell lines where the peptide was observed.  The
+    source-context booleans (``in_cancer`` / ``in_healthy_tissue``) are
+    preserved for quick filtering.
+
+    Parameters
+    ----------
+    hits
+        Raw scan / observations rows with at minimum ``peptide`` and
+        ``mhc_restriction`` columns.  Optional columns (``pmid``,
+        ``source_tissue``, ``disease``, ``cell_line_name``,
+        ``src_cancer``, ``src_healthy_tissue``, ``is_monoallelic``) are
+        used when present and silently skipped when absent.
+
+    Returns
+    -------
+    pd.DataFrame
+        One row per (peptide, mhc_restriction).  Columns:
+        ``peptide``, ``length``, ``mhc_restriction``, ``hit_count``,
+        ``ref_count``, ``pmids``, ``tissues``, ``diseases``,
+        ``cell_lines``, ``in_cancer``, ``in_healthy_tissue``,
+        ``mono_allelic_hit_count``.
+    """
+    if hits.empty:
+        return pd.DataFrame(
+            columns=[
+                "peptide",
+                "length",
+                "mhc_restriction",
+                "hit_count",
+                "ref_count",
+                "pmids",
+                "tissues",
+                "diseases",
+                "cell_lines",
+                "in_cancer",
+                "in_healthy_tissue",
+                "mono_allelic_hit_count",
+            ]
+        )
+
+    def _join_unique(series: pd.Series) -> str:
+        values = {
+            str(v).strip() for v in series.dropna() if str(v).strip() and str(v).lower() != "nan"
+        }
+        return ";".join(sorted(values))
+
+    def _count_unique(series: pd.Series) -> int:
+        return len(
+            {str(v).strip() for v in series.dropna() if str(v).strip() and str(v).lower() != "nan"}
+        )
+
+    agg_cols: dict[str, tuple] = {"hit_count": ("peptide", "size")}
+    if "pmid" in hits.columns:
+        agg_cols["ref_count"] = ("pmid", _count_unique)
+        agg_cols["pmids"] = ("pmid", _join_unique)
+    if "source_tissue" in hits.columns:
+        agg_cols["tissues"] = ("source_tissue", _join_unique)
+    if "disease" in hits.columns:
+        agg_cols["diseases"] = ("disease", _join_unique)
+    if "cell_line_name" in hits.columns:
+        agg_cols["cell_lines"] = ("cell_line_name", _join_unique)
+    if "src_cancer" in hits.columns:
+        agg_cols["in_cancer"] = ("src_cancer", "any")
+    if "src_healthy_tissue" in hits.columns:
+        agg_cols["in_healthy_tissue"] = ("src_healthy_tissue", "any")
+    if "is_monoallelic" in hits.columns:
+        agg_cols["mono_allelic_hit_count"] = ("is_monoallelic", "sum")
+
+    out = hits.groupby(["peptide", "mhc_restriction"], as_index=False).agg(**agg_cols)
+    out.insert(1, "length", out["peptide"].str.len())
+    return out
+
+
 def _apply_min_resolution(hits: pd.DataFrame, min_resolution: str | None) -> pd.DataFrame:
     if min_resolution is None or hits.empty:
         return hits
@@ -413,6 +496,16 @@ def handle(args: argparse.Namespace) -> None:
             out = legacy.merge(out, on="peptide", how="inner")
     elif args.format == "pmhc":
         out = aggregate_per_pmhc(hits)
+        if gene_ident_cols:
+            ids = hits[["peptide", *gene_ident_cols]].drop_duplicates(subset="peptide")
+            out = ids.merge(out, on="peptide", how="inner")
+        elif pep_df is not None:
+            legacy = pep_df[["peptide", "protein_id", "gene_name", "gene_id"]].drop_duplicates(
+                subset="peptide"
+            )
+            out = legacy.merge(out, on="peptide", how="inner")
+    elif args.format == "refs":
+        out = _aggregate_refs(hits)
         if gene_ident_cols:
             ids = hits[["peptide", *gene_ident_cols]].drop_duplicates(subset="peptide")
             out = ids.merge(out, on="peptide", how="inner")

--- a/tsarina/cli_hits.py
+++ b/tsarina/cli_hits.py
@@ -314,11 +314,14 @@ def _aggregate_refs(hits: pd.DataFrame) -> pd.DataFrame:
     Returns
     -------
     pd.DataFrame
-        One row per (peptide, mhc_restriction).  Columns:
-        ``peptide``, ``length``, ``mhc_restriction``, ``hit_count``,
-        ``ref_count``, ``pmids``, ``tissues``, ``diseases``,
+        One row per (peptide, mhc_restriction).  **Output columns depend on
+        which optional inputs were supplied:** only ``peptide``, ``length``,
+        ``mhc_restriction``, and ``hit_count`` are guaranteed.  The rest
+        (``ref_count``, ``pmids``, ``tissues``, ``diseases``,
         ``cell_lines``, ``in_cancer``, ``in_healthy_tissue``,
-        ``mono_allelic_hit_count``.
+        ``mono_allelic_hit_count``) appear only when the corresponding
+        input column was present.  The empty-frame path returns the full
+        canonical column list for downstream shape stability.
     """
     if hits.empty:
         return pd.DataFrame(
@@ -349,10 +352,22 @@ def _aggregate_refs(hits: pd.DataFrame) -> pd.DataFrame:
             {str(v).strip() for v in series.dropna() if str(v).strip() and str(v).lower() != "nan"}
         )
 
+    def _join_unique_numeric(series: pd.Series) -> str:
+        """Like ``_join_unique`` but sorts numerically — use for integer
+        identifiers like PMIDs so a 9-digit PMID doesn't land before an
+        8-digit one under lexicographic ordering."""
+        values: set[int] = set()
+        for v in series.dropna():
+            try:
+                values.add(int(v))
+            except (TypeError, ValueError):
+                continue
+        return ";".join(str(x) for x in sorted(values))
+
     agg_cols: dict[str, tuple] = {"hit_count": ("peptide", "size")}
     if "pmid" in hits.columns:
         agg_cols["ref_count"] = ("pmid", _count_unique)
-        agg_cols["pmids"] = ("pmid", _join_unique)
+        agg_cols["pmids"] = ("pmid", _join_unique_numeric)
     if "source_tissue" in hits.columns:
         agg_cols["tissues"] = ("source_tissue", _join_unique)
     if "disease" in hits.columns:

--- a/tsarina/version.py
+++ b/tsarina/version.py
@@ -10,4 +10,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.8.0"
+__version__ = "0.9.0"


### PR DESCRIPTION
## Context

While answering a real query ("find tumor-specific PRAME peptides on A24:02 or A24 serotype"), I hit a gap in the existing \`--format\` options:

- \`--format peptides\` has tissues + disease + cell_lines, but rolls up across alleles — you lose per-restriction detail.
- \`--format pmhc\` keeps the allele granularity but is lean (peptide, allele, hit_count, ref_count, PMIDs, mono-allelic counts) — no tissues, no cancer/healthy flags.

For therapy prioritization you want **both** — which allele(s) the peptide was seen on, AND which tissues / diseases / studies the evidence comes from.

## Summary

New \`--format refs\` aggregation. Groups by \`(peptide, mhc_restriction)\` and emits:

| column | content |
|---|---|
| \`peptide\`, \`length\`, \`mhc_restriction\` | identity |
| \`hit_count\` | total MS rows for this pMHC |
| \`ref_count\` | distinct PMIDs |
| \`pmids\` | semicolon-joined sorted PMIDs |
| \`tissues\` | semicolon-joined distinct \`source_tissue\` values |
| \`diseases\` | semicolon-joined distinct \`disease\` values |
| \`cell_lines\` | semicolon-joined distinct \`cell_line_name\` values |
| \`in_cancer\` | bool — any row with \`src_cancer=True\` |
| \`in_healthy_tissue\` | bool — any row with \`src_healthy_tissue=True\` |
| \`mono_allelic_hit_count\` | count of rows with direct mono-allelic evidence |

Implemented as \`tsarina.cli_hits._aggregate_refs\` — thin groupby over the raw scan columns. Optional columns absent from the input (e.g. on the cached-observations fast path vs the raw-CSV slow path) are silently skipped, so both code paths produce valid output.

## Live smoke test

\`\`\`
$ tsarina hits --gene PRAME --serotype A24 --format refs \\
    --iedb \$IEDB --cedar \$CEDAR -o /tmp/prame_a24_refs.csv
$ cat /tmp/prame_a24_refs.csv
peptide,...,mhc_restriction,hit_count,ref_count,pmids,tissues,diseases,...,in_cancer,in_healthy_tissue,mono_allelic_hit_count
LYVDSLFFL,...,HLA-A*24:02,1,1,33858848,Thymus,,...,False,False,0
QYIAQFTSQF,...,HLA-A*24:02,1,1,27869121,Lymph Node,skin melanoma,...,True,False,0
\`\`\`

## Test plan

- [x] 4 new tests in \`tests/test_cli_hits_refs.py\`:
  - per-pMHC aggregation with multi-ref peptide (PMIDs sorted, tissues joined, counts correct)
  - canonical empty-frame columns
  - skinny-input robustness (missing optional columns skipped, not crashed)
  - CLI \`_SUPPORTED_FORMATS\` registration
- [x] \`./format.sh\` clean
- [x] \`./lint.sh\` clean
- [x] \`./test.sh\` — 168 passed (was 164)
- [x] Live-tested against real IEDB+CEDAR CSVs for PRAME on A24 serotype