### PR TITLE
v0.11.0: tsarina spanning — population-spanning CTA x HLA pMHC table

### DIFF
--- a/tests/test_spanning.py
+++ b/tests/test_spanning.py
@@ -1,0 +1,331 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for ``tsarina.spanning.spanning_pmhc_set``.
+
+The library function pulls peptides through ``cta_exclusive_peptides``,
+scores them via ``score_presentation``, and pivots the best result per
+(CTA, allele) cell. Tests stub each of those upstream calls so they run
+without Ensembl / mhcflurry installed.
+"""
+
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+from tsarina.spanning import spanning_pmhc_set
+
+
+def _stub_peptides() -> pd.DataFrame:
+    """Three CTAs, two peptides each at length 9."""
+    return pd.DataFrame(
+        {
+            "peptide": [
+                "MAGEAPEP1",
+                "MAGEAPEP2",
+                "PRAMEPEP1",
+                "PRAMEPEP2",
+                "NYESPEPT1",
+                "NYESPEPT2",
+            ],
+            "length": [9, 9, 9, 9, 9, 9],
+            "gene_name": ["MAGEA4", "MAGEA4", "PRAME", "PRAME", "CTAG1B", "CTAG1B"],
+            "gene_id": ["E1", "E1", "E2", "E2", "E3", "E3"],
+        }
+    )
+
+
+def _stub_scores(peptides, alleles, **kwargs) -> pd.DataFrame:
+    """Score every (peptide, allele) pair with deterministic percentiles
+    derived from the peptide and allele strings — lets tests assert which
+    peptide should win each cell."""
+    rows = []
+    for pep in peptides:
+        for allele in alleles:
+            # Lowest percentile = most-presented; PEP1 always beats PEP2
+            # for the same gene; A*02:01 beats A*24:02 for all peptides.
+            base = 0.1 if pep.endswith("1") else 1.5
+            allele_bump = 0.0 if allele == "HLA-A*02:01" else 0.5
+            rows.append(
+                {
+                    "peptide": pep,
+                    "allele": allele,
+                    "presentation_percentile": base + allele_bump,
+                    "presentation_score": 0.95 - (base + allele_bump) / 10,
+                    "affinity_nm": 50.0 + (base + allele_bump) * 100,
+                }
+            )
+    return pd.DataFrame(rows)
+
+
+@pytest.fixture(autouse=True)
+def _stub_pipeline(monkeypatch):
+    """Wire stubs for every upstream call spanning_pmhc_set makes."""
+    monkeypatch.setattr(
+        "tsarina.peptides.cta_exclusive_peptides",
+        lambda **kw: _stub_peptides(),
+        raising=True,
+    )
+    monkeypatch.setattr(
+        "tsarina.peptides.cta_peptides",
+        lambda **kw: _stub_peptides(),
+        raising=True,
+    )
+    monkeypatch.setattr(
+        "tsarina.scoring.score_presentation",
+        _stub_scores,
+        raising=True,
+    )
+    monkeypatch.setattr(
+        "tsarina.gene_sets.CTA_gene_names",
+        lambda: {"MAGEA4", "PRAME", "CTAG1B", "BAGE"},
+        raising=True,
+    )
+    # Stub the bundled CTA dataframe so cta_count / rank_by paths work.
+    cta_csv = pd.DataFrame(
+        {
+            "Symbol": ["MAGEA4", "PRAME", "CTAG1B", "BAGE"],
+            "Ensembl_Gene_ID": ["E1", "E2", "E3", "E4"],
+            "filtered": ["true", "true", "true", "true"],
+            "never_expressed": ["false", "false", "false", "true"],
+            "restriction_confidence": ["HIGH", "HIGH", "MODERATE", "LOW"],
+            "restriction": ["TESTIS", "TESTIS", "PLACENTAL", "TESTIS"],
+            "ms_cancer_peptide_count": [50, 30, 10, 0],
+        }
+    )
+    monkeypatch.setattr("tsarina.loader.cta_dataframe", lambda: cta_csv, raising=True)
+
+
+# ── CTA selection ──────────────────────────────────────────────────────
+
+
+def test_top_n_ranking_by_default_column():
+    """Top 2 by ms_cancer_peptide_count: MAGEA4 (50), PRAME (30).
+    CTAG1B (10) excluded by N=2 cap. BAGE (0) excluded as never_expressed."""
+    df = spanning_pmhc_set(
+        cta_count=2,
+        alleles=["HLA-A*02:01"],
+        max_percentile=10.0,
+    )
+    assert list(df["cta"]) == ["MAGEA4", "PRAME"]
+
+
+def test_explicit_ctas_overrides_ranking():
+    """When --ctas is supplied, --cta-count is ignored and the order is
+    preserved (capped only by membership in CTA_gene_names())."""
+    df = spanning_pmhc_set(
+        ctas=["CTAG1B", "PRAME"],
+        alleles=["HLA-A*02:01"],
+        max_percentile=10.0,
+    )
+    assert list(df["cta"]) == ["CTAG1B", "PRAME"]
+
+
+def test_min_restriction_confidence_filters_low():
+    """LOW-confidence CTAs (BAGE) drop out of ranking when the gate is
+    HIGH/MODERATE."""
+    df = spanning_pmhc_set(
+        cta_count=10,
+        min_restriction_confidence=("HIGH", "MODERATE"),
+        alleles=["HLA-A*02:01"],
+        max_percentile=10.0,
+    )
+    assert "BAGE" not in df["cta"].tolist()
+
+
+def test_min_restriction_confidence_none_admits_low():
+    """Disabling the confidence gate would let BAGE through — but BAGE is
+    also excluded by never_expressed=True. Use a fixture variant via
+    explicit ctas to demonstrate the bypass."""
+    df = spanning_pmhc_set(
+        cta_count=10,
+        min_restriction_confidence=None,
+        alleles=["HLA-A*02:01"],
+        max_percentile=10.0,
+    )
+    # Three remain after never_expressed filter; LOW-confidence BAGE excluded.
+    assert set(df["cta"]) == {"MAGEA4", "PRAME", "CTAG1B"}
+
+
+def test_restriction_levels_filter():
+    """restriction_levels=('PLACENTAL',) keeps only CTAG1B."""
+    df = spanning_pmhc_set(
+        cta_count=10,
+        restriction_levels=("PLACENTAL",),
+        alleles=["HLA-A*02:01"],
+        max_percentile=10.0,
+    )
+    assert list(df["cta"]) == ["CTAG1B"]
+
+
+# ── Allele resolution ──────────────────────────────────────────────────
+
+
+def test_panel_default_resolves_via_get_panel():
+    """Default panel='iedb27_ab' should produce a 27-column wide table
+    plus the 'cta' index column = 28 cols."""
+    df = spanning_pmhc_set(
+        cta_count=2,
+        max_percentile=10.0,
+    )
+    assert df.shape[1] == 28  # 1 cta + 27 alleles
+
+
+def test_explicit_alleles_override_panel():
+    df = spanning_pmhc_set(
+        cta_count=2,
+        alleles=["HLA-A*02:01", "HLA-A*24:02"],
+        max_percentile=10.0,
+    )
+    assert list(df.columns) == ["cta", "HLA-A*02:01", "HLA-A*24:02"]
+
+
+def test_no_alleles_no_panel_raises():
+    with pytest.raises(ValueError, match="alleles or panel"):
+        spanning_pmhc_set(panel=None, alleles=None)
+
+
+# ── Best-per-cell selection ────────────────────────────────────────────
+
+
+def test_lowest_percentile_peptide_wins_each_cell():
+    """Stub gives PEP1 = 0.1, PEP2 = 1.5 baseline. Both pass max=2.0;
+    PEP1 should win every cell."""
+    df = spanning_pmhc_set(
+        ctas=["MAGEA4", "PRAME"],
+        alleles=["HLA-A*02:01"],
+        max_percentile=2.0,
+    )
+    assert df.set_index("cta").loc["MAGEA4", "HLA-A*02:01"] == "MAGEAPEP1"
+    assert df.set_index("cta").loc["PRAME", "HLA-A*02:01"] == "PRAMEPEP1"
+
+
+def test_max_percentile_filters_weak_cells():
+    """Stub: A*24:02 percentiles are 0.6 (PEP1) and 2.0 (PEP2). A cutoff
+    of 0.5 leaves every A*24:02 cell empty; A*02:01 cells (0.1) survive."""
+    df = spanning_pmhc_set(
+        ctas=["MAGEA4", "PRAME"],
+        alleles=["HLA-A*02:01", "HLA-A*24:02"],
+        max_percentile=0.5,
+    )
+    indexed = df.set_index("cta")
+    assert indexed.loc["MAGEA4", "HLA-A*02:01"] == "MAGEAPEP1"
+    assert pd.isna(indexed.loc["MAGEA4", "HLA-A*24:02"])
+
+
+# ── Output formats ─────────────────────────────────────────────────────
+
+
+def test_long_format_has_one_row_per_filled_cell():
+    long = spanning_pmhc_set(
+        ctas=["MAGEA4", "PRAME"],
+        alleles=["HLA-A*02:01", "HLA-A*24:02"],
+        max_percentile=2.0,
+        output_format="long",
+    )
+    # 2 CTAs * 2 alleles = 4 cells, all pass with max=2.0
+    assert len(long) == 4
+    assert set(long.columns) == {
+        "cta",
+        "allele",
+        "peptide",
+        "length",
+        "presentation_percentile",
+        "presentation_score",
+        "affinity_nm",
+    }
+    # Sorted by cta then allele in the supplied order
+    assert list(long["cta"]) == ["MAGEA4", "MAGEA4", "PRAME", "PRAME"]
+
+
+def test_long_format_drops_filtered_cells_entirely():
+    """In long output, cells above max_percentile are absent (not NaN)."""
+    long = spanning_pmhc_set(
+        ctas=["MAGEA4"],
+        alleles=["HLA-A*02:01", "HLA-A*24:02"],
+        max_percentile=0.5,
+        output_format="long",
+    )
+    assert len(long) == 1
+    assert long.iloc[0]["allele"] == "HLA-A*02:01"
+
+
+def test_unrecognized_output_format_raises():
+    with pytest.raises(ValueError, match="output_format"):
+        spanning_pmhc_set(output_format="grid")
+
+
+# ── Edge cases ─────────────────────────────────────────────────────────
+
+
+def test_no_ctas_pass_filter_returns_canonical_empty_frame():
+    """If filters eliminate every CTA, we still return a well-formed
+    (empty) wide table with the requested allele columns."""
+    df = spanning_pmhc_set(
+        ctas=[],
+        alleles=["HLA-A*02:01"],
+        max_percentile=2.0,
+    )
+    assert list(df.columns) == ["cta", "HLA-A*02:01"]
+    assert df.empty
+
+
+def test_size_within_target_envelope_for_default_args():
+    """The headline use case: defaults (25 CTAs x 27 alleles, max 2%)
+    should produce a wide table whose count of filled cells is in the
+    100-1000 spanning-set range. Stub gives exactly 25*27=675 candidate
+    cells; with the stub's 0.1 / 1.5 percentile baselines, every cell
+    passes the 2.0 cutoff, so all 675 are filled — comfortably in range.
+    """
+    # Expand the stub CTA pool so cta_count=25 has enough candidates.
+    extra_genes = [f"GENE{i:03d}" for i in range(25)]
+    extra_peps = pd.DataFrame(
+        {
+            "peptide": [f"PEPGENE{i:03d}" for i in range(25)],
+            "length": [9] * 25,
+            "gene_name": extra_genes,
+            "gene_id": [f"E{i + 10}" for i in range(25)],
+        }
+    )
+
+    import tsarina.peptides
+
+    tsarina.peptides.cta_exclusive_peptides = lambda **kw: pd.concat(
+        [_stub_peptides(), extra_peps], ignore_index=True
+    )
+
+    all_genes = ["MAGEA4", "PRAME", "CTAG1B", *extra_genes]
+    cta_csv = pd.DataFrame(
+        {
+            "Symbol": all_genes,
+            "Ensembl_Gene_ID": [f"E{i}" for i in range(28)],
+            "filtered": ["true"] * 28,
+            "never_expressed": ["false"] * 28,
+            "restriction_confidence": ["HIGH"] * 28,
+            "restriction": ["TESTIS"] * 28,
+            "ms_cancer_peptide_count": list(range(28, 0, -1)),
+        }
+    )
+    import tsarina.gene_sets
+    import tsarina.loader
+
+    tsarina.loader.cta_dataframe = lambda: cta_csv
+    tsarina.gene_sets.CTA_gene_names = lambda: set(all_genes)
+
+    df = spanning_pmhc_set(
+        cta_count=25,
+        panel="iedb27_ab",
+        max_percentile=2.0,
+        output_format="long",
+    )
+    assert 100 < len(df) <= 1000

--- a/tests/test_spanning.py
+++ b/tests/test_spanning.py
@@ -280,12 +280,16 @@ def test_no_ctas_pass_filter_returns_canonical_empty_frame():
     assert df.empty
 
 
-def test_size_within_target_envelope_for_default_args():
+def test_size_within_target_envelope_for_default_args(monkeypatch):
     """The headline use case: defaults (25 CTAs x 27 alleles, max 2%)
     should produce a wide table whose count of filled cells is in the
     100-1000 spanning-set range. Stub gives exactly 25*27=675 candidate
     cells; with the stub's 0.1 / 1.5 percentile baselines, every cell
     passes the 2.0 cutoff, so all 675 are filled — comfortably in range.
