### PR TITLE
v1.1.0: delegate proteome k-mer walk to hitlist.proteome.proteome_kmer_set

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
 ]
 requires-python = ">=3.9"
 dependencies = [
-    "hitlist>=1.12.1",
+    "hitlist>=1.14.2",
     "mhcgnomes>=3.20.0",
     "pandas",
     "numpy",

--- a/tests/test_kmer_caching.py
+++ b/tests/test_kmer_caching.py
@@ -10,73 +10,30 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Tests for the unified k-mer enumeration primitive (tsarina#12 + #19).
+"""Tests for tsarina's delegation to ``hitlist.proteome.proteome_kmer_set``.
 
-``peptides._proteome_kmers(release, lengths, gene_ids)`` walks protein-
-coding transcripts in an Ensembl release and produces a ``frozenset`` of
-every k-mer at the requested lengths within the gene subset.  The walk
-is ~10-60s, so the helper is ``@lru_cache``'d on
-``(release, lengths, gene_ids)``.
+As of v1.1.0 the proteome-walk primitive lives in hitlist (shipped in
+hitlist 1.14.2).  Tsarina owns only:
 
-These tests exercise:
+1. The tsarina-specific CTA / non-CTA gene-ID partition frozensets
+   (``_non_cta_gene_ids`` / ``_cta_gene_ids``) — memoized wrappers
+   around :func:`tsarina.partition.CTA_partition_gene_ids`.
+2. Thin call-site glue in ``cta_exclusive_peptides`` /
+   ``human_exclusive_viral_peptides`` / ``cancer_specific_viral_peptides``
+   that invokes the hitlist primitive with the right gene filter.
 
-1. The unified ``_proteome_kmers`` primitive directly — cache behavior,
-   gene-subset respect, full-proteome path (``gene_ids=None``).
-2. The thin frozenset wrappers (``_non_cta_gene_ids`` /
-   ``_cta_gene_ids``) that memoize the partition-derived sets.
-3. End-to-end caching through the public callers
-   (``cta_exclusive_peptides``, ``human_exclusive_viral_peptides``,
-   ``cancer_specific_viral_peptides``).
-
-A stubbed ``EnsemblRelease`` tracks ``.genes()`` / ``.gene_by_id()``
-call counts so we can assert cache hits vs traversal without pulling
-real Ensembl data.
+These tests exercise the partition memoization and pin down the
+dispatch contract (hitlist gets the right ``gene_ids`` frozenset per
+caller).  The proteome walk itself is tested in hitlist's own test
+suite — tsarina doesn't re-test the primitive.
 """
 
 from __future__ import annotations
 
+import pandas as pd
 import pytest
 
 from tsarina import peptides, viral
-
-
-class _FakeTranscript:
-    def __init__(self, seq: str, biotype: str = "protein_coding"):
-        self.protein_sequence = seq
-        self.biotype = biotype
-
-
-class _FakeGene:
-    def __init__(self, gene_id: str, seq: str, biotype: str = "protein_coding"):
-        self.gene_id = gene_id
-        self.biotype = biotype
-        self.transcripts = [_FakeTranscript(seq, biotype)]
-
-
-class _FakeEnsembl:
-    """Records how many times .genes() and .gene_by_id() are invoked."""
-
-    call_counts: dict[str, int] = {"genes": 0, "gene_by_id": 0}
-
-    def __init__(self, release: int):
-        self.release = release
-        # Fake universe: a handful of "protein" sequences long enough to
-        # yield several k-mers at length 8.
-        self._genes_by_id = {
-            "ENSG_A": _FakeGene("ENSG_A", "MAAAAAAAAA"),
-            "ENSG_B": _FakeGene("ENSG_B", "MCCCCCCCCC"),
-            "ENSG_C": _FakeGene("ENSG_C", "MDDDDDDDDD"),
-        }
-
-    def genes(self):
-        type(self).call_counts["genes"] += 1
-        return list(self._genes_by_id.values())
-
-    def gene_by_id(self, gene_id: str):
-        type(self).call_counts["gene_by_id"] += 1
-        if gene_id not in self._genes_by_id:
-            raise ValueError(gene_id)
-        return self._genes_by_id[gene_id]
 
 
 class _FakePartition:
@@ -85,73 +42,14 @@ class _FakePartition:
 
 
 @pytest.fixture(autouse=True)
-def _reset_caches_and_counts(monkeypatch):
-    peptides._proteome_kmers.cache_clear()
+def _reset_partition_caches(monkeypatch):
     peptides._non_cta_gene_ids.cache_clear()
     peptides._cta_gene_ids.cache_clear()
-    _FakeEnsembl.call_counts = {"genes": 0, "gene_by_id": 0}
-    monkeypatch.setattr("pyensembl.EnsemblRelease", _FakeEnsembl)
     monkeypatch.setattr("tsarina.partition.CTA_partition_gene_ids", lambda r: _FakePartition())
     yield
 
 
-# ── _proteome_kmers primitive ──────────────────────────────────────────
-
-
-def test_proteome_kmers_is_lru_cached():
-    assert hasattr(peptides._proteome_kmers, "cache_info")
-    assert hasattr(peptides._proteome_kmers, "cache_clear")
-
-
-def test_proteome_kmers_full_proteome_uses_genes_iteration():
-    """gene_ids=None walks every gene via ensembl.genes() rather than
-    looking up IDs one-by-one."""
-    result = peptides._proteome_kmers(112, (8,), None)
-    assert isinstance(result, frozenset)
-    assert _FakeEnsembl.call_counts["genes"] == 1
-    assert _FakeEnsembl.call_counts["gene_by_id"] == 0
-    # All three fake genes are protein_coding → all appear.
-    assert "MAAAAAAA" in result
-    assert "MCCCCCCC" in result
-    assert "MDDDDDDD" in result
-
-
-def test_proteome_kmers_gene_subset_uses_gene_by_id():
-    """A supplied gene_ids frozenset goes through gene_by_id()."""
-    result = peptides._proteome_kmers(112, (8,), frozenset({"ENSG_B", "ENSG_C"}))
-    assert "MCCCCCCC" in result
-    assert "MDDDDDDD" in result
-    assert "MAAAAAAA" not in result  # ENSG_A excluded by filter
-    assert _FakeEnsembl.call_counts["genes"] == 0
-    assert _FakeEnsembl.call_counts["gene_by_id"] == 2
-
-
-def test_proteome_kmers_caches_by_gene_ids():
-    """Same (release, lengths) with different gene_ids keys must produce
-    separate cache entries; repeat lookups are cache hits."""
-    peptides._proteome_kmers(112, (8,), frozenset({"ENSG_B"}))
-    peptides._proteome_kmers(112, (8,), frozenset({"ENSG_C"}))
-    info_after_two_distinct = peptides._proteome_kmers.cache_info()
-    assert info_after_two_distinct.misses == 2
-    assert info_after_two_distinct.hits == 0
-
-    # Repeat — both should hit the cache
-    peptides._proteome_kmers(112, (8,), frozenset({"ENSG_B"}))
-    peptides._proteome_kmers(112, (8,), frozenset({"ENSG_C"}))
-    info_after_repeat = peptides._proteome_kmers.cache_info()
-    assert info_after_repeat.misses == 2
-    assert info_after_repeat.hits == 2
-
-
-def test_proteome_kmers_caches_by_lengths():
-    peptides._proteome_kmers(112, (8,), None)
-    peptides._proteome_kmers(112, (9,), None)
-    info = peptides._proteome_kmers.cache_info()
-    assert info.misses == 2
-    assert info.hits == 0
-
-
-# ── Gene-ID frozenset wrappers ─────────────────────────────────────────
+# ── Gene-ID partition frozenset wrappers ───────────────────────────────
 
 
 def test_non_cta_gene_ids_returns_frozenset_of_non_cta_partition():
@@ -166,117 +64,165 @@ def test_cta_gene_ids_returns_frozenset_of_cta_partition():
     assert result == frozenset({"ENSG_A"})
 
 
-def test_gene_id_wrappers_cache_per_release():
-    """Calling the wrapper twice with the same release returns the same
-    frozenset instance — so downstream _proteome_kmers lookups reuse
-    the cached hash rather than rebuilding."""
+def test_gene_id_wrappers_memoize_per_release():
+    """Same release returns the same frozenset instance — avoids
+    rebuilding the partition frozenset on every call."""
+    assert peptides._non_cta_gene_ids(112) is peptides._non_cta_gene_ids(112)
+    assert peptides._cta_gene_ids(112) is peptides._cta_gene_ids(112)
+
+
+def test_gene_id_wrappers_separate_entries_per_release():
+    """Different release → recompute (separate cache key)."""
     r1 = peptides._non_cta_gene_ids(112)
-    r2 = peptides._non_cta_gene_ids(112)
-    assert r1 is r2
+    r2 = peptides._non_cta_gene_ids(113)
+    # Both frozensets should exist and match the stub (same content, but
+    # distinct cache entries keyed on release).
+    info = peptides._non_cta_gene_ids.cache_info()
+    assert info.misses == 2
+    assert r1 == r2  # stub ignores release; values are equal
 
 
-# ── End-to-end caching through public callers ──────────────────────────
+# ── Dispatch to hitlist.proteome.proteome_kmer_set ────────────────────
 
 
-def test_cta_exclusive_peptides_hits_cache_on_repeat(monkeypatch):
-    """The public wrapper must dispatch through _proteome_kmers — second
-    call with the same args does NOT re-walk the proteome."""
-    import pandas as pd
+def test_cta_exclusive_peptides_delegates_to_hitlist_with_non_cta_gene_ids(monkeypatch):
+    """cta_exclusive_peptides must call hitlist.proteome.proteome_kmer_set
+    with gene_ids=_non_cta_gene_ids(release), not rebuild the walk
+    locally."""
+    calls: list[dict] = []
 
+    def _spy(release, lengths, gene_ids=None, **kw):
+        calls.append({"release": release, "lengths": lengths, "gene_ids": gene_ids})
+        return frozenset({"UNWANTEDK"})
+
+    monkeypatch.setattr("hitlist.proteome.proteome_kmer_set", _spy, raising=True)
     monkeypatch.setattr(
         "tsarina.peptides.cta_peptides",
         lambda **kw: pd.DataFrame(
             {
-                "peptide": ["MAAAAAAA", "NEVERSEEN"],
-                "length": [8, 8],
-                "gene_name": ["G1", "G1"],
-                "gene_id": ["X", "X"],
+                "peptide": ["GOODPEPTI", "UNWANTEDK"],
+                "length": [9, 9],
+                "gene_name": ["MAGEA4", "MAGEA4"],
+                "gene_id": ["E1", "E1"],
             }
         ),
         raising=True,
     )
-    peptides.cta_exclusive_peptides(ensembl_release=112, lengths=(8,))
-    gene_by_id_after_first = _FakeEnsembl.call_counts["gene_by_id"]
-    peptides.cta_exclusive_peptides(ensembl_release=112, lengths=(8,))
-    assert _FakeEnsembl.call_counts["gene_by_id"] == gene_by_id_after_first
+
+    out = peptides.cta_exclusive_peptides(ensembl_release=112, lengths=(9,))
+
+    assert len(calls) == 1
+    assert calls[0]["release"] == 112
+    assert calls[0]["lengths"] == (9,)
+    assert calls[0]["gene_ids"] == frozenset({"ENSG_B", "ENSG_C"})
+    # The peptide that appeared in the hitlist-returned background set
+    # must be filtered out.
+    assert list(out["peptide"]) == ["GOODPEPTI"]
 
 
-def test_human_exclusive_viral_peptides_hits_cache_on_repeat(monkeypatch):
-    import pandas as pd
+def test_human_exclusive_viral_peptides_delegates_with_none_gene_ids(monkeypatch):
+    """The full-proteome call passes gene_ids=None so hitlist iterates
+    every protein-coding gene rather than a subset."""
+    calls: list[dict] = []
 
+    def _spy(release, lengths, gene_ids=None, **kw):
+        calls.append({"release": release, "lengths": lengths, "gene_ids": gene_ids})
+        return frozenset({"HUMANSELF"})
+
+    monkeypatch.setattr("hitlist.proteome.proteome_kmer_set", _spy, raising=True)
     monkeypatch.setattr(
         "tsarina.viral.viral_peptides",
         lambda **kw: pd.DataFrame(
             {
-                "peptide": ["VIRALMER", "MAAAAAAA"],
-                "length": [8, 8],
+                "peptide": ["VIRALONLY", "HUMANSELF"],
+                "length": [9, 9],
                 "virus": ["test", "test"],
                 "protein_id": ["P1", "P1"],
             }
         ),
         raising=True,
     )
-    viral.human_exclusive_viral_peptides(virus="test", lengths=(8,), ensembl_release=112)
-    genes_after_first = _FakeEnsembl.call_counts["genes"]
-    viral.human_exclusive_viral_peptides(virus="test", lengths=(8,), ensembl_release=112)
-    assert _FakeEnsembl.call_counts["genes"] == genes_after_first
+
+    out = viral.human_exclusive_viral_peptides(virus="test", lengths=(9,), ensembl_release=112)
+
+    assert len(calls) == 1
+    assert calls[0]["gene_ids"] is None
+    assert calls[0]["release"] == 112
+    assert calls[0]["lengths"] == (9,)
+    assert list(out["peptide"]) == ["VIRALONLY"]
 
 
-def test_cancer_specific_viral_peptides_hits_cache_on_repeat(monkeypatch):
-    """PR D headline: cancer_specific_viral_peptides now shares the
-    cached _proteome_kmers primitive instead of walking the proteome
-    on every call."""
-    import pandas as pd
+def test_cancer_specific_viral_peptides_delegates_twice_non_cta_and_cta(monkeypatch):
+    """cancer_specific_viral_peptides subtracts non-CTA k-mers AND
+    annotates in-CTA-protein membership.  It must call the hitlist
+    primitive twice — once per partition — with the right gene_ids
+    each time."""
+    calls: list[dict] = []
 
+    def _spy(release, lengths, gene_ids=None, **kw):
+        calls.append({"release": release, "lengths": lengths, "gene_ids": gene_ids})
+        if gene_ids == frozenset({"ENSG_B", "ENSG_C"}):  # non-CTA
+            return frozenset({"HUMANNCTA"})
+        if gene_ids == frozenset({"ENSG_A"}):  # CTA
+            return frozenset({"SHAREDCTA"})
+        return frozenset()
+
+    monkeypatch.setattr("hitlist.proteome.proteome_kmer_set", _spy, raising=True)
     monkeypatch.setattr(
         "tsarina.viral.viral_peptides",
         lambda **kw: pd.DataFrame(
             {
-                "peptide": ["VIRALMER", "MAAAAAAA", "MCCCCCCC"],
-                "length": [8, 8, 8],
+                "peptide": ["UNIQUEVIR", "HUMANNCTA", "SHAREDCTA"],
+                "length": [9, 9, 9],
                 "virus": ["test", "test", "test"],
                 "protein_id": ["P1", "P1", "P1"],
             }
         ),
         raising=True,
     )
-    result_1 = viral.cancer_specific_viral_peptides(virus="test", lengths=(8,), ensembl_release=112)
-    gene_by_id_after_first = _FakeEnsembl.call_counts["gene_by_id"]
-    assert gene_by_id_after_first > 0  # first call did real work
 
-    result_2 = viral.cancer_specific_viral_peptides(virus="test", lengths=(8,), ensembl_release=112)
-    # Second call hits the cache — no additional gene_by_id lookups
-    assert _FakeEnsembl.call_counts["gene_by_id"] == gene_by_id_after_first
+    out = viral.cancer_specific_viral_peptides(virus="test", lengths=(9,), ensembl_release=112)
 
-    # Functional equivalence between the two calls
-    assert list(result_1["peptide"]) == list(result_2["peptide"])
-    # in_cta_protein flag set correctly: MAAAAAAA comes from ENSG_A (CTA),
-    # VIRALMER is viral-only, MCCCCCCC comes from ENSG_B (non-CTA → dropped
-    # by the noncta subtraction).
-    kept = set(result_1["peptide"])
-    assert "VIRALMER" in kept
-    assert "MAAAAAAA" in kept  # in CTA proteins, not in non-CTA — kept
-    assert "MCCCCCCC" not in kept  # in non-CTA proteins — filtered
-    maaaaaaa_row = result_1[result_1["peptide"] == "MAAAAAAA"].iloc[0]
-    assert bool(maaaaaaa_row["in_cta_protein"]) is True
-    viralmer_row = result_1[result_1["peptide"] == "VIRALMER"].iloc[0]
-    assert bool(viralmer_row["in_cta_protein"]) is False
+    # Two calls — one per partition
+    assert len(calls) == 2
+    gene_ids_passed = {c["gene_ids"] for c in calls}
+    assert gene_ids_passed == {
+        frozenset({"ENSG_B", "ENSG_C"}),
+        frozenset({"ENSG_A"}),
+    }
+
+    # HUMANNCTA dropped (in non-CTA); UNIQUEVIR and SHAREDCTA kept
+    kept = set(out["peptide"])
+    assert "HUMANNCTA" not in kept
+    assert "UNIQUEVIR" in kept
+    assert "SHAREDCTA" in kept
+    # in_cta_protein flag correctly set
+    shared_row = out[out["peptide"] == "SHAREDCTA"].iloc[0]
+    unique_row = out[out["peptide"] == "UNIQUEVIR"].iloc[0]
+    assert bool(shared_row["in_cta_protein"]) is True
+    assert bool(unique_row["in_cta_protein"]) is False
 
 
-def test_cta_and_non_cta_share_proteome_kmers_cache(monkeypatch):
-    """cta_exclusive_peptides and cancer_specific_viral_peptides both
-    query _proteome_kmers(non_cta). The second function should hit the
-    cache populated by the first — no re-walk across functions."""
-    import pandas as pd
+def test_non_cta_gene_ids_frozenset_is_reused_across_callers(monkeypatch):
+    """Both cta_exclusive_peptides and cancer_specific_viral_peptides
+    query the non-CTA partition.  They should pass the SAME frozenset
+    instance so hitlist's cache keying is stable across callers."""
+    received_gene_ids: list[frozenset] = []
 
+    def _spy(release, lengths, gene_ids=None, **kw):
+        if gene_ids is not None and gene_ids == frozenset({"ENSG_B", "ENSG_C"}):
+            received_gene_ids.append(gene_ids)
+        return frozenset()
+
+    monkeypatch.setattr("hitlist.proteome.proteome_kmer_set", _spy, raising=True)
     monkeypatch.setattr(
         "tsarina.peptides.cta_peptides",
         lambda **kw: pd.DataFrame(
             {
-                "peptide": ["MAAAAAAA"],
-                "length": [8],
-                "gene_name": ["G1"],
-                "gene_id": ["X"],
+                "peptide": ["X" * 9],
+                "length": [9],
+                "gene_name": ["MAGEA4"],
+                "gene_id": ["E1"],
             }
         ),
         raising=True,
@@ -285,19 +231,19 @@ def test_cta_and_non_cta_share_proteome_kmers_cache(monkeypatch):
         "tsarina.viral.viral_peptides",
         lambda **kw: pd.DataFrame(
             {
-                "peptide": ["VIRALMER"],
-                "length": [8],
+                "peptide": ["Y" * 9],
+                "length": [9],
                 "virus": ["test"],
                 "protein_id": ["P1"],
             }
         ),
         raising=True,
     )
-    peptides.cta_exclusive_peptides(ensembl_release=112, lengths=(8,))
-    calls_after_cta = _FakeEnsembl.call_counts["gene_by_id"]
-    viral.cancer_specific_viral_peptides(virus="test", lengths=(8,), ensembl_release=112)
-    # cancer_specific_viral_peptides additionally needs the CTA k-mer set,
-    # so it will do ONE new walk (for the CTA partition) — but NOT re-walk
-    # the non-CTA partition that cta_exclusive_peptides already cached.
-    # CTA partition has 1 gene (ENSG_A) → 1 additional gene_by_id call.
-    assert _FakeEnsembl.call_counts["gene_by_id"] == calls_after_cta + 1
+
+    peptides.cta_exclusive_peptides(ensembl_release=112, lengths=(9,))
+    viral.cancer_specific_viral_peptides(virus="test", lengths=(9,), ensembl_release=112)
+
+    assert len(received_gene_ids) == 2
+    # Both callers receive the SAME frozenset object (not just equal —
+    # identical), so hitlist's cache treats them as one lookup.
+    assert received_gene_ids[0] is received_gene_ids[1]

--- a/tsarina/peptides.py
+++ b/tsarina/peptides.py
@@ -37,101 +37,16 @@ AA20 = set("ACDEFGHIKLMNPQRSTVWY")
 DEFAULT_PEPTIDE_LENGTHS = (8, 9, 10, 11)
 
 
-@lru_cache(maxsize=8)
-def _proteome_kmers(
-    ensembl_release: int,
-    lengths: tuple[int, ...],
-    gene_ids: frozenset[str] | None = None,
-) -> frozenset[str]:
-    """Return every k-mer found in the requested subset of the Ensembl proteome.
-
-    Single cached primitive behind every tsarina function that needs to
-    subtract a self-peptide background — CTA exclusivity, viral human-
-    exclusivity, and viral cancer-specificity all call this with
-    different ``gene_ids`` filters.
-
-    Parameters
-    ----------
-    ensembl_release
-        Ensembl release (e.g. 112).
-    lengths
-        Peptide lengths to enumerate.
-    gene_ids
-        Frozenset of Ensembl gene IDs to restrict the walk to.  ``None``
-        (default) iterates every protein-coding gene in the release,
-        matching what a full-proteome background walk would produce.
-
-    Returns
-    -------
-    frozenset[str]
-        Unique k-mers at the requested lengths across the chosen gene
-        subset, with any non-AA20 residue stretches dropped.
-
-    Notes
-    -----
-    The walk is expensive (~10-60s depending on release + length mix +
-    gene subset size).  Result is ``@lru_cache``'d keyed on
-    ``(ensembl_release, lengths, gene_ids)``, so a second call with the
-    same arguments returns in sub-millisecond time.  Cache holds up to
-    8 combinations — enough for a handful of common partitions
-    (non-CTA, CTA, full proteome) across 1-2 releases.  Clear via
-    ``_proteome_kmers.cache_clear()``.
-
-    Long-term this primitive is a candidate to move upstream into
-    ``hitlist.proteome`` (tracked in hitlist#99) so sibling packages
-    can share a cross-package cache.  Call sites would collapse from
-    ``_proteome_kmers(r, l, gene_ids)`` to the one-line
-    ``hitlist.proteome_kmer_set(r, l, gene_ids=gene_ids)``.
-    """
-    from pyensembl import EnsemblRelease
-
-    ensembl = EnsemblRelease(ensembl_release)
-
-    if gene_ids is None:
-        genes = (g for g in ensembl.genes() if g.biotype == "protein_coding")
-    else:
-        genes = _genes_by_id(ensembl, gene_ids)
-
-    kmers: set[str] = set()
-    for gene in genes:
-        for t in gene.transcripts:
-            if t.biotype != "protein_coding":
-                continue
-            try:
-                seq = t.protein_sequence
-            except Exception:
-                continue
-            if not seq:
-                continue
-            for k in lengths:
-                for i in range(len(seq) - k + 1):
-                    pep = seq[i : i + k]
-                    if set(pep).issubset(AA20):
-                        kmers.add(pep)
-    return frozenset(kmers)
-
-
-def _genes_by_id(ensembl, gene_ids):
-    """Yield ``ensembl.gene_by_id`` results for each id, skipping those
-    that fail lookup or are non-protein-coding."""
-    for gene_id in gene_ids:
-        try:
-            gene = ensembl.gene_by_id(gene_id)
-        except ValueError:
-            continue
-        if gene.biotype != "protein_coding":
-            continue
-        yield gene
-
-
 @lru_cache(maxsize=4)
 def _non_cta_gene_ids(ensembl_release: int) -> frozenset[str]:
     """Cached frozenset of non-CTA Ensembl gene IDs for a release.
 
-    Pre-building the frozenset means downstream ``_proteome_kmers``
-    lookups reuse a single hashable instance rather than rebuilding
-    from the mutable ``CTA_partition_gene_ids(...).non_cta`` set on
-    every call.
+    Pre-building the frozenset means downstream
+    :func:`hitlist.proteome.proteome_kmer_set` calls reuse a single
+    hashable instance rather than rebuilding from the mutable
+    ``CTA_partition_gene_ids(...).non_cta`` set on every call.  The
+    CTA / non-CTA partition is tsarina-specific so it stays here; the
+    proteome walk itself is delegated to hitlist.
     """
     from .partition import CTA_partition_gene_ids
 
@@ -254,13 +169,19 @@ def cta_exclusive_peptides(
 
     Notes
     -----
-    The non-CTA k-mer set is computed once per ``(ensembl_release, lengths)``
-    via :func:`_proteome_kmers` and cached for the life of the process.
-    First call pays ~10-30s walking the non-CTA transcript set; subsequent
-    calls with the same inputs return in sub-millisecond time.
+    The non-CTA k-mer set is computed and cached by
+    :func:`hitlist.proteome.proteome_kmer_set`.  First call pays the
+    Ensembl walk once; subsequent calls with the same
+    ``(ensembl_release, lengths)`` return immediately.  The cache is
+    shared across any sibling pirl-unc package that calls the same
+    primitive in the same process.
     """
-    noncta_peptides = _proteome_kmers(
-        ensembl_release, tuple(lengths), _non_cta_gene_ids(ensembl_release)
+    from hitlist.proteome import proteome_kmer_set
+
+    noncta_peptides = proteome_kmer_set(
+        release=ensembl_release,
+        lengths=tuple(lengths),
+        gene_ids=_non_cta_gene_ids(ensembl_release),
     )
     cta_df = cta_peptides(ensembl_release=ensembl_release, lengths=lengths)
     mask = ~cta_df["peptide"].isin(noncta_peptides)

--- a/tsarina/version.py
+++ b/tsarina/version.py
@@ -10,4 +10,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "1.0.4"
+__version__ = "1.1.0"

--- a/tsarina/viral.py
+++ b/tsarina/viral.py
@@ -52,7 +52,7 @@ from pathlib import Path
 
 import pandas as pd
 
-from .peptides import AA20, _cta_gene_ids, _non_cta_gene_ids, _proteome_kmers
+from .peptides import AA20, _cta_gene_ids, _non_cta_gene_ids
 
 # ── Virus definitions ───────────────────────────────────────────────────────
 
@@ -274,15 +274,18 @@ def human_exclusive_viral_peptides(
     Notes
     -----
     The human k-mer set is computed once per
-    ``(ensembl_release, lengths)`` via :func:`tsarina.peptides._proteome_kmers`
-    and cached for the life of the process.  First call pays ~20-60s walking
-    every protein-coding transcript in the Ensembl release; subsequent
-    calls with the same inputs return in sub-millisecond time.
+    ``(ensembl_release, lengths)`` via
+    :func:`hitlist.proteome.proteome_kmer_set` and cached process-wide.
+    First call pays the Ensembl walk once; subsequent calls with the
+    same inputs return immediately.  The cache is shared across any
+    sibling pirl-unc package that calls the same primitive.
     """
+    from hitlist.proteome import proteome_kmer_set
+
     vdf = viral_peptides(virus=virus, fasta_path=fasta_path, proteins=proteins, lengths=lengths)
     if vdf.empty:
         return vdf
-    human_kmers = _proteome_kmers(ensembl_release, tuple(lengths), None)
+    human_kmers = proteome_kmer_set(release=ensembl_release, lengths=tuple(lengths), gene_ids=None)
     mask = ~vdf["peptide"].isin(human_kmers)
     return vdf[mask].reset_index(drop=True)
 
@@ -323,20 +326,26 @@ def cancer_specific_viral_peptides(
     Notes
     -----
     Both the CTA and non-CTA k-mer sets are computed via
-    :func:`tsarina.peptides._proteome_kmers` and cached for the life of
-    the process, shared with :func:`cta_exclusive_peptides` /
+    :func:`hitlist.proteome.proteome_kmer_set` and cached process-wide,
+    shared with :func:`cta_exclusive_peptides` /
     :func:`human_exclusive_viral_peptides` where their gene filters
     overlap.  First call pays the Ensembl walk; subsequent calls with
     the same ``(release, lengths)`` return in sub-millisecond time.
     """
+    from hitlist.proteome import proteome_kmer_set
+
     vdf = viral_peptides(virus=virus, fasta_path=fasta_path, proteins=proteins, lengths=lengths)
     if vdf.empty:
         vdf["in_cta_protein"] = pd.Series(dtype=bool)
         return vdf
 
     lengths_t = tuple(lengths)
-    noncta_kmers = _proteome_kmers(ensembl_release, lengths_t, _non_cta_gene_ids(ensembl_release))
-    cta_kmers = _proteome_kmers(ensembl_release, lengths_t, _cta_gene_ids(ensembl_release))
+    noncta_kmers = proteome_kmer_set(
+        release=ensembl_release, lengths=lengths_t, gene_ids=_non_cta_gene_ids(ensembl_release)
+    )
+    cta_kmers = proteome_kmer_set(
+        release=ensembl_release, lengths=lengths_t, gene_ids=_cta_gene_ids(ensembl_release)
+    )
 
     # Keep peptides NOT in non-CTA proteins; annotate which also occur in CTA proteins.
     mask = ~vdf["peptide"].isin(noncta_kmers)


### PR DESCRIPTION
Closes hitlist#99 (downstream side).

## What

The proteome-walk primitive tsarina has cached locally since v0.10.1 (unified under \`_proteome_kmers\` in v1.0.1) is now available upstream as \`hitlist.proteome.proteome_kmer_set\` — shipped in hitlist 1.14.2, live on PyPI. Collapse tsarina's local copy into a delegate so any sibling pirl-unc package calling the same primitive in the same process shares one in-process cache.

## Changes

- **\`pyproject.toml\`** — \`hitlist>=1.12.1\` → \`hitlist>=1.14.2\` (the version that first shipped \`proteome_kmer_set\`).
- **\`tsarina/peptides.py\`** — delete \`_proteome_kmers\` entirely. \`cta_exclusive_peptides\` now calls \`hitlist.proteome.proteome_kmer_set(release, lengths, gene_ids=_non_cta_gene_ids(release))\`.
- **\`tsarina/viral.py\`** — \`human_exclusive_viral_peptides\` calls hitlist with \`gene_ids=None\` (full proteome); \`cancer_specific_viral_peptides\` calls hitlist twice (non-CTA for subtraction, CTA for the \`in_cta_protein\` annotation).
- The tsarina-specific partition frozenset wrappers (\`_non_cta_gene_ids\` / \`_cta_gene_ids\`) **stay** — CTA / non-CTA is tsarina's concept; only the proteome walk itself goes upstream.

**No public API change. No output schema change.** Net −50 LOC in tsarina.

## Why

Before this PR: tsarina maintained its own \`@lru_cache\`'d proteome walk. A sibling package (perseus, topiary wrapper, notebook script) calling an equivalent primitive paid a second copy of the walk in memory. This was flagged from the start of the v0.10.1 caching work as the right long-term shape (see PR #18 / tsarina#12 / hitlist#99).

After this PR: hitlist owns the primitive; tsarina is strictly downstream. Cross-package callers that pass the same \`(release, lengths, gene_ids)\` get cache hits.

## Tests

Rewrote \`tests/test_kmer_caching.py\` around the delegation contract:

- Partition frozenset memoization (same release → same instance; different release → new entry).
- \`cta_exclusive_peptides\` delegates to hitlist with the right \`gene_ids=_non_cta_gene_ids(release)\`.
- \`human_exclusive_viral_peptides\` delegates with \`gene_ids=None\`.
- \`cancer_specific_viral_peptides\` delegates **twice** — once per partition — and sets \`in_cta_protein\` correctly.
- The non-CTA frozenset **instance is reused across callers** (identical, not just equal), so hitlist's cache treats cross-caller calls as one lookup rather than recomputing.

The proteome-walk primitive itself is tested in hitlist's own test suite — tsarina doesn't re-test the walk.

## Test plan

- [x] \`./format.sh\` clean
- [x] \`./lint.sh\` clean
- [x] \`./test.sh\` — 207 passed
- [x] Delegation unit tests exercise the hitlist call contract via monkeypatched \`hitlist.proteome.proteome_kmer_set\` with call-tracking spies

## Dependency bump

Users on \`hitlist<1.14.2\` will see pip refuse the upgrade. hitlist 1.14.2 (and 1.14.0+) also carries the memory-footprint reductions from hitlist PR #111 that make \`hitlist data build\` survive on 8-16 GB laptops — so anyone bumping tsarina picks up that fix as a bonus.