### PR TITLE
v1.0.2: spanning test polish — require_cta_exclusive routing, multi-length, CLI smoke

### DIFF
--- a/tests/test_cli_spanning.py
+++ b/tests/test_cli_spanning.py
@@ -1,0 +1,77 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""CLI smoke tests for ``tsarina spanning``.
+
+Mirrors the pattern in ``test_cli_hits.py`` / ``test_cli_personalize.py``:
+exercise the argparse surface via subprocess so flag parsing, choices
+enforcement, and help-text sanity are pinned down independently of the
+library-level coverage in ``test_spanning.py``.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+
+
+def _run_cli(*args: str, check: bool = True) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [sys.executable, "-m", "tsarina.cli", *args],
+        capture_output=True,
+        text=True,
+        check=check,
+    )
+
+
+def test_spanning_help_exits_zero():
+    r = _run_cli("spanning", "--help")
+    assert r.returncode == 0
+    for flag in (
+        "--cta-count",
+        "--ctas",
+        "--panel",
+        "--alleles",
+        "--max-percentile",
+        "--format",
+        "--predictor",
+    ):
+        assert flag in r.stdout, f"missing help text for {flag}"
+
+
+def test_spanning_unknown_panel_rejected():
+    r = _run_cli("spanning", "--panel", "does-not-exist", check=False)
+    assert r.returncode != 0
+    combined = r.stderr + r.stdout
+    # argparse reports the valid choices on invalid input
+    assert "iedb27_ab" in combined
+
+
+def test_spanning_unknown_format_rejected():
+    r = _run_cli("spanning", "--format", "grid", check=False)
+    assert r.returncode != 0
+    combined = r.stderr + r.stdout
+    assert "wide" in combined and "long" in combined
+
+
+def test_spanning_unknown_predictor_rejected():
+    r = _run_cli("spanning", "--predictor", "bogus", check=False)
+    assert r.returncode != 0
+    combined = r.stderr + r.stdout
+    assert "mhcflurry" in combined
+
+
+def test_spanning_is_registered_in_main_help():
+    """``tsarina --help`` should list spanning as a top-level subcommand."""
+    r = _run_cli("--help")
+    assert r.returncode == 0
+    assert "spanning" in r.stdout

--- a/tests/test_spanning.py
+++ b/tests/test_spanning.py
@@ -329,3 +329,151 @@ def test_size_within_target_envelope_for_default_args(monkeypatch):
         output_format="long",
     )
     assert 100 < len(df) <= 1000
