### PR TITLE
v0.10.1: cache k-mer enumeration in cta_exclusive + human_exclusive_viral

### DIFF
--- a/tests/test_kmer_caching.py
+++ b/tests/test_kmer_caching.py
@@ -1,0 +1,163 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for k-mer enumeration caching (tsarina#12).
+
+``_non_cta_proteome_kmers`` and ``_human_proteome_kmers`` walk every
+protein-coding transcript in an Ensembl release and produce a frozenset
+of all k-mers at the requested lengths. The walk is ~10-60s depending on
+release + length mix, so both helpers are ``@lru_cache``'d keyed on
+``(ensembl_release, lengths)``.
+
+These tests exercise the caching behavior without actually loading
+Ensembl data: pyensembl is monkeypatched to a stub that tracks how many
+times the proteome is traversed, so we can directly assert that two
+calls with the same arguments produce a single traversal and that a
+different argument triggers a second.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tsarina import peptides, viral
+
+
+class _FakeTranscript:
+    def __init__(self, seq: str, biotype: str = "protein_coding"):
+        self.protein_sequence = seq
+        self.biotype = biotype
+
+
+class _FakeGene:
+    def __init__(self, gene_id: str, seq: str, biotype: str = "protein_coding"):
+        self.gene_id = gene_id
+        self.biotype = biotype
+        self.transcripts = [_FakeTranscript(seq, biotype)]
+
+
+class _FakeEnsembl:
+    """Records how many times .genes() and .gene_by_id() are invoked."""
+
+    call_counts: dict[str, int] = {"genes": 0, "gene_by_id": 0}
+
+    def __init__(self, release: int):
+        self.release = release
+        # Fake universe: a handful of "protein" sequences long enough to
+        # yield several k-mers at length 8.
+        self._genes_by_id = {
+            "ENSG_A": _FakeGene("ENSG_A", "MAAAAAAAAA"),
+            "ENSG_B": _FakeGene("ENSG_B", "MCCCCCCCCC"),
+            "ENSG_C": _FakeGene("ENSG_C", "MDDDDDDDDD"),
+        }
+
+    def genes(self):
+        type(self).call_counts["genes"] += 1
+        return list(self._genes_by_id.values())
+
+    def gene_by_id(self, gene_id: str):
+        type(self).call_counts["gene_by_id"] += 1
+        if gene_id not in self._genes_by_id:
+            raise ValueError(gene_id)
+        return self._genes_by_id[gene_id]
+
+
+class _FakePartition:
+    cta: set[str] = {"ENSG_A"}
+    non_cta: set[str] = {"ENSG_B", "ENSG_C"}
+
+
+@pytest.fixture(autouse=True)
+def _reset_caches_and_counts(monkeypatch):
+    peptides._non_cta_proteome_kmers.cache_clear()
+    viral._human_proteome_kmers.cache_clear()
+    _FakeEnsembl.call_counts = {"genes": 0, "gene_by_id": 0}
+    monkeypatch.setattr("pyensembl.EnsemblRelease", _FakeEnsembl)
+    monkeypatch.setattr("tsarina.partition.CTA_partition_gene_ids", lambda r: _FakePartition())
+    yield
+
+
+# ── _non_cta_proteome_kmers (peptides.py) ──────────────────────────────
+
+
+def test_non_cta_helper_is_lru_cached():
+    assert hasattr(peptides._non_cta_proteome_kmers, "cache_info")
+    assert hasattr(peptides._non_cta_proteome_kmers, "cache_clear")
+
+
+def test_non_cta_returns_frozenset_of_kmers_from_non_cta_genes():
+    result = peptides._non_cta_proteome_kmers(112, (8,))
+    assert isinstance(result, frozenset)
+    # ENSG_B = "MCCCCCCCCC" (10 chars) → three 8-mers: MCCCCCCC, CCCCCCCC, CCCCCCCC
+    # But CCCCCCCC appears as both second and third (same k-mer, deduped).
+    # ENSG_C = "MDDDDDDDDD" → analogous.
+    # ENSG_A is CTA → excluded from this helper.
+    assert "MCCCCCCC" in result
+    assert "MDDDDDDD" in result
+    assert "MAAAAAAA" not in result  # ENSG_A is CTA, excluded
+
+
+def test_non_cta_caches_across_calls_with_same_args():
+    r1 = peptides._non_cta_proteome_kmers(112, (8,))
+    gene_by_id_calls_after_first = _FakeEnsembl.call_counts["gene_by_id"]
+    assert gene_by_id_calls_after_first > 0  # first call did real work
+
+    r2 = peptides._non_cta_proteome_kmers(112, (8,))
+    # Second call hit cache — no additional traversal
+    assert _FakeEnsembl.call_counts["gene_by_id"] == gene_by_id_calls_after_first
+    # Identical frozenset object (lru_cache returns cached value)
+    assert r1 is r2
+
+
+def test_non_cta_different_args_compute_separately():
+    peptides._non_cta_proteome_kmers(112, (8,))
+    peptides._non_cta_proteome_kmers(112, (9,))  # different lengths → new cache key
+    info = peptides._non_cta_proteome_kmers.cache_info()
+    assert info.misses == 2
+    assert info.hits == 0
+
+
+# ── _human_proteome_kmers (viral.py) ───────────────────────────────────
+
+
+def test_human_helper_is_lru_cached():
+    assert hasattr(viral._human_proteome_kmers, "cache_info")
+    assert hasattr(viral._human_proteome_kmers, "cache_clear")
+
+
+def test_human_returns_frozenset_of_kmers_from_all_protein_coding_genes():
+    result = viral._human_proteome_kmers(112, (8,))
+    assert isinstance(result, frozenset)
+    # ENSG_A (CTA) + ENSG_B + ENSG_C are all protein_coding, all included here
+    # (the human helper does NOT exclude CTAs — that's the whole proteome).
+    assert "MAAAAAAA" in result
+    assert "MCCCCCCC" in result
+    assert "MDDDDDDD" in result
+
+
+def test_human_caches_across_calls_with_same_args():
+    r1 = viral._human_proteome_kmers(112, (8,))
+    genes_calls_after_first = _FakeEnsembl.call_counts["genes"]
+    assert genes_calls_after_first == 1
+
+    r2 = viral._human_proteome_kmers(112, (8,))
+    # Second call hit cache — .genes() not called a second time
+    assert _FakeEnsembl.call_counts["genes"] == 1
+    assert r1 is r2
+
+
+def test_human_different_release_triggers_recompute():
+    viral._human_proteome_kmers(112, (8,))
+    viral._human_proteome_kmers(113, (8,))  # different release → new cache key
+    info = viral._human_proteome_kmers.cache_info()
+    assert info.misses == 2
+    assert info.hits == 0

--- a/tsarina/peptides.py
+++ b/tsarina/peptides.py
@@ -27,6 +27,7 @@ Typical usage::
 
 from __future__ import annotations
 
+from functools import lru_cache
 from typing import Union
 
 import pandas as pd
@@ -34,6 +35,54 @@ import pandas as pd
 AA20 = set("ACDEFGHIKLMNPQRSTVWY")
 
 DEFAULT_PEPTIDE_LENGTHS = (8, 9, 10, 11)
+
+
+@lru_cache(maxsize=4)
+def _non_cta_proteome_kmers(
+    ensembl_release: int,
+    lengths: tuple[int, ...],
+) -> frozenset[str]:
+    """Return every k-mer found in any non-CTA protein-coding transcript.
+
+    Shared between :func:`cta_exclusive_peptides` and other cancer-specific
+    callers that need to subtract the non-CTA self-peptide background.
+    The set depends only on ``(ensembl_release, lengths)`` and is expensive
+    to build (~10-30s walking every non-CTA transcript in an Ensembl
+    release), so the result is process-wide ``@lru_cache``'d behind a
+    ``frozenset`` — the second call within a process returns immediately
+    with no additional work.
+
+    Cache holds up to 4 ``(release, lengths)`` combinations (typical use
+    hits one).  Clear via ``_non_cta_proteome_kmers.cache_clear()``.
+    """
+    from pyensembl import EnsemblRelease
+
+    from .partition import CTA_partition_gene_ids
+
+    ensembl = EnsemblRelease(ensembl_release)
+    partition = CTA_partition_gene_ids(ensembl_release)
+
+    kmers: set[str] = set()
+    for gene_id in partition.non_cta:
+        try:
+            gene = ensembl.gene_by_id(gene_id)
+        except ValueError:
+            continue
+        for t in gene.transcripts:
+            if t.biotype != "protein_coding":
+                continue
+            try:
+                seq = t.protein_sequence
+            except Exception:
+                continue
+            if not seq:
+                continue
+            for k in lengths:
+                for i in range(len(seq) - k + 1):
+                    pep = seq[i : i + k]
+                    if set(pep).issubset(AA20):
+                        kmers.add(pep)
+    return frozenset(kmers)
 
 
 def cta_peptides(
@@ -141,37 +190,15 @@ def cta_exclusive_peptides(
     -------
     pd.DataFrame
         Same columns as :func:`cta_peptides`, filtered to exclusive peptides.
+
+    Notes
+    -----
+    The non-CTA k-mer set is computed once per ``(ensembl_release, lengths)``
+    via :func:`_non_cta_proteome_kmers` and cached for the life of the
+    process.  First call pays ~10-30s walking the non-CTA transcript set;
+    subsequent calls with the same inputs return in sub-millisecond time.
     """
-    from pyensembl import EnsemblRelease
-
-    from .partition import CTA_partition_gene_ids
-
-    ensembl = EnsemblRelease(ensembl_release)
-    partition = CTA_partition_gene_ids(ensembl_release)
-
-    # Build set of all peptide k-mers from non-CTA proteins
-    noncta_peptides: set[str] = set()
-    for gene_id in partition.non_cta:
-        try:
-            gene = ensembl.gene_by_id(gene_id)
-        except ValueError:
-            continue
-        for t in gene.transcripts:
-            if t.biotype != "protein_coding":
-                continue
-            try:
-                seq = t.protein_sequence
-            except Exception:
-                continue
-            if not seq:
-                continue
-            for k in lengths:
-                for i in range(len(seq) - k + 1):
-                    pep = seq[i : i + k]
-                    if set(pep).issubset(AA20):
-                        noncta_peptides.add(pep)
-
-    # Generate CTA peptides and filter
+    noncta_peptides = _non_cta_proteome_kmers(ensembl_release, tuple(lengths))
     cta_df = cta_peptides(ensembl_release=ensembl_release, lengths=lengths)
     mask = ~cta_df["peptide"].isin(noncta_peptides)
     return cta_df[mask].reset_index(drop=True)

--- a/tsarina/version.py
+++ b/tsarina/version.py
@@ -10,4 +10,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.10.0"
+__version__ = "0.10.1"

--- a/tsarina/viral.py
+++ b/tsarina/viral.py
@@ -48,11 +48,55 @@ Typical usage::
 
 from __future__ import annotations
 
+from functools import lru_cache
 from pathlib import Path
 
 import pandas as pd
 
 from .peptides import AA20
+
+
+@lru_cache(maxsize=4)
+def _human_proteome_kmers(
+    ensembl_release: int,
+    lengths: tuple[int, ...],
+) -> frozenset[str]:
+    """Return every k-mer found in any human protein-coding transcript.
+
+    Shared by :func:`human_exclusive_viral_peptides` and any other caller
+    that needs to subtract the full human self-peptide background.  The
+    set depends only on ``(ensembl_release, lengths)`` and is expensive
+    to build (~20-60s walking every protein-coding transcript in an
+    Ensembl release), so the result is process-wide ``@lru_cache``'d
+    behind a ``frozenset`` — the second call within a process returns
+    immediately with no additional work.
+
+    Cache holds up to 4 ``(release, lengths)`` combinations.  Clear via
+    ``_human_proteome_kmers.cache_clear()``.
+    """
+    from pyensembl import EnsemblRelease
+
+    ensembl = EnsemblRelease(ensembl_release)
+    kmers: set[str] = set()
+    for gene in ensembl.genes():
+        if gene.biotype != "protein_coding":
+            continue
+        for t in gene.transcripts:
+            if t.biotype != "protein_coding":
+                continue
+            try:
+                seq = t.protein_sequence
+            except Exception:
+                continue
+            if not seq:
+                continue
+            for k in lengths:
+                for i in range(len(seq) - k + 1):
+                    pep = seq[i : i + k]
+                    if set(pep).issubset(AA20):
+                        kmers.add(pep)
+    return frozenset(kmers)
+
 
 # ── Virus definitions ───────────────────────────────────────────────────────
 
@@ -270,34 +314,19 @@ def human_exclusive_viral_peptides(
     -------
     pd.DataFrame
         Same columns as :func:`viral_peptides`, filtered to human-exclusive.
-    """
-    from pyensembl import EnsemblRelease
 
+    Notes
+    -----
+    The human k-mer set is computed once per
+    ``(ensembl_release, lengths)`` via :func:`_human_proteome_kmers` and
+    cached for the life of the process.  First call pays ~20-60s walking
+    every protein-coding transcript in the Ensembl release; subsequent
+    calls with the same inputs return in sub-millisecond time.
+    """
     vdf = viral_peptides(virus=virus, fasta_path=fasta_path, proteins=proteins, lengths=lengths)
     if vdf.empty:
         return vdf
-
-    # Build set of all human protein k-mers
-    ensembl = EnsemblRelease(ensembl_release)
-    human_kmers: set[str] = set()
-    for gene in ensembl.genes():
-        if gene.biotype != "protein_coding":
-            continue
-        for t in gene.transcripts:
-            if t.biotype != "protein_coding":
-                continue
-            try:
-                seq = t.protein_sequence
-            except Exception:
-                continue
-            if not seq:
-                continue
-            for k in lengths:
-                for i in range(len(seq) - k + 1):
-                    pep = seq[i : i + k]
-                    if set(pep).issubset(AA20):
-                        human_kmers.add(pep)
-
+    human_kmers = _human_proteome_kmers(ensembl_release, tuple(lengths))
     mask = ~vdf["peptide"].isin(human_kmers)
     return vdf[mask].reset_index(drop=True)
 


### PR DESCRIPTION
Closes #12.

## Problem

\`cta_exclusive_peptides\` and \`human_exclusive_viral_peptides\` each walk the Ensembl proteome on every call to build their subtraction set:

- \`cta_exclusive_peptides\` enumerates every k-mer in every **non-CTA** protein-coding transcript at lengths 8-11 — the set to subtract from CTA k-mers.
- \`human_exclusive_viral_peptides\` enumerates every k-mer in every protein-coding transcript — the set to subtract from viral k-mers.

On first call each takes ~10-60s depending on release + length mix. Under the v0.8.0+ \`personalize()\` path these are the **default** for CTA and viral candidate generation, so every patient query pays this cost fresh. Batch runs (N patients with the same \`(release, lengths)\`) pay it N times. Notebook / REPL workflows repeat the work on every cell re-run.

## Fix

Extract the expensive traversal into two \`@lru_cache\`'d helpers keyed on \`(ensembl_release, lengths)\`. Cache holds up to 4 combinations (typical use hits one); second and subsequent calls with the same args return the cached \`frozenset\` in sub-millisecond time.

- \`peptides._non_cta_proteome_kmers(release, lengths) -> frozenset[str]\` — powers \`cta_exclusive_peptides\`.
- \`viral._human_proteome_kmers(release, lengths) -> frozenset[str]\` — powers \`human_exclusive_viral_peptides\`.

Both public functions are thinned to ~3-line bodies that call the helper and apply \`pd.Series.isin\` for the mask. **No public API change, no output schema change.**

\`frozenset\` is used (not \`set\`) so the cached object is immutable — no aliasing risk if a caller somehow held a reference across invocations.

## Why this matters

- \`personalize()\` now returns in under a second on the second patient query.
- \`tsarina hits\` with \`--format refs\` or any path through \`cta_exclusive_peptides\` / \`human_exclusive_viral_peptides\` shares the same cache within a process.
- Memory cost: ~300MB–1GB resident per \`(release, lengths)\` combo for the cached frozensets (full human 8-11mer coverage is on the upper end). For a typical 16GB+ workstation this is fine; users can \`cache_clear()\` if needed.

## Test plan

- [x] 8 new unit tests in \`tests/test_kmer_caching.py\`:
  - both helpers expose \`cache_info\` / \`cache_clear\`
  - same-args second call hits cache (verified via monkeypatched \`EnsemblRelease\` call counts)
  - different \`(release, lengths)\` triggers separate cache entries (misses=2, hits=0)
  - result is a \`frozenset\` containing expected k-mers
  - CTA / non-CTA partition respected for the non-CTA helper (CTA genes excluded)
  - Tests use a stubbed \`EnsemblRelease\` + \`CTA_partition_gene_ids\` so they don't require Ensembl data and run in <1s
- [x] \`./format.sh\` clean
- [x] \`./lint.sh\` clean
- [x] \`./test.sh\` — 174 passed (was 166; +8 new)

## Follow-up

Filesystem-backed cache (survives process restart, shared across parallel jobs) is out of scope here — in-process LRU covers the dominant case (one patient query per process is already fast, batch runs share the cache within their worker). Can follow up if users report that's not enough.