### PR TITLE
v1.0.4: refs CLI smoke + merge-path coverage

### DIFF
--- a/tests/test_cli_hits.py
+++ b/tests/test_cli_hits.py
@@ -37,6 +37,26 @@ def test_hits_help_describes_include_binding_assays_union():
     assert "evidence_kind" in r.stdout
 
 
+def test_hits_format_refs_is_listed_as_choice():
+    """The argparse ``--format`` help text should advertise ``refs`` as
+    a valid choice alongside the older peptides / pmhc / raw options."""
+    r = _run_cli("hits", "--help")
+    assert r.returncode == 0
+    # argparse renders choices inline with the flag, e.g. "{peptides,pmhc,refs,raw}"
+    assert "refs" in r.stdout
+    # Sibling options should still be advertised
+    assert "peptides" in r.stdout
+    assert "pmhc" in r.stdout
+
+
+def test_hits_format_refs_rejects_unknown_value():
+    r = _run_cli("hits", "--gene", "PRAME", "--format", "not-a-format", check=False)
+    assert r.returncode != 0
+    combined = r.stderr + r.stdout
+    # argparse error message surfaces the valid choices on invalid input
+    assert "refs" in combined and "peptides" in combined
+
+
 def test_hits_requires_gene_or_uniprot():
     r = _run_cli("hits", check=False)
     assert r.returncode != 0

--- a/tests/test_cli_hits_refs.py
+++ b/tests/test_cli_hits_refs.py
@@ -64,3 +64,135 @@ def test_hitlist_aggregator_produces_ms_pmhc_prefixed_columns():
     assert row["ms_pmhc_pmids"] == "27869121;38000001"
     assert bool(row["ms_pmhc_in_cancer"]) is True
     assert int(row["ms_pmhc_mono_hit_count"]) == 1
+
+
+# ── Handler merge-path coverage ────────────────────────────────────────
+
+
+def test_refs_handler_merges_gene_ident_cols_from_cached_path(tmp_path):
+    """When the cached-observations fast path returns rows with
+    ``gene_names`` / ``gene_ids`` / ``protein_ids`` columns, the refs
+    branch of cli_hits.handle() must join those identity columns onto
+    the aggregator output so output shape stays consistent with the
+    raw-CSV override path."""
+    import argparse
+    from unittest.mock import patch
+
+    import pandas as pd
+
+    from tsarina import cli_hits
+
+    hits_frame = pd.DataFrame(
+        {
+            "peptide": ["QYIAQFTSQF", "LYVDSLFFL"],
+            "mhc_restriction": ["HLA-A*24:02", "HLA-A*24:02"],
+            "gene_names": ["PRAME", "PRAME"],
+            "gene_ids": ["ENSG00000185686", "ENSG00000185686"],
+            "protein_ids": ["ENST00000405655", "ENST00000405655"],
+            "pmid": [27869121, 33858848],
+            "source_tissue": ["Lymph Node", "Thymus"],
+            "disease": ["skin melanoma", ""],
+            "cell_line_name": ["", ""],
+            "src_cancer": [True, False],
+            "src_healthy_tissue": [False, False],
+            "is_monoallelic": [False, False],
+        }
+    )
+
+    output_csv = tmp_path / "refs.csv"
+    args = argparse.Namespace(
+        gene="PRAME",
+        uniprot=None,
+        allele=[],
+        serotype=[],
+        species="Homo sapiens",
+        mhc_class="I",
+        min_resolution=None,
+        lengths=(8, 9, 10, 11),
+        ensembl_release=112,
+        include_binding_assays=False,
+        mono_allelic_only=False,
+        format="refs",
+        predict=False,
+        predictor="mhcflurry",
+        iedb_path=None,
+        cedar_path=None,
+        skip_ms_evidence=False,
+        output=str(output_csv),
+    )
+    with (
+        patch("tsarina.indexing.ensure_index_built"),
+        patch("hitlist.observations.load_observations", return_value=hits_frame),
+    ):
+        cli_hits.handle(args)
+
+    out = pd.read_csv(output_csv)
+    # Gene-ident columns from the cached path must be merged onto the refs output.
+    for col in ("gene_names", "gene_ids", "protein_ids"):
+        assert col in out.columns, f"gene_ident_cols merge dropped {col}"
+    # Aggregator output shape should also be intact alongside the idents.
+    assert "ms_pmhc_hit_count" in out.columns
+    assert set(out["peptide"]) == {"QYIAQFTSQF", "LYVDSLFFL"}
+    # Each peptide's gene identity should survive the merge without duplication.
+    assert all(out["gene_names"] == "PRAME")
+
+
+def test_refs_handler_passes_through_when_no_gene_ident_cols(tmp_path):
+    """When the scan result lacks gene_names / gene_ids / protein_ids
+    (e.g. raw-scan override path without the enumeration frame), the
+    refs branch should still produce the aggregator output rather than
+    erroring or dropping rows."""
+    import argparse
+    from unittest.mock import patch
+
+    import pandas as pd
+
+    from tsarina import cli_hits
+
+    hits_frame = pd.DataFrame(
+        {
+            "peptide": ["QYIAQFTSQF"],
+            "mhc_restriction": ["HLA-A*24:02"],
+            "pmid": [27869121],
+            "source_tissue": ["Lymph Node"],
+            "disease": ["skin melanoma"],
+            "cell_line_name": [""],
+            "src_cancer": [True],
+            "src_healthy_tissue": [False],
+            "is_monoallelic": [False],
+        }
+    )
+
+    output_csv = tmp_path / "refs.csv"
+    args = argparse.Namespace(
+        gene="PRAME",
+        uniprot=None,
+        allele=[],
+        serotype=[],
+        species="Homo sapiens",
+        mhc_class="I",
+        min_resolution=None,
+        lengths=(8, 9, 10, 11),
+        ensembl_release=112,
+        include_binding_assays=False,
+        mono_allelic_only=False,
+        format="refs",
+        predict=False,
+        predictor="mhcflurry",
+        iedb_path=None,
+        cedar_path=None,
+        skip_ms_evidence=False,
+        output=str(output_csv),
+    )
+    with (
+        patch("tsarina.indexing.ensure_index_built"),
+        patch("hitlist.observations.load_observations", return_value=hits_frame),
+    ):
+        cli_hits.handle(args)
+
+    out = pd.read_csv(output_csv)
+    # Output has the aggregator columns but no gene_ident_cols since
+    # the input didn't provide them.
+    assert "ms_pmhc_hit_count" in out.columns
+    assert "gene_names" not in out.columns
+    assert list(out["peptide"]) == ["QYIAQFTSQF"]