+
+
+# ── require_cta_exclusive routing ──────────────────────────────────────
+
+
+def test_require_cta_exclusive_true_calls_exclusive(monkeypatch):
+    """Default True path must dispatch to cta_exclusive_peptides, not
+    cta_peptides."""
+    calls = {"exclusive": 0, "non_exclusive": 0}
+
+    def _exclusive(**kw):
+        calls["exclusive"] += 1
+        return _stub_peptides()
+
+    def _non_exclusive(**kw):
+        calls["non_exclusive"] += 1
+        return _stub_peptides()
+
+    monkeypatch.setattr("tsarina.peptides.cta_exclusive_peptides", _exclusive, raising=True)
+    monkeypatch.setattr("tsarina.peptides.cta_peptides", _non_exclusive, raising=True)
+
+    spanning_pmhc_set(
+        ctas=["MAGEA4"],
+        alleles=["HLA-A*02:01"],
+        require_cta_exclusive=True,
+        max_percentile=10.0,
+    )
+    assert calls == {"exclusive": 1, "non_exclusive": 0}
+
+
+def test_require_cta_exclusive_false_calls_cta_peptides(monkeypatch):
+    """False path must dispatch to cta_peptides (full CTA k-mers, no
+    exclusivity gate), never the exclusive fn."""
+    calls = {"exclusive": 0, "non_exclusive": 0}
+
+    def _exclusive(**kw):
+        calls["exclusive"] += 1
+        return _stub_peptides()
+
+    def _non_exclusive(**kw):
+        calls["non_exclusive"] += 1
+        return _stub_peptides()
+
+    monkeypatch.setattr("tsarina.peptides.cta_exclusive_peptides", _exclusive, raising=True)
+    monkeypatch.setattr("tsarina.peptides.cta_peptides", _non_exclusive, raising=True)
+
+    spanning_pmhc_set(
+        ctas=["MAGEA4"],
+        alleles=["HLA-A*02:01"],
+        require_cta_exclusive=False,
+        max_percentile=10.0,
+    )
+    assert calls == {"exclusive": 0, "non_exclusive": 1}
+
+
+# ── Multi-length best-per-cell ─────────────────────────────────────────
+
+
+def _stub_peptides_multi_length() -> pd.DataFrame:
+    """Mixed 9-mer and 10-mer peptides so the best-per-cell selection
+    must reach across lengths."""
+    return pd.DataFrame(
+        {
+            "peptide": [
+                "MAGEAPEP9M",  # 10-mer; stub gives it percentile 0.3
+                "MAGEAPEP1",  # 9-mer; stub gives it percentile 0.1 (wins)
+                "PRAMEPEP0X",  # 10-mer; stub gives it percentile 0.05 (wins)
+                "PRAMEPEP2",  # 9-mer; stub gives it percentile 1.5
+            ],
+            "length": [10, 9, 10, 9],
+            "gene_name": ["MAGEA4", "MAGEA4", "PRAME", "PRAME"],
+            "gene_id": ["E1", "E1", "E2", "E2"],
+        }
+    )
+
+
+def _stub_scores_multi_length(peptides, alleles, **kwargs) -> pd.DataFrame:
+    """Deterministic percentile per peptide — chosen so the 10-mer wins
+    for PRAME and the 9-mer wins for MAGEA4, regardless of allele."""
+    percentile_by_peptide = {
+        "MAGEAPEP9M": 0.3,
+        "MAGEAPEP1": 0.1,
+        "PRAMEPEP0X": 0.05,
+        "PRAMEPEP2": 1.5,
+    }
+    rows = []
+    for pep in peptides:
+        pct = percentile_by_peptide.get(pep, 5.0)
+        for allele in alleles:
+            rows.append(
+                {
+                    "peptide": pep,
+                    "allele": allele,
+                    "presentation_percentile": pct,
+                    "presentation_score": 0.95 - pct / 10,
+                    "affinity_nm": 50.0 + pct * 100,
+                }
+            )
+    return pd.DataFrame(rows)
+
+
+def test_multi_length_best_per_cell_winner_can_be_any_length(monkeypatch):
+    """With lengths=(9, 10), each cell's winner should be the
+    lowest-percentile peptide across BOTH lengths — not length-biased."""
+    monkeypatch.setattr(
+        "tsarina.peptides.cta_exclusive_peptides",
+        lambda **kw: _stub_peptides_multi_length(),
+        raising=True,
+    )
+    monkeypatch.setattr(
+        "tsarina.scoring.score_presentation", _stub_scores_multi_length, raising=True
+    )
+
+    df = spanning_pmhc_set(
+        ctas=["MAGEA4", "PRAME"],
+        alleles=["HLA-A*02:01"],
+        lengths=(9, 10),
+        max_percentile=2.0,
+    )
+    indexed = df.set_index("cta")
+    # MAGEA4: MAGEAPEP1 (9-mer, 0.1%) beats MAGEAPEP9M (10-mer, 0.3%)
+    assert indexed.loc["MAGEA4", "HLA-A*02:01"] == "MAGEAPEP1"
+    # PRAME: PRAMEPEP0X (10-mer, 0.05%) beats PRAMEPEP2 (9-mer, 1.5%)
+    assert indexed.loc["PRAME", "HLA-A*02:01"] == "PRAMEPEP0X"
+
+
+def test_multi_length_long_format_preserves_winner_length(monkeypatch):
+    """In long format, the length column should reflect the winning
+    peptide's length, not a default."""
+    monkeypatch.setattr(
+        "tsarina.peptides.cta_exclusive_peptides",
+        lambda **kw: _stub_peptides_multi_length(),
+        raising=True,
+    )
+    monkeypatch.setattr(
+        "tsarina.scoring.score_presentation", _stub_scores_multi_length, raising=True
+    )
+
+    long = spanning_pmhc_set(
+        ctas=["MAGEA4", "PRAME"],
+        alleles=["HLA-A*02:01"],
+        lengths=(9, 10),
+        max_percentile=2.0,
+        output_format="long",
+    )
+    rows = {r["cta"]: r for _, r in long.iterrows()}
+    assert int(rows["MAGEA4"]["length"]) == 9  # MAGEAPEP1
+    assert int(rows["PRAME"]["length"]) == 10  # PRAMEPEP0X

--- a/tsarina/version.py
+++ b/tsarina/version.py
@@ -10,4 +10,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "1.0.1"
+__version__ = "1.0.2"


### PR DESCRIPTION
Closes #22 and #23.

## What

Tightens coverage on \`tsarina.spanning\` / \`tsarina.cli_spanning\` wiring. No behavior change; tests-only patch bump.

**\`tests/test_spanning.py\` (+4 tests)**

- \`test_require_cta_exclusive_{true,false}\` — call-counter stubs track which of \`cta_exclusive_peptides\` vs \`cta_peptides\` fires on each flag setting. Pins down the routing that the library signature + handler both wire through.
- \`test_multi_length_best_per_cell_winner_can_be_any_length\` — mixed 9-mer / 10-mer fixture with 10-mer winning one cell and 9-mer winning another; asserts best-per-cell crosses lengths correctly.
- \`test_multi_length_long_format_preserves_winner_length\` — same fixture, long output; asserts the \`length\` column reflects the winning peptide's actual length.

**\`tests/test_cli_spanning.py\` (new, +5 tests)**

Mirrors the pattern in \`test_cli_hits.py\` / \`test_cli_personalize.py\`: subprocess-based argparse smoke tests for the CLI surface. Covers \`--help\` (exits 0, headline flags present), invalid \`--panel\` / \`--format\` / \`--predictor\` rejection, and registration of \`spanning\` in the top-level \`tsarina --help\`.

## Test plan

- [x] 9 new tests all green
- [x] \`./format.sh\` clean
- [x] \`./lint.sh\` clean
- [x] \`./test.sh\` — 202 passed (was 193)