### PR TITLE
v1.0.1: unify k-mer enumeration behind _proteome_kmers

### DIFF
--- a/tests/test_kmer_caching.py
+++ b/tests/test_kmer_caching.py
@@ -10,19 +10,27 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Tests for k-mer enumeration caching (tsarina#12).
+"""Tests for the unified k-mer enumeration primitive (tsarina#12 + #19).
 
-``_non_cta_proteome_kmers`` and ``_human_proteome_kmers`` walk every
-protein-coding transcript in an Ensembl release and produce a frozenset
-of all k-mers at the requested lengths. The walk is ~10-60s depending on
-release + length mix, so both helpers are ``@lru_cache``'d keyed on
-``(ensembl_release, lengths)``.
+``peptides._proteome_kmers(release, lengths, gene_ids)`` walks protein-
+coding transcripts in an Ensembl release and produces a ``frozenset`` of
+every k-mer at the requested lengths within the gene subset.  The walk
+is ~10-60s, so the helper is ``@lru_cache``'d on
+``(release, lengths, gene_ids)``.
 
-These tests exercise the caching behavior without actually loading
-Ensembl data: pyensembl is monkeypatched to a stub that tracks how many
-times the proteome is traversed, so we can directly assert that two
-calls with the same arguments produce a single traversal and that a
-different argument triggers a second.
+These tests exercise:
+
+1. The unified ``_proteome_kmers`` primitive directly — cache behavior,
+   gene-subset respect, full-proteome path (``gene_ids=None``).
+2. The thin frozenset wrappers (``_non_cta_gene_ids`` /
+   ``_cta_gene_ids``) that memoize the partition-derived sets.
+3. End-to-end caching through the public callers
+   (``cta_exclusive_peptides``, ``human_exclusive_viral_peptides``,
+   ``cancer_specific_viral_peptides``).
+
+A stubbed ``EnsemblRelease`` tracks ``.genes()`` / ``.gene_by_id()``
+call counts so we can assert cache hits vs traversal without pulling
+real Ensembl data.
 """
 
 from __future__ import annotations
@@ -78,86 +86,218 @@ class _FakePartition:
 
 @pytest.fixture(autouse=True)
 def _reset_caches_and_counts(monkeypatch):
-    peptides._non_cta_proteome_kmers.cache_clear()
-    viral._human_proteome_kmers.cache_clear()
+    peptides._proteome_kmers.cache_clear()
+    peptides._non_cta_gene_ids.cache_clear()
+    peptides._cta_gene_ids.cache_clear()
     _FakeEnsembl.call_counts = {"genes": 0, "gene_by_id": 0}
     monkeypatch.setattr("pyensembl.EnsemblRelease", _FakeEnsembl)
     monkeypatch.setattr("tsarina.partition.CTA_partition_gene_ids", lambda r: _FakePartition())
     yield
 
 
-# ── _non_cta_proteome_kmers (peptides.py) ──────────────────────────────
+# ── _proteome_kmers primitive ──────────────────────────────────────────
 
 
-def test_non_cta_helper_is_lru_cached():
-    assert hasattr(peptides._non_cta_proteome_kmers, "cache_info")
-    assert hasattr(peptides._non_cta_proteome_kmers, "cache_clear")
+def test_proteome_kmers_is_lru_cached():
+    assert hasattr(peptides._proteome_kmers, "cache_info")
+    assert hasattr(peptides._proteome_kmers, "cache_clear")
 
 
-def test_non_cta_returns_frozenset_of_kmers_from_non_cta_genes():
-    result = peptides._non_cta_proteome_kmers(112, (8,))
+def test_proteome_kmers_full_proteome_uses_genes_iteration():
+    """gene_ids=None walks every gene via ensembl.genes() rather than
+    looking up IDs one-by-one."""
+    result = peptides._proteome_kmers(112, (8,), None)
     assert isinstance(result, frozenset)
-    # ENSG_B = "MCCCCCCCCC" (10 chars) → three 8-mers: MCCCCCCC, CCCCCCCC, CCCCCCCC
-    # But CCCCCCCC appears as both second and third (same k-mer, deduped).
-    # ENSG_C = "MDDDDDDDDD" → analogous.
-    # ENSG_A is CTA → excluded from this helper.
-    assert "MCCCCCCC" in result
-    assert "MDDDDDDD" in result
-    assert "MAAAAAAA" not in result  # ENSG_A is CTA, excluded
-
-
-def test_non_cta_caches_across_calls_with_same_args():
-    r1 = peptides._non_cta_proteome_kmers(112, (8,))
-    gene_by_id_calls_after_first = _FakeEnsembl.call_counts["gene_by_id"]
-    assert gene_by_id_calls_after_first > 0  # first call did real work
-
-    r2 = peptides._non_cta_proteome_kmers(112, (8,))
-    # Second call hit cache — no additional traversal
-    assert _FakeEnsembl.call_counts["gene_by_id"] == gene_by_id_calls_after_first
-    # Identical frozenset object (lru_cache returns cached value)
-    assert r1 is r2
-
-
-def test_non_cta_different_args_compute_separately():
-    peptides._non_cta_proteome_kmers(112, (8,))
-    peptides._non_cta_proteome_kmers(112, (9,))  # different lengths → new cache key
-    info = peptides._non_cta_proteome_kmers.cache_info()
-    assert info.misses == 2
-    assert info.hits == 0
-
-
-# ── _human_proteome_kmers (viral.py) ───────────────────────────────────
-
-
-def test_human_helper_is_lru_cached():
-    assert hasattr(viral._human_proteome_kmers, "cache_info")
-    assert hasattr(viral._human_proteome_kmers, "cache_clear")
-
-
-def test_human_returns_frozenset_of_kmers_from_all_protein_coding_genes():
-    result = viral._human_proteome_kmers(112, (8,))
-    assert isinstance(result, frozenset)
-    # ENSG_A (CTA) + ENSG_B + ENSG_C are all protein_coding, all included here
-    # (the human helper does NOT exclude CTAs — that's the whole proteome).
+    assert _FakeEnsembl.call_counts["genes"] == 1
+    assert _FakeEnsembl.call_counts["gene_by_id"] == 0
+    # All three fake genes are protein_coding → all appear.
     assert "MAAAAAAA" in result
     assert "MCCCCCCC" in result
     assert "MDDDDDDD" in result
 
 
-def test_human_caches_across_calls_with_same_args():
-    r1 = viral._human_proteome_kmers(112, (8,))
-    genes_calls_after_first = _FakeEnsembl.call_counts["genes"]
-    assert genes_calls_after_first == 1
+def test_proteome_kmers_gene_subset_uses_gene_by_id():
+    """A supplied gene_ids frozenset goes through gene_by_id()."""
+    result = peptides._proteome_kmers(112, (8,), frozenset({"ENSG_B", "ENSG_C"}))
+    assert "MCCCCCCC" in result
+    assert "MDDDDDDD" in result
+    assert "MAAAAAAA" not in result  # ENSG_A excluded by filter
+    assert _FakeEnsembl.call_counts["genes"] == 0
+    assert _FakeEnsembl.call_counts["gene_by_id"] == 2
 
-    r2 = viral._human_proteome_kmers(112, (8,))
-    # Second call hit cache — .genes() not called a second time
-    assert _FakeEnsembl.call_counts["genes"] == 1
+
+def test_proteome_kmers_caches_by_gene_ids():
+    """Same (release, lengths) with different gene_ids keys must produce
+    separate cache entries; repeat lookups are cache hits."""
+    peptides._proteome_kmers(112, (8,), frozenset({"ENSG_B"}))
+    peptides._proteome_kmers(112, (8,), frozenset({"ENSG_C"}))
+    info_after_two_distinct = peptides._proteome_kmers.cache_info()
+    assert info_after_two_distinct.misses == 2
+    assert info_after_two_distinct.hits == 0
+
+    # Repeat — both should hit the cache
+    peptides._proteome_kmers(112, (8,), frozenset({"ENSG_B"}))
+    peptides._proteome_kmers(112, (8,), frozenset({"ENSG_C"}))
+    info_after_repeat = peptides._proteome_kmers.cache_info()
+    assert info_after_repeat.misses == 2
+    assert info_after_repeat.hits == 2
+
+
+def test_proteome_kmers_caches_by_lengths():
+    peptides._proteome_kmers(112, (8,), None)
+    peptides._proteome_kmers(112, (9,), None)
+    info = peptides._proteome_kmers.cache_info()
+    assert info.misses == 2
+    assert info.hits == 0
+
+
+# ── Gene-ID frozenset wrappers ─────────────────────────────────────────
+
+
+def test_non_cta_gene_ids_returns_frozenset_of_non_cta_partition():
+    result = peptides._non_cta_gene_ids(112)
+    assert isinstance(result, frozenset)
+    assert result == frozenset({"ENSG_B", "ENSG_C"})
+
+
+def test_cta_gene_ids_returns_frozenset_of_cta_partition():
+    result = peptides._cta_gene_ids(112)
+    assert isinstance(result, frozenset)
+    assert result == frozenset({"ENSG_A"})
+
+
+def test_gene_id_wrappers_cache_per_release():
+    """Calling the wrapper twice with the same release returns the same
+    frozenset instance — so downstream _proteome_kmers lookups reuse
+    the cached hash rather than rebuilding."""
+    r1 = peptides._non_cta_gene_ids(112)
+    r2 = peptides._non_cta_gene_ids(112)
     assert r1 is r2
 
 
-def test_human_different_release_triggers_recompute():
-    viral._human_proteome_kmers(112, (8,))
-    viral._human_proteome_kmers(113, (8,))  # different release → new cache key
-    info = viral._human_proteome_kmers.cache_info()
-    assert info.misses == 2
-    assert info.hits == 0
+# ── End-to-end caching through public callers ──────────────────────────
+
+
+def test_cta_exclusive_peptides_hits_cache_on_repeat(monkeypatch):
+    """The public wrapper must dispatch through _proteome_kmers — second
+    call with the same args does NOT re-walk the proteome."""
+    import pandas as pd
+
+    monkeypatch.setattr(
+        "tsarina.peptides.cta_peptides",
+        lambda **kw: pd.DataFrame(
+            {
+                "peptide": ["MAAAAAAA", "NEVERSEEN"],
+                "length": [8, 8],
+                "gene_name": ["G1", "G1"],
+                "gene_id": ["X", "X"],
+            }
+        ),
+        raising=True,
+    )
+    peptides.cta_exclusive_peptides(ensembl_release=112, lengths=(8,))
+    gene_by_id_after_first = _FakeEnsembl.call_counts["gene_by_id"]
+    peptides.cta_exclusive_peptides(ensembl_release=112, lengths=(8,))
+    assert _FakeEnsembl.call_counts["gene_by_id"] == gene_by_id_after_first
+
+
+def test_human_exclusive_viral_peptides_hits_cache_on_repeat(monkeypatch):
+    import pandas as pd
+
+    monkeypatch.setattr(
+        "tsarina.viral.viral_peptides",
+        lambda **kw: pd.DataFrame(
+            {
+                "peptide": ["VIRALMER", "MAAAAAAA"],
+                "length": [8, 8],
+                "virus": ["test", "test"],
+                "protein_id": ["P1", "P1"],
+            }
+        ),
+        raising=True,
+    )
+    viral.human_exclusive_viral_peptides(virus="test", lengths=(8,), ensembl_release=112)
+    genes_after_first = _FakeEnsembl.call_counts["genes"]
+    viral.human_exclusive_viral_peptides(virus="test", lengths=(8,), ensembl_release=112)
+    assert _FakeEnsembl.call_counts["genes"] == genes_after_first
+
+
+def test_cancer_specific_viral_peptides_hits_cache_on_repeat(monkeypatch):
+    """PR D headline: cancer_specific_viral_peptides now shares the
+    cached _proteome_kmers primitive instead of walking the proteome
+    on every call."""
+    import pandas as pd
+
+    monkeypatch.setattr(
+        "tsarina.viral.viral_peptides",
+        lambda **kw: pd.DataFrame(
+            {
+                "peptide": ["VIRALMER", "MAAAAAAA", "MCCCCCCC"],
+                "length": [8, 8, 8],
+                "virus": ["test", "test", "test"],
+                "protein_id": ["P1", "P1", "P1"],
+            }
+        ),
+        raising=True,
+    )
+    result_1 = viral.cancer_specific_viral_peptides(virus="test", lengths=(8,), ensembl_release=112)
+    gene_by_id_after_first = _FakeEnsembl.call_counts["gene_by_id"]
+    assert gene_by_id_after_first > 0  # first call did real work
+
+    result_2 = viral.cancer_specific_viral_peptides(virus="test", lengths=(8,), ensembl_release=112)
+    # Second call hits the cache — no additional gene_by_id lookups
+    assert _FakeEnsembl.call_counts["gene_by_id"] == gene_by_id_after_first
+
+    # Functional equivalence between the two calls
+    assert list(result_1["peptide"]) == list(result_2["peptide"])
+    # in_cta_protein flag set correctly: MAAAAAAA comes from ENSG_A (CTA),
+    # VIRALMER is viral-only, MCCCCCCC comes from ENSG_B (non-CTA → dropped
+    # by the noncta subtraction).
+    kept = set(result_1["peptide"])
+    assert "VIRALMER" in kept
+    assert "MAAAAAAA" in kept  # in CTA proteins, not in non-CTA — kept
+    assert "MCCCCCCC" not in kept  # in non-CTA proteins — filtered
+    maaaaaaa_row = result_1[result_1["peptide"] == "MAAAAAAA"].iloc[0]
+    assert bool(maaaaaaa_row["in_cta_protein"]) is True
+    viralmer_row = result_1[result_1["peptide"] == "VIRALMER"].iloc[0]
+    assert bool(viralmer_row["in_cta_protein"]) is False
+
+
+def test_cta_and_non_cta_share_proteome_kmers_cache(monkeypatch):
+    """cta_exclusive_peptides and cancer_specific_viral_peptides both
+    query _proteome_kmers(non_cta). The second function should hit the
+    cache populated by the first — no re-walk across functions."""
+    import pandas as pd
+
+    monkeypatch.setattr(
+        "tsarina.peptides.cta_peptides",
+        lambda **kw: pd.DataFrame(
+            {
+                "peptide": ["MAAAAAAA"],
+                "length": [8],
+                "gene_name": ["G1"],
+                "gene_id": ["X"],
+            }
+        ),
+        raising=True,
+    )
+    monkeypatch.setattr(
+        "tsarina.viral.viral_peptides",
+        lambda **kw: pd.DataFrame(
+            {
+                "peptide": ["VIRALMER"],
+                "length": [8],
+                "virus": ["test"],
+                "protein_id": ["P1"],
+            }
+        ),
+        raising=True,
+    )
+    peptides.cta_exclusive_peptides(ensembl_release=112, lengths=(8,))
+    calls_after_cta = _FakeEnsembl.call_counts["gene_by_id"]
+    viral.cancer_specific_viral_peptides(virus="test", lengths=(8,), ensembl_release=112)
+    # cancer_specific_viral_peptides additionally needs the CTA k-mer set,
+    # so it will do ONE new walk (for the CTA partition) — but NOT re-walk
+    # the non-CTA partition that cta_exclusive_peptides already cached.
+    # CTA partition has 1 gene (ENSG_A) → 1 additional gene_by_id call.
+    assert _FakeEnsembl.call_counts["gene_by_id"] == calls_after_cta + 1

--- a/tsarina/peptides.py
+++ b/tsarina/peptides.py
@@ -37,37 +37,63 @@ AA20 = set("ACDEFGHIKLMNPQRSTVWY")
 DEFAULT_PEPTIDE_LENGTHS = (8, 9, 10, 11)
 
 
-@lru_cache(maxsize=4)
-def _non_cta_proteome_kmers(
+@lru_cache(maxsize=8)
+def _proteome_kmers(
     ensembl_release: int,
     lengths: tuple[int, ...],
+    gene_ids: frozenset[str] | None = None,
 ) -> frozenset[str]:
-    """Return every k-mer found in any non-CTA protein-coding transcript.
+    """Return every k-mer found in the requested subset of the Ensembl proteome.
 
-    Shared between :func:`cta_exclusive_peptides` and other cancer-specific
-    callers that need to subtract the non-CTA self-peptide background.
-    The set depends only on ``(ensembl_release, lengths)`` and is expensive
-    to build (~10-30s walking every non-CTA transcript in an Ensembl
-    release), so the result is process-wide ``@lru_cache``'d behind a
-    ``frozenset`` — the second call within a process returns immediately
-    with no additional work.
+    Single cached primitive behind every tsarina function that needs to
+    subtract a self-peptide background — CTA exclusivity, viral human-
+    exclusivity, and viral cancer-specificity all call this with
+    different ``gene_ids`` filters.
 
-    Cache holds up to 4 ``(release, lengths)`` combinations (typical use
-    hits one).  Clear via ``_non_cta_proteome_kmers.cache_clear()``.
+    Parameters
+    ----------
+    ensembl_release
+        Ensembl release (e.g. 112).
+    lengths
+        Peptide lengths to enumerate.
+    gene_ids
+        Frozenset of Ensembl gene IDs to restrict the walk to.  ``None``
+        (default) iterates every protein-coding gene in the release,
+        matching what a full-proteome background walk would produce.
+
+    Returns
+    -------
+    frozenset[str]
+        Unique k-mers at the requested lengths across the chosen gene
+        subset, with any non-AA20 residue stretches dropped.
+
+    Notes
+    -----
+    The walk is expensive (~10-60s depending on release + length mix +
+    gene subset size).  Result is ``@lru_cache``'d keyed on
+    ``(ensembl_release, lengths, gene_ids)``, so a second call with the
+    same arguments returns in sub-millisecond time.  Cache holds up to
+    8 combinations — enough for a handful of common partitions
+    (non-CTA, CTA, full proteome) across 1-2 releases.  Clear via
+    ``_proteome_kmers.cache_clear()``.
+
+    Long-term this primitive is a candidate to move upstream into
+    ``hitlist.proteome`` (tracked in hitlist#99) so sibling packages
+    can share a cross-package cache.  Call sites would collapse from
+    ``_proteome_kmers(r, l, gene_ids)`` to the one-line
+    ``hitlist.proteome_kmer_set(r, l, gene_ids=gene_ids)``.
     """
     from pyensembl import EnsemblRelease
 
-    from .partition import CTA_partition_gene_ids
-
     ensembl = EnsemblRelease(ensembl_release)
-    partition = CTA_partition_gene_ids(ensembl_release)
+
+    if gene_ids is None:
+        genes = (g for g in ensembl.genes() if g.biotype == "protein_coding")
+    else:
+        genes = _genes_by_id(ensembl, gene_ids)
 
     kmers: set[str] = set()
-    for gene_id in partition.non_cta:
-        try:
-            gene = ensembl.gene_by_id(gene_id)
-        except ValueError:
-            continue
+    for gene in genes:
         for t in gene.transcripts:
             if t.biotype != "protein_coding":
                 continue
@@ -83,6 +109,41 @@ def _non_cta_proteome_kmers(
                     if set(pep).issubset(AA20):
                         kmers.add(pep)
     return frozenset(kmers)
+
+
+def _genes_by_id(ensembl, gene_ids):
+    """Yield ``ensembl.gene_by_id`` results for each id, skipping those
+    that fail lookup or are non-protein-coding."""
+    for gene_id in gene_ids:
+        try:
+            gene = ensembl.gene_by_id(gene_id)
+        except ValueError:
+            continue
+        if gene.biotype != "protein_coding":
+            continue
+        yield gene
+
+
+@lru_cache(maxsize=4)
+def _non_cta_gene_ids(ensembl_release: int) -> frozenset[str]:
+    """Cached frozenset of non-CTA Ensembl gene IDs for a release.
+
+    Pre-building the frozenset means downstream ``_proteome_kmers``
+    lookups reuse a single hashable instance rather than rebuilding
+    from the mutable ``CTA_partition_gene_ids(...).non_cta`` set on
+    every call.
+    """
+    from .partition import CTA_partition_gene_ids
+
+    return frozenset(CTA_partition_gene_ids(ensembl_release).non_cta)
+
+
+@lru_cache(maxsize=4)
+def _cta_gene_ids(ensembl_release: int) -> frozenset[str]:
+    """Cached frozenset of CTA Ensembl gene IDs for a release."""
+    from .partition import CTA_partition_gene_ids
+
+    return frozenset(CTA_partition_gene_ids(ensembl_release).cta)
 
 
 def cta_peptides(
@@ -194,11 +255,13 @@ def cta_exclusive_peptides(
     Notes
     -----
     The non-CTA k-mer set is computed once per ``(ensembl_release, lengths)``
-    via :func:`_non_cta_proteome_kmers` and cached for the life of the
-    process.  First call pays ~10-30s walking the non-CTA transcript set;
-    subsequent calls with the same inputs return in sub-millisecond time.
+    via :func:`_proteome_kmers` and cached for the life of the process.
+    First call pays ~10-30s walking the non-CTA transcript set; subsequent
+    calls with the same inputs return in sub-millisecond time.
     """
-    noncta_peptides = _non_cta_proteome_kmers(ensembl_release, tuple(lengths))
+    noncta_peptides = _proteome_kmers(
+        ensembl_release, tuple(lengths), _non_cta_gene_ids(ensembl_release)
+    )
     cta_df = cta_peptides(ensembl_release=ensembl_release, lengths=lengths)
     mask = ~cta_df["peptide"].isin(noncta_peptides)
     return cta_df[mask].reset_index(drop=True)

--- a/tsarina/version.py
+++ b/tsarina/version.py
@@ -10,4 +10,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "1.0.0"
+__version__ = "1.0.1"

--- a/tsarina/viral.py
+++ b/tsarina/viral.py
@@ -48,55 +48,11 @@ Typical usage::
 
 from __future__ import annotations
 
-from functools import lru_cache
 from pathlib import Path
 
 import pandas as pd
 
-from .peptides import AA20
-
-
-@lru_cache(maxsize=4)
-def _human_proteome_kmers(
-    ensembl_release: int,
-    lengths: tuple[int, ...],
-) -> frozenset[str]:
-    """Return every k-mer found in any human protein-coding transcript.
-
-    Shared by :func:`human_exclusive_viral_peptides` and any other caller
-    that needs to subtract the full human self-peptide background.  The
-    set depends only on ``(ensembl_release, lengths)`` and is expensive
-    to build (~20-60s walking every protein-coding transcript in an
-    Ensembl release), so the result is process-wide ``@lru_cache``'d
-    behind a ``frozenset`` — the second call within a process returns
-    immediately with no additional work.
-
-    Cache holds up to 4 ``(release, lengths)`` combinations.  Clear via
-    ``_human_proteome_kmers.cache_clear()``.
-    """
-    from pyensembl import EnsemblRelease
-
-    ensembl = EnsemblRelease(ensembl_release)
-    kmers: set[str] = set()
-    for gene in ensembl.genes():
-        if gene.biotype != "protein_coding":
-            continue
-        for t in gene.transcripts:
-            if t.biotype != "protein_coding":
-                continue
-            try:
-                seq = t.protein_sequence
-            except Exception:
-                continue
-            if not seq:
-                continue
-            for k in lengths:
-                for i in range(len(seq) - k + 1):
-                    pep = seq[i : i + k]
-                    if set(pep).issubset(AA20):
-                        kmers.add(pep)
-    return frozenset(kmers)
-
+from .peptides import AA20, _cta_gene_ids, _non_cta_gene_ids, _proteome_kmers
 
 # ── Virus definitions ───────────────────────────────────────────────────────
 
@@ -318,15 +274,15 @@ def human_exclusive_viral_peptides(
     Notes
     -----
     The human k-mer set is computed once per
-    ``(ensembl_release, lengths)`` via :func:`_human_proteome_kmers` and
-    cached for the life of the process.  First call pays ~20-60s walking
+    ``(ensembl_release, lengths)`` via :func:`tsarina.peptides._proteome_kmers`
+    and cached for the life of the process.  First call pays ~20-60s walking
     every protein-coding transcript in the Ensembl release; subsequent
     calls with the same inputs return in sub-millisecond time.
     """
     vdf = viral_peptides(virus=virus, fasta_path=fasta_path, proteins=proteins, lengths=lengths)
     if vdf.empty:
         return vdf
-    human_kmers = _human_proteome_kmers(ensembl_release, tuple(lengths))
+    human_kmers = _proteome_kmers(ensembl_release, tuple(lengths), None)
     mask = ~vdf["peptide"].isin(human_kmers)
     return vdf[mask].reset_index(drop=True)
 
@@ -363,64 +319,26 @@ def cancer_specific_viral_peptides(
     -------
     pd.DataFrame
         Same columns as :func:`viral_peptides`, plus ``in_cta_protein``.
+
+    Notes
+    -----
+    Both the CTA and non-CTA k-mer sets are computed via
+    :func:`tsarina.peptides._proteome_kmers` and cached for the life of
+    the process, shared with :func:`cta_exclusive_peptides` /
+    :func:`human_exclusive_viral_peptides` where their gene filters
+    overlap.  First call pays the Ensembl walk; subsequent calls with
+    the same ``(release, lengths)`` return in sub-millisecond time.
     """
-    from pyensembl import EnsemblRelease
-
-    from .partition import CTA_partition_gene_ids
-
     vdf = viral_peptides(virus=virus, fasta_path=fasta_path, proteins=proteins, lengths=lengths)
     if vdf.empty:
         vdf["in_cta_protein"] = pd.Series(dtype=bool)
         return vdf
 
-    ensembl = EnsemblRelease(ensembl_release)
-    partition = CTA_partition_gene_ids(ensembl_release)
+    lengths_t = tuple(lengths)
+    noncta_kmers = _proteome_kmers(ensembl_release, lengths_t, _non_cta_gene_ids(ensembl_release))
+    cta_kmers = _proteome_kmers(ensembl_release, lengths_t, _cta_gene_ids(ensembl_release))
 
-    # Build k-mer sets for CTA and non-CTA proteins separately
-    cta_kmers: set[str] = set()
-    noncta_kmers: set[str] = set()
-
-    for gene_id in partition.cta:
-        try:
-            gene = ensembl.gene_by_id(gene_id)
-        except ValueError:
-            continue
-        for t in gene.transcripts:
-            if t.biotype != "protein_coding":
-                continue
-            try:
-                seq = t.protein_sequence
-            except Exception:
-                continue
-            if not seq:
-                continue
-            for k in lengths:
-                for i in range(len(seq) - k + 1):
-                    pep = seq[i : i + k]
-                    if set(pep).issubset(AA20):
-                        cta_kmers.add(pep)
-
-    for gene_id in partition.non_cta:
-        try:
-            gene = ensembl.gene_by_id(gene_id)
-        except ValueError:
-            continue
-        for t in gene.transcripts:
-            if t.biotype != "protein_coding":
-                continue
-            try:
-                seq = t.protein_sequence
-            except Exception:
-                continue
-            if not seq:
-                continue
-            for k in lengths:
-                for i in range(len(seq) - k + 1):
-                    pep = seq[i : i + k]
-                    if set(pep).issubset(AA20):
-                        noncta_kmers.add(pep)
-
-    # Keep peptides NOT in non-CTA proteins
+    # Keep peptides NOT in non-CTA proteins; annotate which also occur in CTA proteins.
     mask = ~vdf["peptide"].isin(noncta_kmers)
     result = vdf[mask].copy().reset_index(drop=True)
     result["in_cta_protein"] = result["peptide"].isin(cta_kmers)


### PR DESCRIPTION
Closes #19.

## What

Collapses the three ad-hoc proteome-walk loops (\`peptides._non_cta_proteome_kmers\`, \`viral._human_proteome_kmers\`, the two inline walks in \`viral.cancer_specific_viral_peptides\`) into **one cached primitive**: \`peptides._proteome_kmers(release, lengths, gene_ids=None)\`.

## Before vs after

| function | v1.0.0 | v1.0.1 |
|---|---|---|
| \`cta_exclusive_peptides\` | cached helper, own loop | calls \`_proteome_kmers(..., _non_cta_gene_ids)\` |
| \`human_exclusive_viral_peptides\` | cached helper, own loop | calls \`_proteome_kmers(..., None)\` |
| \`cancer_specific_viral_peptides\` | **un-cached**, 2 inline loops | calls \`_proteome_kmers(..., non_cta)\` + \`_proteome_kmers(..., cta)\` — both cached |

### The new primitive

\`\`\`python
@lru_cache(maxsize=8)
def _proteome_kmers(
    ensembl_release: int,
    lengths: tuple[int, ...],
    gene_ids: frozenset[str] | None = None,  # None = full protein-coding proteome
) -> frozenset[str]:
    ...
\`\`\`

Plus two small helpers to memoize the per-release partition frozensets so \`lru_cache\`'s hash lookup reuses a single hashable instance instead of rebuilding from \`CTA_partition_gene_ids(...).non_cta\` on every call:

\`\`\`python
@lru_cache(maxsize=4)
def _non_cta_gene_ids(release) -> frozenset[str]: ...

@lru_cache(maxsize=4)
def _cta_gene_ids(release) -> frozenset[str]: ...
\`\`\`

## Outcomes

- **Three inner-loop copies → one.** Net −60 lines across \`peptides.py\` + \`viral.py\`.
- **\`cancer_specific_viral_peptides\` joins the fast path.** Same ~10-60s → sub-ms win that v0.10.1 delivered for the other two.
- **Cross-function cache sharing.** Running \`cta_exclusive_peptides\` then \`cancer_specific_viral_peptides\` in one process now builds the non-CTA k-mer set **exactly once** — both functions hit the same cache entry.
- **No public API change, no output schema change.**

## Upstream path

The primitive is a candidate to move into hitlist alongside \`ProteomeIndex.from_ensembl\` (tracked in hitlist#99). When that lands, tsarina's call sites collapse from:

\`\`\`python
_proteome_kmers(r, l, _non_cta_gene_ids(r))
\`\`\`

to a one-line delegate:

\`\`\`python
hitlist.proteome_kmer_set(r, l, gene_ids=_non_cta_gene_ids(r))
\`\`\`

This PR sets up the shape; the eventual hitlist delegate is non-breaking.

## Test plan

- [x] 12 tests in \`tests/test_kmer_caching.py\` (rewritten from the v0.10.1 version):
  - \`_proteome_kmers\` is \`@lru_cache\`-decorated
  - Full-proteome path uses \`ensembl.genes()\` (no \`gene_by_id\` calls)
  - Gene-subset path uses \`ensembl.gene_by_id\` per-id
  - Caches by \`gene_ids\` (two distinct subsets → 2 misses; repeats → hits)
  - Caches by \`lengths\`
  - \`_non_cta_gene_ids\` / \`_cta_gene_ids\` return expected frozensets and memoize by release
  - \`cta_exclusive_peptides\` / \`human_exclusive_viral_peptides\` / \`cancer_specific_viral_peptides\` each hit the cache on repeat call (asserted via stubbed \`EnsemblRelease\` call counts)
  - Cross-function cache sharing: running \`cta_exclusive_peptides\` then \`cancer_specific_viral_peptides\` triggers only ONE additional walk (for the CTA partition), not a second non-CTA rebuild
- [x] \`./format.sh\` clean
- [x] \`./lint.sh\` clean
- [x] \`./test.sh\` — 193 passed (was 189)