### PR TITLE
v0.10.0: drop local _aggregate_refs, route --format refs through hitlist

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
 ]
 requires-python = ">=3.9"
 dependencies = [
-    "hitlist>=1.10.0",
+    "hitlist>=1.12.1",
     "mhcgnomes>=3.20.0",
     "pandas",
     "numpy",

--- a/tests/test_cli_hits_refs.py
+++ b/tests/test_cli_hits_refs.py
@@ -10,151 +10,57 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Tests for the ``--format refs`` aggregation in ``tsarina hits``."""
+"""Tsarina-side tests for the ``--format refs`` path.
+
+The aggregation itself lives in hitlist 1.12.0+ as
+``hitlist.aggregate.aggregate_per_pmhc_with_refs`` and is tested there
+(``tests/test_aggregate.py``). These tests only cover the tsarina-side
+wiring: CLI format registration + end-to-end dispatch to the hitlist
+function with ``ms_pmhc_*`` columns surfaced through the handler.
+"""
 
 from __future__ import annotations
 
 import pandas as pd
+from hitlist.aggregate import aggregate_per_pmhc_with_refs
 
-from tsarina.cli_hits import _aggregate_refs
-
-
-def _scan_fixture() -> pd.DataFrame:
-    """Two peptides x one allele, with two references for peptide A and
-    mixed cancer / healthy-tissue provenance."""
-    return pd.DataFrame(
-        {
-            "peptide": [
-                "QYIAQFTSQF",
-                "QYIAQFTSQF",
-                "LYVDSLFFL",
-            ],
-            "mhc_restriction": [
-                "HLA-A*24:02",
-                "HLA-A*24:02",
-                "HLA-A*24:02",
-            ],
-            "pmid": [27869121, 38000001, 33858848],
-            "source_tissue": ["Lymph Node", "Skin", "Thymus"],
-            "disease": ["skin melanoma", "skin melanoma", ""],
-            "cell_line_name": ["", "", ""],
-            "src_cancer": [True, True, False],
-            "src_healthy_tissue": [False, False, False],
-            "src_healthy_thymus": [False, False, True],
-            "is_monoallelic": [False, True, False],
-        }
-    )
-
-
-def test_refs_aggregates_per_pmhc_with_counts_and_lists():
-    out = _aggregate_refs(_scan_fixture())
-    assert set(out.columns) >= {
-        "peptide",
-        "length",
-        "mhc_restriction",
-        "hit_count",
-        "ref_count",
-        "pmids",
-        "tissues",
-        "diseases",
-        "in_cancer",
-        "in_healthy_tissue",
-        "mono_allelic_hit_count",
-    }
-    assert len(out) == 2  # two distinct (peptide, allele) rows
-
-    q_row = out[out["peptide"] == "QYIAQFTSQF"].iloc[0]
-    assert int(q_row["length"]) == 10
-    assert int(q_row["hit_count"]) == 2
-    assert int(q_row["ref_count"]) == 2
-    # pmids are sorted strings; both PMIDs appear
-    assert q_row["pmids"] == "27869121;38000001"
-    assert q_row["tissues"] == "Lymph Node;Skin"
-    assert q_row["diseases"] == "skin melanoma"
-    assert bool(q_row["in_cancer"]) is True
-    assert bool(q_row["in_healthy_tissue"]) is False
-    assert int(q_row["mono_allelic_hit_count"]) == 1
-
-    l_row = out[out["peptide"] == "LYVDSLFFL"].iloc[0]
-    assert int(l_row["length"]) == 9
-    assert int(l_row["ref_count"]) == 1
-    assert l_row["pmids"] == "33858848"
-    assert l_row["tissues"] == "Thymus"
-    assert l_row["diseases"] == ""
-    assert bool(l_row["in_cancer"]) is False
-
-
-def test_refs_empty_input_returns_canonical_columns():
-    out = _aggregate_refs(pd.DataFrame(columns=["peptide", "mhc_restriction"]))
-    assert out.empty
-    assert list(out.columns) == [
-        "peptide",
-        "length",
-        "mhc_restriction",
-        "hit_count",
-        "ref_count",
-        "pmids",
-        "tissues",
-        "diseases",
-        "cell_lines",
-        "in_cancer",
-        "in_healthy_tissue",
-        "mono_allelic_hit_count",
-    ]
-
-
-def test_refs_missing_optional_columns_skips_them():
-    """Raw scan vs cached observations produce slightly different column
-    sets. The aggregator must silently skip any optional columns absent
-    from the input rather than crashing."""
-    skinny = pd.DataFrame(
-        {
-            "peptide": ["ABCDEFGHI", "ABCDEFGHI"],
-            "mhc_restriction": ["HLA-A*02:01", "HLA-A*02:01"],
-            # no pmid / source_tissue / src_cancer / is_monoallelic columns
-        }
-    )
-    out = _aggregate_refs(skinny)
-    assert len(out) == 1
-    assert int(out.iloc[0]["hit_count"]) == 2
-    # Optional columns that weren't supplied are absent from the output,
-    # not None / NaN artifacts.
-    assert "pmids" not in out.columns
-    assert "tissues" not in out.columns
-    assert "in_cancer" not in out.columns
+from tsarina.cli_hits import _SUPPORTED_FORMATS
 
 
 def test_refs_is_in_cli_format_choices():
-    from tsarina.cli_hits import _SUPPORTED_FORMATS
-
     assert "refs" in _SUPPORTED_FORMATS
 
 
-def test_refs_pmids_sorted_numerically_not_lexicographically():
-    """PMIDs are integers. Lexicographic sort would place a 9-digit PMID
-    before an 8-digit one (``"1000000000" < "999999999"`` as strings)."""
+def test_hitlist_aggregator_produces_ms_pmhc_prefixed_columns():
+    """Contract check against hitlist.aggregate.aggregate_per_pmhc_with_refs:
+    the output columns tsarina's --format refs path surfaces should carry
+    the ``ms_pmhc_*`` prefix.  If hitlist ever renames these, this test
+    catches it before the CLI output silently drifts."""
     hits = pd.DataFrame(
         {
-            "peptide": ["SAME9PEP"] * 3,
-            "mhc_restriction": ["HLA-A*02:01"] * 3,
-            "pmid": [999999999, 38000001, 1000000000],
+            "peptide": ["QYIAQFTSQF", "QYIAQFTSQF"],
+            "mhc_restriction": ["HLA-A*24:02", "HLA-A*24:02"],
+            "pmid": [27869121, 38000001],
+            "source_tissue": ["Lymph Node", "Skin"],
+            "src_cancer": [True, True],
+            "src_healthy_tissue": [False, False],
+            "is_monoallelic": [False, True],
         }
     )
-    out = _aggregate_refs(hits)
-    assert out.loc[0, "pmids"] == "38000001;999999999;1000000000"
-    assert int(out.loc[0, "ref_count"]) == 3
-
-
-def test_refs_in_healthy_tissue_true_when_any_row_flagged():
-    """Positive-case coverage for the ``in_healthy_tissue`` aggregation."""
-    hits = pd.DataFrame(
-        {
-            "peptide": ["RISKY9PEP", "RISKY9PEP"],
-            "mhc_restriction": ["HLA-A*02:01", "HLA-A*02:01"],
-            "src_cancer": [True, False],
-            "src_healthy_tissue": [False, True],
-        }
-    )
-    out = _aggregate_refs(hits)
-    assert bool(out.loc[0, "in_cancer"]) is True
-    assert bool(out.loc[0, "in_healthy_tissue"]) is True
+    out = aggregate_per_pmhc_with_refs(hits)
+    assert len(out) == 1
+    row = out.iloc[0]
+    # Core hitlist-contract columns the tsarina CLI depends on.
+    for col in (
+        "ms_pmhc_hit_count",
+        "ms_pmhc_ref_count",
+        "ms_pmhc_pmids",
+        "ms_pmhc_tissues",
+        "ms_pmhc_in_cancer",
+        "ms_pmhc_in_healthy_tissue",
+        "ms_pmhc_mono_hit_count",
+    ):
+        assert col in out.columns, f"hitlist aggregator changed — missing {col}"
+    assert row["ms_pmhc_pmids"] == "27869121;38000001"
+    assert bool(row["ms_pmhc_in_cancer"]) is True
+    assert int(row["ms_pmhc_mono_hit_count"]) == 1

--- a/tsarina/cli_hits.py
+++ b/tsarina/cli_hits.py
@@ -133,8 +133,10 @@ def build_parser(sub: argparse._SubParsersAction) -> argparse.ArgumentParser:
         default="pmhc",
         help=(
             "Output aggregation (default pmhc). 'refs' adds per-pMHC columns "
-            "for ref_count, pmids, tissues, diseases, cell_lines, and the "
-            "cancer / healthy-tissue source flags."
+            "for ms_pmhc_ref_count, ms_pmhc_pmids, ms_pmhc_tissues, "
+            "ms_pmhc_diseases, ms_pmhc_cell_lines, and the "
+            "ms_pmhc_in_cancer / ms_pmhc_in_healthy_tissue source flags. "
+            "Backed by hitlist.aggregate.aggregate_per_pmhc_with_refs."
         ),
     )
     p.add_argument(
@@ -292,100 +294,6 @@ def _filter_by_serotype(hits: pd.DataFrame, serotypes: list[str]) -> pd.DataFram
     return hits[hits["mhc_restriction"].map(_matches)].copy()
 
 
-def _aggregate_refs(hits: pd.DataFrame) -> pd.DataFrame:
-    """Per-(peptide, allele) aggregation focused on references + tissues.
-
-    Produces a leaner alternative to :func:`hitlist.aggregate_per_pmhc` that
-    exposes the provenance columns reviewers usually want on a pMHC row:
-    reference count, the actual PMID list, and the distinct tissues /
-    diseases / cell lines where the peptide was observed.  The
-    source-context booleans (``in_cancer`` / ``in_healthy_tissue``) are
-    preserved for quick filtering.
-
-    Parameters
-    ----------
-    hits
-        Raw scan / observations rows with at minimum ``peptide`` and
-        ``mhc_restriction`` columns.  Optional columns (``pmid``,
-        ``source_tissue``, ``disease``, ``cell_line_name``,
-        ``src_cancer``, ``src_healthy_tissue``, ``is_monoallelic``) are
-        used when present and silently skipped when absent.
-
-    Returns
-    -------
-    pd.DataFrame
-        One row per (peptide, mhc_restriction).  **Output columns depend on
-        which optional inputs were supplied:** only ``peptide``, ``length``,
-        ``mhc_restriction``, and ``hit_count`` are guaranteed.  The rest
-        (``ref_count``, ``pmids``, ``tissues``, ``diseases``,
-        ``cell_lines``, ``in_cancer``, ``in_healthy_tissue``,
-        ``mono_allelic_hit_count``) appear only when the corresponding
-        input column was present.  The empty-frame path returns the full
-        canonical column list for downstream shape stability.
-    """
-    if hits.empty:
-        return pd.DataFrame(
-            columns=[
-                "peptide",
-                "length",
-                "mhc_restriction",
-                "hit_count",
-                "ref_count",
-                "pmids",
-                "tissues",
-                "diseases",
-                "cell_lines",
-                "in_cancer",
-                "in_healthy_tissue",
-                "mono_allelic_hit_count",
-            ]
-        )
-
-    def _join_unique(series: pd.Series) -> str:
-        values = {
-            str(v).strip() for v in series.dropna() if str(v).strip() and str(v).lower() != "nan"
-        }
-        return ";".join(sorted(values))
-
-    def _count_unique(series: pd.Series) -> int:
-        return len(
-            {str(v).strip() for v in series.dropna() if str(v).strip() and str(v).lower() != "nan"}
-        )
-
-    def _join_unique_numeric(series: pd.Series) -> str:
-        """Like ``_join_unique`` but sorts numerically — use for integer
-        identifiers like PMIDs so a 9-digit PMID doesn't land before an
-        8-digit one under lexicographic ordering."""
-        values: set[int] = set()
-        for v in series.dropna():
-            try:
-                values.add(int(v))
-            except (TypeError, ValueError):
-                continue
-        return ";".join(str(x) for x in sorted(values))
-
-    agg_cols: dict[str, tuple] = {"hit_count": ("peptide", "size")}
-    if "pmid" in hits.columns:
-        agg_cols["ref_count"] = ("pmid", _count_unique)
-        agg_cols["pmids"] = ("pmid", _join_unique_numeric)
-    if "source_tissue" in hits.columns:
-        agg_cols["tissues"] = ("source_tissue", _join_unique)
-    if "disease" in hits.columns:
-        agg_cols["diseases"] = ("disease", _join_unique)
-    if "cell_line_name" in hits.columns:
-        agg_cols["cell_lines"] = ("cell_line_name", _join_unique)
-    if "src_cancer" in hits.columns:
-        agg_cols["in_cancer"] = ("src_cancer", "any")
-    if "src_healthy_tissue" in hits.columns:
-        agg_cols["in_healthy_tissue"] = ("src_healthy_tissue", "any")
-    if "is_monoallelic" in hits.columns:
-        agg_cols["mono_allelic_hit_count"] = ("is_monoallelic", "sum")
-
-    out = hits.groupby(["peptide", "mhc_restriction"], as_index=False).agg(**agg_cols)
-    out.insert(1, "length", out["peptide"].str.len())
-    return out
-
-
 def _apply_min_resolution(hits: pd.DataFrame, min_resolution: str | None) -> pd.DataFrame:
     if min_resolution is None or hits.empty:
         return hits
@@ -431,7 +339,11 @@ def handle(args: argparse.Namespace) -> None:
         return
 
     # ── 3. Load MS evidence ────────────────────────────────────────────
-    from hitlist.aggregate import aggregate_per_peptide, aggregate_per_pmhc
+    from hitlist.aggregate import (
+        aggregate_per_peptide,
+        aggregate_per_pmhc,
+        aggregate_per_pmhc_with_refs,
+    )
 
     if args.iedb_path is not None or args.cedar_path is not None:
         # Explicit raw-CSV override path — scan only, no observations index.
@@ -520,7 +432,7 @@ def handle(args: argparse.Namespace) -> None:
             )
             out = legacy.merge(out, on="peptide", how="inner")
     elif args.format == "refs":
-        out = _aggregate_refs(hits)
+        out = aggregate_per_pmhc_with_refs(hits)
         if gene_ident_cols:
             ids = hits[["peptide", *gene_ident_cols]].drop_duplicates(subset="peptide")
             out = ids.merge(out, on="peptide", how="inner")

--- a/tsarina/version.py
+++ b/tsarina/version.py
@@ -10,4 +10,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.9.0"
+__version__ = "0.10.0"


### PR DESCRIPTION
Closes #16.

## Context

tsarina v0.9.0 introduced \`_aggregate_refs\` in \`cli_hits.py\` as an interim per-pMHC aggregator with provenance. The aggregation is generic scan-frame logic; it belongs upstream. **hitlist 1.12.0** upstreamed an equivalent as \`hitlist.aggregate.aggregate_per_pmhc_with_refs\` (hitlist PR #91). **hitlist 1.12.1** (PR #92) also landed a required fix to \`classify_allele_resolution\` for \`Pair[Gene, Gene]\` strings — without it, \`hitlist data build\` crashes on current IEDB/CEDAR exports.

This PR retires tsarina's local copy and delegates entirely to hitlist.

## Changes

- **\`pyproject.toml\`** — \`hitlist>=1.10.0\` → \`hitlist>=1.12.1\`.
- **\`tsarina/cli_hits.py\`** — delete \`_aggregate_refs\` (~95 lines); import \`aggregate_per_pmhc_with_refs\` from \`hitlist.aggregate\` and dispatch to it on \`args.format == \"refs\"\`. \`--format\` help text updated.
- **\`tests/test_cli_hits_refs.py\`** — drop the 6 unit tests duplicating hitlist's own coverage (hitlist's \`tests/test_aggregate.py\` covers the same ground). Keep the CLI \`_SUPPORTED_FORMATS\` check and add a single contract test asserting hitlist's aggregator surfaces the \`ms_pmhc_*\` columns this CLI depends on. If hitlist ever renames these columns, the contract test fails before tsarina's CLI output silently drifts.
- Net −182 lines of aggregation code.

## Breaking change — column rename

| v0.9.0 | v0.10.0 |
|---|---|
| \`hit_count\` | \`ms_pmhc_hit_count\` |
| \`ref_count\` | \`ms_pmhc_ref_count\` |
| \`pmids\` | \`ms_pmhc_pmids\` |
| \`tissues\` | \`ms_pmhc_tissues\` |
| \`diseases\` | \`ms_pmhc_diseases\` |
| \`cell_lines\` | \`ms_pmhc_cell_lines\` |
| \`in_cancer\` | \`ms_pmhc_in_cancer\` |
| \`in_healthy_tissue\` | \`ms_pmhc_in_healthy_tissue\` |
| \`mono_allelic_hit_count\` | \`ms_pmhc_mono_hit_count\` |

Aligns tsarina with hitlist's existing \`ms_pmhc_*\` convention (see \`aggregate_per_pmhc\`). Minor version bump 0.9.0 → 0.10.0. The \`refs\` format shipped 4 days ago so stable consumers are unlikely.

## Live smoke test

\`\`\`
$ tsarina hits --gene PRAME --serotype A24 --format refs \\
    --iedb \$IEDB --cedar \$CEDAR -o /tmp/prame_a24_refs_v2.csv
$ cat /tmp/prame_a24_refs_v2.csv
peptide,...,ms_pmhc_hit_count,ms_pmhc_ref_count,ms_pmhc_pmids,ms_pmhc_tissues,ms_pmhc_diseases,ms_pmhc_cell_lines,ms_pmhc_in_cancer,ms_pmhc_in_healthy_tissue,ms_pmhc_mono_hit_count
LYVDSLFFL,...,1,1,33858848,Thymus,,,False,False,0
QYIAQFTSQF,...,1,1,27869121,Lymph Node,skin melanoma,,True,False,0
\`\`\`

Same rows as v0.9.0, new column names.

## Test plan

- [x] \`./format.sh\` clean
- [x] \`./lint.sh\` clean
- [x] \`./test.sh\` — 166 passed (was 170; lost the 4 behavior tests now redundantly covered by hitlist's \`tests/test_aggregate.py\`)
- [x] Live-tested against real IEDB+CEDAR for PRAME / A24 — column names match hitlist output 1:1, row counts and values unchanged