### PR TITLE
v1.0.3: spanning progress indication

### DIFF
--- a/tests/test_spanning.py
+++ b/tests/test_spanning.py
@@ -280,6 +280,124 @@ def test_no_ctas_pass_filter_returns_canonical_empty_frame():
     assert df.empty
 
 
+# ── on_progress callback ───────────────────────────────────────────────
+
+
+def test_on_progress_default_is_silent():
+    """Library contract: when on_progress is not supplied, the function
+    runs without calling any progress callback (or printing anywhere).
+
+    Confirmed indirectly by the function completing without error; the
+    explicit-callback test below asserts the callback IS called on the
+    opt-in path."""
+    df = spanning_pmhc_set(
+        ctas=["MAGEA4", "PRAME"],
+        alleles=["HLA-A*02:01"],
+        max_percentile=2.0,
+    )
+    assert not df.empty  # sanity — stub produces rows
+
+
+def test_on_progress_callback_receives_three_stages():
+    messages: list[str] = []
+    spanning_pmhc_set(
+        ctas=["MAGEA4", "PRAME"],
+        alleles=["HLA-A*02:01", "HLA-A*24:02"],
+        max_percentile=2.0,
+        on_progress=messages.append,
+    )
+    # Expect three stages: pre-scoring, post-scoring, summary.
+    assert len(messages) == 3
+    pre, post, summary = messages
+    # Pre-scoring mentions peptide + allele counts and predictor.
+    assert "peptides" in pre.lower() and "alleles" in pre.lower()
+    assert "mhcflurry" in pre
+    # Post-scoring mentions elapsed time.
+    assert "Scored" in post
+    assert "s" in post  # the elapsed-seconds suffix
+    # Summary mentions CTA + allele counts and filled-cell count.
+    assert "CTAs" in summary
+    assert "alleles" in summary
+    assert "filled cells" in summary
+
+
+def test_on_progress_pre_scoring_message_has_accurate_counts():
+    """The pre-scoring message's numbers should match the actual peptide
+    and allele pool sizes: stub has 2 peptides for {MAGEA4, PRAME} each
+    = 4 unique peptides, crossed with 3 alleles = 12 predictions."""
+    messages: list[str] = []
+    spanning_pmhc_set(
+        ctas=["MAGEA4", "PRAME"],
+        alleles=["HLA-A*02:01", "HLA-A*24:02", "HLA-B*07:02"],
+        max_percentile=10.0,
+        on_progress=messages.append,
+    )
+    pre = messages[0]
+    assert "4 peptides" in pre
+    assert "3 alleles" in pre
+    assert "12 predictions" in pre
+
+
+def test_on_progress_summary_reports_filled_cell_count():
+    """Summary message's filled-cell count should equal the count the
+    output table actually carries (rows with a non-NaN peptide)."""
+    messages: list[str] = []
+    long = spanning_pmhc_set(
+        ctas=["MAGEA4", "PRAME"],
+        alleles=["HLA-A*02:01", "HLA-A*24:02"],
+        max_percentile=2.0,
+        output_format="long",
+        on_progress=messages.append,
+    )
+    summary = messages[-1]
+    assert f"{len(long)} filled cells" in summary
+
+
+def test_cli_handler_wires_on_progress_to_stderr(monkeypatch, capsys):
+    """The CLI handler must pass a stderr-printing callback into
+    spanning_pmhc_set.  Verify callback messages land on stderr (not
+    stdout) and that the DataFrame itself still serializes to stdout."""
+    import argparse
+
+    from tsarina import cli_spanning
+
+    captured_kwargs: dict = {}
+
+    def _fake_spanning(*args, **kwargs):
+        captured_kwargs.update(kwargs)
+        if kwargs.get("on_progress"):
+            kwargs["on_progress"]("fake-progress-message")
+        return pd.DataFrame({"cta": ["MAGEA4"], "HLA-A*02:01": ["PEPTIDE9"]})
+
+    monkeypatch.setattr("tsarina.spanning.spanning_pmhc_set", _fake_spanning)
+
+    args = argparse.Namespace(
+        cta_count=25,
+        cta_rank_by="ms_cancer_peptide_count",
+        ctas=None,
+        min_restriction_confidence=["HIGH", "MODERATE"],
+        restriction_levels=None,
+        alleles=None,
+        panel="iedb27_ab",
+        lengths=(9,),
+        ensembl_release=112,
+        require_cta_exclusive=True,
+        predictor="mhcflurry",
+        max_percentile=2.0,
+        format="wide",
+        output=None,
+    )
+    cli_spanning.handle(args)
+
+    assert "on_progress" in captured_kwargs
+    assert callable(captured_kwargs["on_progress"])
+
+    captured = capsys.readouterr()
+    assert "fake-progress-message" in captured.err
+    assert "fake-progress-message" not in captured.out
+    assert "MAGEA4" in captured.out  # DataFrame serialized to stdout
+
+
 def test_size_within_target_envelope_for_default_args(monkeypatch):
     """The headline use case: defaults (25 CTAs x 27 alleles, max 2%)
     should produce a wide table whose count of filled cells is in the

--- a/tsarina/cli_spanning.py
+++ b/tsarina/cli_spanning.py
@@ -167,6 +167,9 @@ def handle(args: argparse.Namespace) -> None:
     else:
         min_restriction_confidence = tuple(v.upper() for v in args.min_restriction_confidence)
 
+    def _on_progress(msg: str) -> None:
+        print(msg, file=sys.stderr)
+
     df = spanning_pmhc_set(
         cta_count=args.cta_count,
         cta_rank_by=args.cta_rank_by,
@@ -181,6 +184,7 @@ def handle(args: argparse.Namespace) -> None:
         predictor=args.predictor,
         max_percentile=args.max_percentile,
         output_format=args.format,
+        on_progress=_on_progress,
     )
 
     if args.output:

--- a/tsarina/spanning.py
+++ b/tsarina/spanning.py
@@ -35,7 +35,8 @@ Typical usage::
 
 from __future__ import annotations
 
-from collections.abc import Iterable
+import time
+from collections.abc import Callable, Iterable
 
 import pandas as pd
 
@@ -66,6 +67,7 @@ def spanning_pmhc_set(
     predictor: str = "mhcflurry",
     max_percentile: float = 2.0,
     output_format: str = "wide",
+    on_progress: Callable[[str], None] | None = None,
 ) -> pd.DataFrame:
     """Build a CTA x HLA spanning pMHC table.
 