--- a/tsarina/version.py
+++ b/tsarina/version.py
@@ -10,4 +10,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "1.0.3"
+__version__ = "1.0.4"


### PR DESCRIPTION
Closes #14 + closes #20.

## What

Tightens \`tsarina hits --format refs\` test coverage without touching production code. No behavior change.

**\`tests/test_cli_hits.py\` (+2 tests)**

- \`test_hits_format_refs_is_listed_as_choice\` — argparse \`--help\` advertises \`refs\` alongside the older \`peptides\` / \`pmhc\` / \`raw\` options.
- \`test_hits_format_refs_rejects_unknown_value\` — a bogus \`--format\` value is rejected with exit code != 0 and the error surfaces the valid choices.

**\`tests/test_cli_hits_refs.py\` (+2 tests)**

- \`test_refs_handler_merges_gene_ident_cols_from_cached_path\` — when the cached-observations fast path returns hits with \`gene_names\` / \`gene_ids\` / \`protein_ids\` columns, the handler's refs branch must join those identity columns onto the aggregator output. Patches \`load_observations\` with a PRAME frame that carries the ident columns; asserts they survive into the final CSV.
- \`test_refs_handler_passes_through_when_no_gene_ident_cols\` — raw-scan override path (no ident columns in the hits frame) still produces valid aggregator output.

## Why close #20 too

#20 asked for integration tests proving \`cta_exclusive_peptides\` / \`human_exclusive_viral_peptides\` hit the cached helpers on repeat calls. The v1.0.1 k-mer unification PR (#25) already added these to \`tests/test_kmer_caching.py\`:

- \`test_cta_exclusive_peptides_hits_cache_on_repeat\`
- \`test_human_exclusive_viral_peptides_hits_cache_on_repeat\`
- \`test_cancer_specific_viral_peptides_hits_cache_on_repeat\` (bonus — wasn't asked for but is also there)

Plus \`test_cta_and_non_cta_share_proteome_kmers_cache\` which verifies cross-function cache sharing, which goes further than the original issue. So closing #20 as done-by-other-work.

## Test plan

- [x] 4 new tests all green
- [x] \`./format.sh\` clean
- [x] \`./lint.sh\` clean
- [x] \`./test.sh\` — 197 passed (was 193; +4 new)

## Note on stacking

PRs #26 (spanning test polish) and #27 (spanning progress) are in flight on the same 1.0.1 base. This PR is branched from 1.0.1 as well; if the others merge first, rebasing is trivial — no overlapping hunks. Version numbers (1.0.2 / 1.0.3 / 1.0.4) are non-colliding.