+
+    Uses ``monkeypatch.setattr`` (not raw attribute assignment) so the
+    expanded stubs are torn down after this test and don't leak into the
+    rest of the test session.
     """
     # Expand the stub CTA pool so cta_count=25 has enough candidates.
     extra_genes = [f"GENE{i:03d}" for i in range(25)]
@@ -297,13 +301,6 @@ def test_size_within_target_envelope_for_default_args():
             "gene_id": [f"E{i + 10}" for i in range(25)],
         }
     )
-
-    import tsarina.peptides
-
-    tsarina.peptides.cta_exclusive_peptides = lambda **kw: pd.concat(
-        [_stub_peptides(), extra_peps], ignore_index=True
-    )
-
     all_genes = ["MAGEA4", "PRAME", "CTAG1B", *extra_genes]
     cta_csv = pd.DataFrame(
         {
@@ -316,11 +313,14 @@ def test_size_within_target_envelope_for_default_args():
             "ms_cancer_peptide_count": list(range(28, 0, -1)),
         }
     )
-    import tsarina.gene_sets
-    import tsarina.loader
 
-    tsarina.loader.cta_dataframe = lambda: cta_csv
-    tsarina.gene_sets.CTA_gene_names = lambda: set(all_genes)
+    monkeypatch.setattr(
+        "tsarina.peptides.cta_exclusive_peptides",
+        lambda **kw: pd.concat([_stub_peptides(), extra_peps], ignore_index=True),
+        raising=True,
+    )
+    monkeypatch.setattr("tsarina.loader.cta_dataframe", lambda: cta_csv, raising=True)
+    monkeypatch.setattr("tsarina.gene_sets.CTA_gene_names", lambda: set(all_genes), raising=True)
 
     df = spanning_pmhc_set(
         cta_count=25,

--- a/tsarina/cli.py
+++ b/tsarina/cli.py
@@ -173,7 +173,7 @@ def _handle_data(args: argparse.Namespace) -> None:
 
 
 def main() -> None:
-    from . import cli_hits, cli_personalize
+    from . import cli_hits, cli_personalize, cli_spanning
 
     parser = argparse.ArgumentParser(
         prog="tsarina",
@@ -184,6 +184,7 @@ def main() -> None:
     _build_data_parser(sub)
     cli_personalize.build_parser(sub)
     cli_hits.build_parser(sub)
+    cli_spanning.build_parser(sub)
 
     args = parser.parse_args()
     if args.command is None:
@@ -196,6 +197,8 @@ def main() -> None:
         cli_personalize.handle(args)
     elif args.command == "hits":
         cli_hits.handle(args)
+    elif args.command == "spanning":
+        cli_spanning.handle(args)
 
 
 if __name__ == "__main__":

--- a/tsarina/cli_spanning.py
+++ b/tsarina/cli_spanning.py
@@ -1,0 +1,190 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""``tsarina spanning`` CLI — population-spanning CTA x HLA pMHC table.
+
+Wraps :func:`tsarina.spanning.spanning_pmhc_set` with argparse.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+
+_SUPPORTED_PREDICTORS = ("mhcflurry", "netmhcpan", "netmhcpan_el")
+_SUPPORTED_FORMATS = ("wide", "long")
+_SUPPORTED_PANELS = (
+    "iedb27_ab",
+    "iedb36_abc",
+    "global44_abc",
+    "global48_abc",
+    "global51_abc_ssa",
+)
+
+
+def _split_csv(value: str) -> list[str]:
+    return [s.strip() for s in value.split(",") if s.strip()]
+
+
+def _parse_lengths(value: str) -> tuple[int, ...]:
+    try:
+        return tuple(int(x) for x in _split_csv(value))
+    except ValueError as e:
+        raise argparse.ArgumentTypeError(f"--lengths must be integers: {value!r}") from e
+
+
+def build_parser(sub: argparse._SubParsersAction) -> argparse.ArgumentParser:
+    p = sub.add_parser(
+        "spanning",
+        help="Build a population-spanning CTA x HLA pMHC table.",
+        description=(
+            "Produce a CTA x HLA pivot table where each cell is the best-presented "
+            "peptide for that CTA on that HLA allele. Defaults to top-25 CTAs (ranked "
+            "by ms_cancer_peptide_count) crossed with the IEDB-27 panel at 9-mer "
+            "length and a 2.0%% presentation-percentile cutoff — typically yielding "
+            "200-400 filled cells, suitable as a baseline spanning set for off-the-"
+            "shelf vaccine / TCR programs."
+        ),
+    )
+    p.add_argument(
+        "--cta-count",
+        type=int,
+        default=25,
+        help="Top N CTAs to include when --ctas is not supplied (default 25).",
+    )
+    p.add_argument(
+        "--cta-rank-by",
+        default="ms_cancer_peptide_count",
+        help=(
+            "Column in the bundled CTA CSV used to rank candidates "
+            "(default 'ms_cancer_peptide_count'; falls back to alphabetical "
+            "Symbol order if the column is missing or all-NaN)."
+        ),
+    )
+    p.add_argument(
+        "--ctas",
+        type=_split_csv,
+        default=None,
+        help=(
+            "Explicit gene symbols, comma-separated (e.g. 'MAGEA4,PRAME,NY-ESO-1'). "
+            "Overrides --cta-count / --cta-rank-by."
+        ),
+    )
+    p.add_argument(
+        "--min-restriction-confidence",
+        type=_split_csv,
+        default=["HIGH", "MODERATE"],
+        help=(
+            "Allowed restriction_confidence bins, comma-separated (default "
+            "'HIGH,MODERATE'; pass 'ANY' to disable)."
+        ),
+    )
+    p.add_argument(
+        "--restriction-levels",
+        type=_split_csv,
+        default=None,
+        help=(
+            "Restriction levels to keep, comma-separated (e.g. 'TESTIS,PLACENTAL'). "
+            "Default keeps all levels."
+        ),
+    )
+    p.add_argument(
+        "--alleles",
+        type=_split_csv,
+        default=None,
+        help="Explicit allele list (e.g. 'HLA-A*02:01,HLA-A*24:02'). Overrides --panel.",
+    )
+    p.add_argument(
+        "--panel",
+        choices=_SUPPORTED_PANELS,
+        default="iedb27_ab",
+        help="Named panel from tsarina.alleles (default 'iedb27_ab').",
+    )
+    p.add_argument(
+        "--lengths",
+        type=_parse_lengths,
+        default=(9,),
+        help="Peptide lengths to enumerate (default 9).",
+    )
+    p.add_argument(
+        "--ensembl-release",
+        type=int,
+        default=112,
+        help="Ensembl release (default 112).",
+    )
+    p.add_argument(
+        "--no-require-cta-exclusive",
+        dest="require_cta_exclusive",
+        action="store_false",
+        help="Allow CTA peptides that also appear in non-CTA proteins.",
+    )
+    p.add_argument(
+        "--predictor",
+        choices=_SUPPORTED_PREDICTORS,
+        default="mhcflurry",
+        help="mhctools predictor (default mhcflurry).",
+    )
+    p.add_argument(
+        "--max-percentile",
+        type=float,
+        default=2.0,
+        help="Maximum presentation percentile for a cell to be filled (default 2.0).",
+    )
+    p.add_argument(
+        "--format",
+        choices=_SUPPORTED_FORMATS,
+        default="wide",
+        help=(
+            "Output format (default 'wide'). 'wide' = CTA rows x allele cols with "
+            "peptide as cell value. 'long' = one row per filled cell with peptide / "
+            "length / percentile / score / affinity columns."
+        ),
+    )
+    p.add_argument(
+        "-o",
+        "--output",
+        default=None,
+        help="Write CSV to this path (default: stdout).",
+    )
+    return p
+
+
+def handle(args: argparse.Namespace) -> None:
+    from .spanning import spanning_pmhc_set
+
+    min_restriction_confidence: tuple[str, ...] | None
+    if any(v.upper() == "ANY" for v in args.min_restriction_confidence):
+        min_restriction_confidence = None
+    else:
+        min_restriction_confidence = tuple(v.upper() for v in args.min_restriction_confidence)
+
+    df = spanning_pmhc_set(
+        cta_count=args.cta_count,
+        cta_rank_by=args.cta_rank_by,
+        ctas=args.ctas,
+        min_restriction_confidence=min_restriction_confidence,
+        restriction_levels=tuple(args.restriction_levels) if args.restriction_levels else None,
+        alleles=tuple(args.alleles) if args.alleles else None,
+        panel=args.panel,
+        lengths=args.lengths,
+        ensembl_release=args.ensembl_release,
+        require_cta_exclusive=args.require_cta_exclusive,
+        predictor=args.predictor,
+        max_percentile=args.max_percentile,
+        output_format=args.format,
+    )
+
+    if args.output:
+        df.to_csv(args.output, index=False)
+        print(f"Wrote {len(df)} rows to {args.output}", file=sys.stderr)
+    else:
+        df.to_csv(sys.stdout, index=False)

--- a/tsarina/spanning.py
+++ b/tsarina/spanning.py
@@ -1,0 +1,337 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Population-spanning pMHC sets for off-the-shelf vaccine / TCR programs.
+
+A *spanning set* is a small panel of peptide-HLA pairs designed to
+maximize patient coverage across a population: the most common cancer-
+testis antigens (CTAs) crossed with the most frequent HLA class I
+alleles, with each (CTA, HLA) cell filled by the single best-presented
+peptide that the CTA's protein offers for that allele.
+
+The output is a wide pivot table — CTA rows, HLA columns, peptide at the
+intersection — plus an optional long format that preserves percentile,
+presentation score, and affinity for downstream filtering.
+
+Typical usage::
+
+    from tsarina.spanning import spanning_pmhc_set
+
+    table = spanning_pmhc_set(
+        cta_count=25,
+        panel="iedb27_ab",
+        max_percentile=2.0,
+    )
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+import pandas as pd
+
+_DEFAULT_RANK_COLUMN = "ms_cancer_peptide_count"
+
+_LONG_OUTPUT_COLUMNS: tuple[str, ...] = (
+    "cta",
+    "allele",
+    "peptide",
+    "length",
+    "presentation_percentile",
+    "presentation_score",
+    "affinity_nm",
+)
+
+
+def spanning_pmhc_set(
+    cta_count: int = 25,
+    cta_rank_by: str = _DEFAULT_RANK_COLUMN,
+    ctas: Iterable[str] | None = None,
+    min_restriction_confidence: Iterable[str] | None = ("HIGH", "MODERATE"),
+    restriction_levels: Iterable[str] | None = None,
+    alleles: Iterable[str] | None = None,
+    panel: str | None = "iedb27_ab",
+    lengths: tuple[int, ...] = (9,),
+    ensembl_release: int = 112,
+    require_cta_exclusive: bool = True,
+    predictor: str = "mhcflurry",
+    max_percentile: float = 2.0,
+    output_format: str = "wide",
+) -> pd.DataFrame:
+    """Build a CTA x HLA spanning pMHC table.
+
+    Parameters
+    ----------
+    cta_count
+        Number of top CTAs to include when ``ctas`` is not supplied.
+    cta_rank_by
+        Column in the bundled CTA CSV used to rank candidates.  Default
+        ``"ms_cancer_peptide_count"`` (most-observed-in-cancer first).
+        Falls back to alphabetical ``Symbol`` order when the column is
+        missing or all-NaN.
+    ctas
+        Explicit list of gene symbols.  Overrides ``cta_count`` /
+        ``cta_rank_by``.  Genes not present in the bundled CTA CSV are
+        silently dropped.
+    min_restriction_confidence
+        Allowed ``restriction_confidence`` bins (e.g. ``("HIGH",
+        "MODERATE")``).  Pass ``None`` to disable.  Applied before
+        ranking.
+    restriction_levels
+        Optional set of ``restriction`` values to keep (e.g.
+        ``("TESTIS", "PLACENTAL")``).  ``None`` (default) keeps all.
+    alleles
+        Explicit allele list.  Overrides ``panel``.
+    panel
+        Named panel from :mod:`tsarina.alleles`.  Default
+        ``"iedb27_ab"`` (27 globally-common HLA-A/B alleles).
+    lengths
+        Peptide lengths (default 9-mers — the dominant class I length and
+        the most therapeutically relevant for vaccine / TCR design).
+    ensembl_release
+        Ensembl release for peptide enumeration (default 112).
+    require_cta_exclusive
+        If True (default), use :func:`tsarina.peptides.cta_exclusive_peptides`
+        — peptides that do NOT appear in any non-CTA protein.  Set False
+        to fall back to :func:`tsarina.peptides.cta_peptides` (all CTA
+        k-mers, no exclusivity gate).
+    predictor
+        mhctools predictor key.  ``"mhcflurry"`` (default), ``"netmhcpan"``,
+        or ``"netmhcpan_el"``.
+    max_percentile
+        Maximum presentation percentile for a cell to be filled.  Cells
+        whose best peptide exceeds this threshold are left blank in wide
+        output (or absent in long output).  Default 2.0% — the standard
+        MHC class I "presented" threshold.
+    output_format
+        ``"wide"`` (default) — pivot with CTA rows, allele columns, and
+        the chosen peptide as the cell value.
+        ``"long"`` — one row per filled cell with peptide, length,
+        percentile, score, and affinity columns.
+
+    Returns
+    -------
+    pd.DataFrame
+        Wide pivot or long table per ``output_format``.
+
+    Raises
+    ------
+    ValueError
+        If neither ``alleles`` nor ``panel`` is supplied, or if
+        ``output_format`` is unrecognized.
+    ImportError
+        If the scoring backend (topiary + mhctools + chosen predictor)
+        is not installed.
+    """
+    if output_format not in ("wide", "long"):
+        raise ValueError(f"output_format must be 'wide' or 'long', got {output_format!r}")
+
+    allele_list = _resolve_alleles(alleles, panel)
+    cta_list = _resolve_ctas(
+        ctas=ctas,
+        cta_count=cta_count,
+        cta_rank_by=cta_rank_by,
+        min_restriction_confidence=min_restriction_confidence,
+        restriction_levels=restriction_levels,
+    )
+
+    if not cta_list or not allele_list:
+        return _empty_output(cta_list, allele_list, output_format)
+
+    pep_df = _resolve_peptides(
+        cta_list=cta_list,
+        lengths=lengths,
+        ensembl_release=ensembl_release,
+        require_cta_exclusive=require_cta_exclusive,
+    )
+    if pep_df.empty:
+        return _empty_output(cta_list, allele_list, output_format)
+
+    from .scoring import score_presentation
+
+    unique_peptides = pep_df["peptide"].unique().tolist()
+    scores = score_presentation(peptides=unique_peptides, alleles=allele_list, predictor=predictor)
+
+    best = _best_per_cell(scores, pep_df, max_percentile)
+
+    if output_format == "wide":
+        return _to_wide(best, cta_list, allele_list)
+    return _to_long(best, cta_list, allele_list)
+
+
+# ── Helpers ────────────────────────────────────────────────────────────
+
+
+def _resolve_alleles(
+    alleles: Iterable[str] | None,
+    panel: str | None,
+) -> list[str]:
+    if alleles is not None:
+        out = [a for a in alleles if a]
+        if not out:
+            raise ValueError("alleles is empty")
+        return out
+    if panel is None:
+        raise ValueError("Specify either alleles or panel")
+    from .alleles import get_panel
+
+    return list(get_panel(panel))
+
+
+def _resolve_ctas(
+    ctas: Iterable[str] | None,
+    cta_count: int,
+    cta_rank_by: str,
+    min_restriction_confidence: Iterable[str] | None,
+    restriction_levels: Iterable[str] | None,
+) -> list[str]:
+    """Pick the CTA gene set per the resolution order: explicit override
+    wins; else filter the bundled CTA CSV and take top-N by rank."""
+    from .gene_sets import CTA_gene_names
+    from .loader import cta_dataframe
+
+    valid = CTA_gene_names()
+
+    if ctas is not None:
+        return [g for g in ctas if g in valid]
+
+    df = cta_dataframe()
+    if "filtered" in df.columns:
+        df = df[df["filtered"].astype(str).str.lower() == "true"]
+    if "never_expressed" in df.columns:
+        df = df[~(df["never_expressed"].astype(str).str.lower() == "true")]
+
+    if min_restriction_confidence is not None and "restriction_confidence" in df.columns:
+        wanted = {c.upper() for c in min_restriction_confidence}
+        df = df[df["restriction_confidence"].astype(str).str.upper().isin(wanted)]
+
+    if restriction_levels is not None and "restriction" in df.columns:
+        wanted_levels = set(restriction_levels)
+        df = df[df["restriction"].isin(wanted_levels)]
+
+    if cta_rank_by in df.columns and df[cta_rank_by].notna().any():
+        df = df.sort_values(cta_rank_by, ascending=False, na_position="last")
+    else:
+        df = df.sort_values("Symbol")
+
+    df = df[df["Symbol"].isin(valid)]
+    return df["Symbol"].head(cta_count).tolist()
+
+
+def _resolve_peptides(
+    cta_list: list[str],
+    lengths: tuple[int, ...],
+    ensembl_release: int,
+    require_cta_exclusive: bool,
+) -> pd.DataFrame:
+    if require_cta_exclusive:
+        from .peptides import cta_exclusive_peptides
+
+        all_peps = cta_exclusive_peptides(ensembl_release=ensembl_release, lengths=tuple(lengths))
+    else:
+        from .peptides import cta_peptides
+
+        all_peps = cta_peptides(ensembl_release=ensembl_release, lengths=tuple(lengths))
+    if all_peps.empty:
+        return all_peps
+    return all_peps[all_peps["gene_name"].isin(cta_list)].copy()
+
+
+def _best_per_cell(
+    scores: pd.DataFrame,
+    pep_df: pd.DataFrame,
+    max_percentile: float,
+) -> pd.DataFrame:
+    """For each (cta, allele), pick the lowest-percentile peptide above
+    the max_percentile cutoff."""
+    if scores.empty or "presentation_percentile" not in scores.columns:
+        return pd.DataFrame(
+            columns=[
+                "cta",
+                "allele",
+                "peptide",
+                "length",
+                "presentation_percentile",
+                "presentation_score",
+                "affinity_nm",
+            ]
+        )
+
+    pep_meta = (
+        pep_df[["peptide", "gene_name", "length"]]
+        .drop_duplicates(subset="peptide")
+        .rename(columns={"gene_name": "cta"})
+    )
+    scored = scores.merge(pep_meta, on="peptide", how="inner")
+
+    sort_cols = ["presentation_percentile", "peptide", "allele"]
+    best = (
+        scored.sort_values(sort_cols, kind="mergesort")
+        .groupby(["cta", "allele"], as_index=False)
+        .first()
+    )
+    best = best[best["presentation_percentile"] <= max_percentile].copy()
+    for col in ("presentation_score", "affinity_nm"):
+        if col not in best.columns:
+            best[col] = pd.NA
+    return best[
+        [
+            "cta",
+            "allele",
+            "peptide",
+            "length",
+            "presentation_percentile",
+            "presentation_score",
+            "affinity_nm",
+        ]
+    ]
+
+
+def _to_wide(
+    best: pd.DataFrame,
+    cta_list: list[str],
+    allele_list: list[str],
+) -> pd.DataFrame:
+    if best.empty:
+        wide = pd.DataFrame(index=cta_list, columns=allele_list, dtype=object)
+    else:
+        wide = best.pivot(index="cta", columns="allele", values="peptide")
+        wide = wide.reindex(index=cta_list, columns=allele_list)
+    wide.index.name = "cta"
+    wide = wide.reset_index()
+    return wide
+
+
+def _to_long(
+    best: pd.DataFrame,
+    cta_list: list[str],
+    allele_list: list[str],
+) -> pd.DataFrame:
+    if best.empty:
+        return pd.DataFrame(columns=list(_LONG_OUTPUT_COLUMNS))
+    cta_order = {gene: i for i, gene in enumerate(cta_list)}
+    allele_order = {a: i for i, a in enumerate(allele_list)}
+    out = best.copy()
+    out["_cta_order"] = out["cta"].map(cta_order)
+    out["_allele_order"] = out["allele"].map(allele_order)
+    out = out.sort_values(["_cta_order", "_allele_order"]).drop(
+        columns=["_cta_order", "_allele_order"]
+    )
+    return out[list(_LONG_OUTPUT_COLUMNS)].reset_index(drop=True)
+
+
+def _empty_output(cta_list: list[str], allele_list: list[str], output_format: str) -> pd.DataFrame:
+    if output_format == "wide":
+        wide = pd.DataFrame(index=cta_list, columns=allele_list, dtype=object)
+        wide.index.name = "cta"
+        return wide.reset_index()
+    return pd.DataFrame(columns=list(_LONG_OUTPUT_COLUMNS))

--- a/tsarina/spanning.py
+++ b/tsarina/spanning.py
@@ -81,7 +81,9 @@ def spanning_pmhc_set(
     ctas
         Explicit list of gene symbols.  Overrides ``cta_count`` /
         ``cta_rank_by``.  Genes not present in the bundled CTA CSV are
-        silently dropped.
+        silently dropped.  Note: ``min_restriction_confidence`` and
+        ``restriction_levels`` gates do **not** apply on this path —
+        the explicit list wins verbatim.
     min_restriction_confidence
         Allowed ``restriction_confidence`` bins (e.g. ``("HIGH",
         "MODERATE")``).  Pass ``None`` to disable.  Applied before

--- a/tsarina/version.py
+++ b/tsarina/version.py
@@ -10,4 +10,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.11.0"
+__version__ = "1.0.0"

--- a/tsarina/version.py
+++ b/tsarina/version.py
@@ -10,4 +10,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.10.1"
+__version__ = "0.11.0"


### PR DESCRIPTION
## What

New top-level subcommand and library function for off-the-shelf vaccine / TCR programs:

\`\`\`
tsarina spanning [--cta-count 25] [--panel iedb27_ab] [--max-percentile 2.0] [...]
\`\`\`

Pick the top-N most-studied CTAs (default 25, ranked by \`ms_cancer_peptide_count\` after restriction-confidence filtering), cross with a population-spanning HLA panel (default IEDB-27), score every (peptide, allele) cell via topiary, and emit a wide pivot where each cell is the **single best-presented peptide** for that (CTA, HLA) pair. Cells whose best peptide exceeds the percentile cutoff are blank.

## API + CLI surface

| flag | API kwarg | default | purpose |
|---|---|---|---|
| \`--cta-count N\` | \`cta_count\` | 25 | top-N CTAs by ranking |
| \`--cta-rank-by COL\` | \`cta_rank_by\` | \`ms_cancer_peptide_count\` | column to sort by |
| \`--ctas G,G,...\` | \`ctas\` | None | explicit CTA override |
| \`--min-restriction-confidence H,M\` | \`min_restriction_confidence\` | \`(HIGH, MODERATE)\` | confidence gate |
| \`--restriction-levels TESTIS,...\` | \`restriction_levels\` | None | optional restriction filter |
| \`--alleles HLA-A*02:01,...\` | \`alleles\` | None | explicit allele override |
| \`--panel NAME\` | \`panel\` | \`iedb27_ab\` | named panel (also iedb36_abc, global44_abc, global48_abc, global51_abc_ssa) |
| \`--lengths 8,9,...\` | \`lengths\` | \`(9,)\` | peptide lengths |
| \`--ensembl-release N\` | \`ensembl_release\` | 112 | |
| \`--no-require-cta-exclusive\` | \`require_cta_exclusive\` | True | CTA-exclusivity gate |
| \`--predictor mhcflurry\|netmhcpan\|netmhcpan_el\` | \`predictor\` | \`mhcflurry\` | scoring backend |
| \`--max-percentile 2.0\` | \`max_percentile\` | 2.0 | per-cell presentation cutoff |
| \`--format wide\|long\` | \`output_format\` | \`wide\` | output shape |
| \`-o PATH\` | — | stdout | output destination |

## Output formats

**wide** (default): CTA rows × allele columns, peptide as cell value.

\`\`\`
cta,HLA-A*01:01,HLA-A*02:01,...,HLA-B*58:01
MAGEA3,EVDPIGHLY,KVAELVHFL,...,ASSSLQLVF
MAGEA4,EVDPASNTY,KVLEHVVRV,...,SALPTTISF
...
\`\`\`

**long**: one row per filled cell with full prediction columns.

\`\`\`
cta,allele,peptide,length,presentation_percentile,presentation_score,affinity_nm
MAGEA3,HLA-A*01:01,EVDPIGHLY,9,0.0021,0.94,15.2
MAGEA3,HLA-A*02:01,KVAELVHFL,9,0.45,0.71,127.8
...
\`\`\`

## Live smoke test

\`tsarina spanning --cta-count 10 --panel iedb27_ab --max-percentile 2.0\` produced a 242-cell long table on local data. Canonical immunogenic peptides land in their expected cells:

- **MAGE-A3 EVDPIGHLY** for HLA-A*01:01 (well-known vaccine candidate, in clinical trials)
- **MAGE-A1 EADPTGHSY** for HLA-A*01:01 (canonical CTA peptide)
- **MAGE-A4 SYVKVLEHV** for HLA-A*24:02 (published A*24 ligand)

Sanity check passed.

## Test plan

- [x] 15 new tests in \`tests/test_spanning.py\`:
  - top-N ranking by default column
  - explicit CTA override bypasses ranking
  - \`min_restriction_confidence\` + \`restriction_levels\` filters
  - panel name resolution + explicit allele override
  - missing alleles AND panel → \`ValueError\`
  - lowest-percentile peptide wins each cell
  - \`max_percentile\` gate filters weak cells
  - wide vs long output shape + sort order
  - long format drops filtered cells entirely
  - unknown \`output_format\` raises
  - empty-CTA frame returns canonical empty wide table
  - **size-envelope check**: defaults produce a long table with > 100 and ≤ 1000 rows
- [x] Tests stub \`cta_exclusive_peptides\`, \`cta_dataframe\`, \`score_presentation\`, \`CTA_gene_names\` so they run in <1s with no Ensembl / mhcflurry needed.
- [x] \`./format.sh\` clean
- [x] \`./lint.sh\` clean
- [x] \`./test.sh\` — 189 passed (was 174)

## Known local gotcha (env-specific, not a code defect)

On this Mac the brew Python 3.9 vs shared-venv Python 3.12 split makes \`tsarina spanning\` exit with SIGSEGV at ~15+ CTAs (memory pressure / OpenMP duplicate-library issue with mhcflurry). Workaround for now: use \`KMP_DUPLICATE_LIB_OK=TRUE python -m tsarina.cli spanning ...\` and stay at \`--cta-count <= 10\` per invocation locally. CI environments that have a clean tensorflow / mhcflurry install should not hit this.