@@ -119,6 +121,14 @@ def spanning_pmhc_set(
         the chosen peptide as the cell value.
         ``"long"`` — one row per filled cell with peptide, length,
         percentile, score, and affinity columns.
+    on_progress
+        Optional callable invoked with a human-readable status string at
+        each pipeline stage (pre-scoring, post-scoring with elapsed
+        seconds, post-pivot summary).  Used by the CLI handler to emit
+        stderr progress lines on multi-minute runs; library callers
+        leave it ``None`` (default) for silent operation.  The library
+        itself never prints — it only formats messages and hands them
+        to the callback.
 
     Returns
     -------
@@ -161,9 +171,27 @@ def spanning_pmhc_set(
     from .scoring import score_presentation
 
     unique_peptides = pep_df["peptide"].unique().tolist()
+    n_predictions = len(unique_peptides) * len(allele_list)
+    if on_progress is not None:
+        on_progress(
+            f"Scoring {len(unique_peptides)} peptides x {len(allele_list)} alleles "
+            f"(~{n_predictions} predictions) via {predictor}..."
+        )
+
+    scoring_start = time.perf_counter()
     scores = score_presentation(peptides=unique_peptides, alleles=allele_list, predictor=predictor)
+    scoring_elapsed = time.perf_counter() - scoring_start
+
+    if on_progress is not None:
+        on_progress(f"Scored {n_predictions} predictions in {scoring_elapsed:.1f}s")
 
     best = _best_per_cell(scores, pep_df, max_percentile)
+
+    if on_progress is not None:
+        on_progress(
+            f"Spanning set: {len(cta_list)} CTAs x {len(allele_list)} alleles, "
+            f"{len(best)} filled cells at percentile <= {max_percentile}"
+        )
 
     if output_format == "wide":
         return _to_wide(best, cta_list, allele_list)

--- a/tsarina/version.py
+++ b/tsarina/version.py
@@ -10,4 +10,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "1.0.2"
+__version__ = "1.0.3"


### PR DESCRIPTION
Closes #24.

## What

Multi-minute \`tsarina spanning\` runs now emit progress messages on stderr instead of going silent during the ~340k-prediction scoring phase. Library stays quiet by default (opt-in via \`on_progress\` callback); CLI wires the stderr printer.

## Library (\`tsarina.spanning.spanning_pmhc_set\`)

New \`on_progress: Callable[[str], None] | None = None\` kwarg. Library formats human-readable strings and hands them to the callback — never prints directly.

Three callpoints:

- **Pre-scoring**: \`\"Scoring {N} peptides x {M} alleles (~{P} predictions) via {predictor}...\"\`
- **Post-scoring**: \`\"Scored {P} predictions in {elapsed:.1f}s\"\`
- **Post-pivot summary**: \`\"Spanning set: {C} CTAs x {M} alleles, {F} filled cells at percentile <= {max_percentile}\"\`

## CLI (\`tsarina.cli_spanning.handle\`)

Passes \`on_progress=lambda msg: print(msg, file=sys.stderr)\`. Stdout remains reserved for the CSV payload so downstream pipes / redirection aren't polluted.

## Test plan

- [x] 5 new tests in \`tests/test_spanning.py\`:
  - Default \`on_progress=None\` silent path
  - Callback receives exactly 3 messages in order
  - Pre-scoring message has accurate peptide × allele × prediction counts
  - Summary message's filled-cell count matches the output length
  - CLI handler wires the callback to stderr while keeping the DataFrame on stdout (\`capsys\` capture)
- [x] \`./format.sh\` clean
- [x] \`./lint.sh\` clean
- [x] \`./test.sh\` — 198 passed (was 193; +5 new)

## Note

Stacked behind PR #26 (spanning test polish) on the same underlying feature area. This PR was branched from main before #26 landed, so if #26 merges first, rebasing is trivial (no overlapping hunks).