### PR TITLE
v1.2.0: bump hitlist pin to >=1.15.1; push --lengths through to cached loader path

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
 ]
 requires-python = ">=3.9"
 dependencies = [
-    "hitlist>=1.14.2",
+    "hitlist>=1.15.1",
     "mhcgnomes>=3.20.0",
     "pandas",
     "numpy",

--- a/tests/test_cli_hits.py
+++ b/tests/test_cli_hits.py
@@ -266,11 +266,46 @@ def test_cached_path_non_contiguous_lengths_exact_set_filter(tmp_path):
     assert got_lengths == {9, 11}
 
 
-def test_cached_path_omitted_lengths_skips_bounds_pushdown(tmp_path):
-    """When --lengths is omitted (args.lengths is None), the cached path
-    must NOT push length_min / length_max - otherwise an MHC-I-flavored
-    default would silently drop MHC-II rows for users who don't pass the
-    flag.  Preserves pre-v1.2.0 behavior for that invocation shape."""
+def test_cached_path_omitted_lengths_and_class_skips_bounds_pushdown(tmp_path):
+    """When neither --lengths nor --mhc-class is set, the cached path
+    must NOT push length_min / length_max.  Preserves "load everything"
+    semantics for unqualified queries so off-window rows aren't silently
+    dropped by an opinionated default."""
+    from tsarina import cli_hits
+
+    args = _base_cached_args(tmp_path, lengths=None, mhc_class=None)
+    empty = pd.DataFrame({"peptide": pd.Series(dtype=str), "mhc_restriction": pd.Series(dtype=str)})
+    with (
+        patch("tsarina.indexing.ensure_index_built"),
+        patch("hitlist.observations.load_observations", return_value=empty) as ms_only,
+    ):
+        cli_hits.handle(args)
+    kwargs = ms_only.call_args.kwargs
+    assert kwargs.get("length_min") is None
+    assert kwargs.get("length_max") is None
+
+
+def test_cached_path_class_I_derives_8_to_15_bounds(tmp_path):
+    """--mhc-class I without --lengths populates length bounds as 8-15
+    (wider than textbook 8-11 to catch phospho-extended class I ligands
+    hitlist actually curates).  Explicit --lengths would override."""
+    from tsarina import cli_hits
+
+    args = _base_cached_args(tmp_path, lengths=None, mhc_class="I")
+    empty = pd.DataFrame({"peptide": pd.Series(dtype=str), "mhc_restriction": pd.Series(dtype=str)})
+    with (
+        patch("tsarina.indexing.ensure_index_built"),
+        patch("hitlist.observations.load_observations", return_value=empty) as ms_only,
+    ):
+        cli_hits.handle(args)
+    kwargs = ms_only.call_args.kwargs
+    assert kwargs.get("length_min") == 8
+    assert kwargs.get("length_max") == 15
+
+
+def test_cached_path_class_II_derives_12_to_45_bounds(tmp_path):
+    """--mhc-class II without --lengths populates length bounds as 12-45
+    (wider than textbook 12-25 to accommodate long class II tails)."""
     from tsarina import cli_hits
 
     args = _base_cached_args(tmp_path, lengths=None, mhc_class="II")
@@ -281,5 +316,23 @@ def test_cached_path_omitted_lengths_skips_bounds_pushdown(tmp_path):
     ):
         cli_hits.handle(args)
     kwargs = ms_only.call_args.kwargs
-    assert kwargs.get("length_min") is None
-    assert kwargs.get("length_max") is None
+    assert kwargs.get("length_min") == 12
+    assert kwargs.get("length_max") == 45
+
+
+def test_cached_path_explicit_lengths_override_class_default(tmp_path):
+    """Explicit --lengths must win over the --mhc-class-derived default:
+    requesting --lengths 9,10 with --mhc-class I should push [9, 10],
+    not the class I default [8, 15]."""
+    from tsarina import cli_hits
+
+    args = _base_cached_args(tmp_path, lengths=(9, 10), mhc_class="I")
+    empty = pd.DataFrame({"peptide": pd.Series(dtype=str), "mhc_restriction": pd.Series(dtype=str)})
+    with (
+        patch("tsarina.indexing.ensure_index_built"),
+        patch("hitlist.observations.load_observations", return_value=empty) as ms_only,
+    ):
+        cli_hits.handle(args)
+    kwargs = ms_only.call_args.kwargs
+    assert kwargs.get("length_min") == 9
+    assert kwargs.get("length_max") == 10

--- a/tests/test_cli_hits.py
+++ b/tests/test_cli_hits.py
@@ -156,14 +156,14 @@ def test_default_cached_path_uses_load_observations_not_union(tmp_path):
     all_ev.assert_not_called()
 
 
-def _base_cached_args(tmp_path, lengths, *, include_binding_assays=False):
+def _base_cached_args(tmp_path, lengths, *, include_binding_assays=False, mhc_class="I"):
     return argparse.Namespace(
         gene="PRAME",
         uniprot=None,
         allele=[],
         serotype=[],
         species="Homo sapiens",
-        mhc_class="I",
+        mhc_class=mhc_class,
         min_resolution=None,
         lengths=lengths,
         ensembl_release=112,
@@ -200,10 +200,16 @@ def test_cached_path_pushes_length_bounds_to_load_observations(tmp_path):
 
 def test_cached_path_pushes_length_bounds_to_load_all_evidence(tmp_path):
     """Parity with load_observations: the union path must also forward
-    length_min/length_max derived from --lengths."""
+    length_min/length_max derived from --lengths.  Use an MHC-II window
+    so the class / length pairing matches realistic usage."""
     from tsarina import cli_hits
 
-    args = _base_cached_args(tmp_path, lengths=(12, 13, 14, 15), include_binding_assays=True)
+    args = _base_cached_args(
+        tmp_path,
+        lengths=(12, 13, 14, 15),
+        include_binding_assays=True,
+        mhc_class="II",
+    )
     empty = pd.DataFrame(
         {
             "peptide": pd.Series(dtype=str),
@@ -223,7 +229,9 @@ def test_cached_path_pushes_length_bounds_to_load_all_evidence(tmp_path):
 
 def test_cached_path_non_contiguous_lengths_exact_set_filter(tmp_path):
     """--lengths 9,11 (non-contiguous) pushes a [9, 11] bound to hitlist
-    but must post-filter to the exact set so 10-mers don't leak through."""
+    but must post-filter to the exact set so 10-mers don't leak through.
+    Verifies both the bound-forwarding and the post-filter independently
+    so a refactor that drops one and keeps the other still fails a test."""
     from tsarina import cli_hits
 
     args = _base_cached_args(tmp_path, lengths=(9, 11))
@@ -240,7 +248,7 @@ def test_cached_path_non_contiguous_lengths_exact_set_filter(tmp_path):
 
     with (
         patch("tsarina.indexing.ensure_index_built"),
-        patch("hitlist.observations.load_observations", return_value=hits),
+        patch("hitlist.observations.load_observations", return_value=hits) as ms_only,
         patch("tsarina.cli_hits._write", side_effect=_capture_write),
         patch(
             "hitlist.aggregate.aggregate_per_pmhc",
@@ -248,6 +256,30 @@ def test_cached_path_non_contiguous_lengths_exact_set_filter(tmp_path):
         ),
     ):
         cli_hits.handle(args)
+
+    kwargs = ms_only.call_args.kwargs
+    assert kwargs.get("length_min") == 9
+    assert kwargs.get("length_max") == 11
+
     out = captured["df"]
     got_lengths = {len(p) for p in out["peptide"]}
     assert got_lengths == {9, 11}
+
+
+def test_cached_path_omitted_lengths_skips_bounds_pushdown(tmp_path):
+    """When --lengths is omitted (args.lengths is None), the cached path
+    must NOT push length_min / length_max - otherwise an MHC-I-flavored
+    default would silently drop MHC-II rows for users who don't pass the
+    flag.  Preserves pre-v1.2.0 behavior for that invocation shape."""
+    from tsarina import cli_hits
+
+    args = _base_cached_args(tmp_path, lengths=None, mhc_class="II")
+    empty = pd.DataFrame({"peptide": pd.Series(dtype=str), "mhc_restriction": pd.Series(dtype=str)})
+    with (
+        patch("tsarina.indexing.ensure_index_built"),
+        patch("hitlist.observations.load_observations", return_value=empty) as ms_only,
+    ):
+        cli_hits.handle(args)
+    kwargs = ms_only.call_args.kwargs
+    assert kwargs.get("length_min") is None
+    assert kwargs.get("length_max") is None

--- a/tests/test_cli_hits.py
+++ b/tests/test_cli_hits.py
@@ -154,3 +154,100 @@ def test_default_cached_path_uses_load_observations_not_union(tmp_path):
         cli_hits.handle(args)
     ms_only.assert_called_once()
     all_ev.assert_not_called()
+
+
+def _base_cached_args(tmp_path, lengths, *, include_binding_assays=False):
+    return argparse.Namespace(
+        gene="PRAME",
+        uniprot=None,
+        allele=[],
+        serotype=[],
+        species="Homo sapiens",
+        mhc_class="I",
+        min_resolution=None,
+        lengths=lengths,
+        ensembl_release=112,
+        include_binding_assays=include_binding_assays,
+        mono_allelic_only=False,
+        format="pmhc",
+        predict=False,
+        predictor="mhcflurry",
+        iedb_path=None,
+        cedar_path=None,
+        skip_ms_evidence=False,
+        output=str(tmp_path / "out.csv"),
+    )
+
+
+def test_cached_path_pushes_length_bounds_to_load_observations(tmp_path):
+    """hitlist 1.15.1+ exposes length_min/length_max on load_observations.
+    tsarina's --lengths flag controls enumeration; on the cached path those
+    bounds must also push down so we don't silently pull e.g. 13-mer MHC-II
+    rows when the user asked for 8-11."""
+    from tsarina import cli_hits
+
+    args = _base_cached_args(tmp_path, lengths=(8, 9, 10, 11))
+    empty = pd.DataFrame({"peptide": pd.Series(dtype=str), "mhc_restriction": pd.Series(dtype=str)})
+    with (
+        patch("tsarina.indexing.ensure_index_built"),
+        patch("hitlist.observations.load_observations", return_value=empty) as ms_only,
+    ):
+        cli_hits.handle(args)
+    kwargs = ms_only.call_args.kwargs
+    assert kwargs.get("length_min") == 8
+    assert kwargs.get("length_max") == 11
+
+
+def test_cached_path_pushes_length_bounds_to_load_all_evidence(tmp_path):
+    """Parity with load_observations: the union path must also forward
+    length_min/length_max derived from --lengths."""
+    from tsarina import cli_hits
+
+    args = _base_cached_args(tmp_path, lengths=(12, 13, 14, 15), include_binding_assays=True)
+    empty = pd.DataFrame(
+        {
+            "peptide": pd.Series(dtype=str),
+            "mhc_restriction": pd.Series(dtype=str),
+            "evidence_kind": pd.Series(dtype=str),
+        }
+    )
+    with (
+        patch("tsarina.indexing.ensure_index_built"),
+        patch("hitlist.observations.load_all_evidence", return_value=empty) as all_ev,
+    ):
+        cli_hits.handle(args)
+    kwargs = all_ev.call_args.kwargs
+    assert kwargs.get("length_min") == 12
+    assert kwargs.get("length_max") == 15
+
+
+def test_cached_path_non_contiguous_lengths_exact_set_filter(tmp_path):
+    """--lengths 9,11 (non-contiguous) pushes a [9, 11] bound to hitlist
+    but must post-filter to the exact set so 10-mers don't leak through."""
+    from tsarina import cli_hits
+
+    args = _base_cached_args(tmp_path, lengths=(9, 11))
+    hits = pd.DataFrame(
+        {
+            "peptide": ["AAAAAAAAA", "AAAAAAAAAA", "AAAAAAAAAAA"],  # 9, 10, 11
+            "mhc_restriction": ["HLA-A*02:01"] * 3,
+        }
+    )
+    captured: dict[str, pd.DataFrame] = {}
+
+    def _capture_write(path, df):
+        captured["df"] = df
+
+    with (
+        patch("tsarina.indexing.ensure_index_built"),
+        patch("hitlist.observations.load_observations", return_value=hits),
+        patch("tsarina.cli_hits._write", side_effect=_capture_write),
+        patch(
+            "hitlist.aggregate.aggregate_per_pmhc",
+            side_effect=lambda df: df[["peptide", "mhc_restriction"]].copy(),
+        ),
+    ):
+        cli_hits.handle(args)
+    out = captured["df"]
+    got_lengths = {len(p) for p in out["peptide"]}
+    assert got_lengths == {9, 11}

--- a/tsarina/cli_hits.py
+++ b/tsarina/cli_hits.py
@@ -46,6 +46,32 @@ def _parse_lengths(value: str) -> tuple[int, ...]:
         raise argparse.ArgumentTypeError(f"--lengths must be integers: {value!r}") from e
 
 
+# Class-default peptide length windows used when --lengths is omitted.
+# Intentionally wider than textbook 8-11 / 12-25 to catch non-canonical
+# ligands hitlist actually curates (phospho-extended class I, long class
+# II tails).  An explicit --lengths overrides these.
+_CLASS_I_DEFAULT_LENGTHS = tuple(range(8, 16))  # 8-15
+_CLASS_II_DEFAULT_LENGTHS = tuple(range(12, 46))  # 12-45
+
+
+def _resolve_lengths(args: argparse.Namespace) -> tuple[int, ...] | None:
+    """Resolve --lengths with --mhc-class fallbacks.
+
+    - Explicit --lengths always wins.
+    - Otherwise derive from --mhc-class: class I -> 8-15, class II -> 12-45.
+    - If neither is set, return None so the cached observations path skips
+      length bounds (preserves "load everything" semantics for unqualified
+      queries rather than silently dropping off-window rows).
+    """
+    if args.lengths is not None:
+        return args.lengths
+    if args.mhc_class == "I":
+        return _CLASS_I_DEFAULT_LENGTHS
+    if args.mhc_class == "II":
+        return _CLASS_II_DEFAULT_LENGTHS
+    return None
+
+
 def build_parser(sub: argparse._SubParsersAction) -> argparse.ArgumentParser:
     p = sub.add_parser(
         "hits",
@@ -104,10 +130,9 @@ def build_parser(sub: argparse._SubParsersAction) -> argparse.ArgumentParser:
             "--iedb / --cedar) controls the k-mer walk; on the cached "
             "observations path bounds the loader's length filter "
             "(hitlist>=1.15.1). If omitted, defaults are derived from "
-            "--mhc-class: 8-11 for class I or unspecified, 12-25 for "
-            "class II. The cached path skips length bounds entirely when "
-            "--lengths is not explicitly set, so MHC-II rows are not "
-            "silently dropped."
+            "--mhc-class: 8-15 for class I, 12-45 for class II. When "
+            "neither --lengths nor --mhc-class is set, the cached path "
+            "skips length bounds entirely so nothing is silently dropped."
         ),
     )
     p.add_argument(
@@ -335,12 +360,12 @@ def handle(args: argparse.Namespace) -> None:
     needs_peptide_enumeration = args.skip_ms_evidence or (
         args.iedb_path is not None or args.cedar_path is not None
     )
-    # Enumeration needs a concrete length set; the cached path does not.
-    # When --lengths is omitted, fall back to an MHC-class-appropriate
-    # default for enumeration only.
-    enumeration_lengths = args.lengths
-    if enumeration_lengths is None:
-        enumeration_lengths = tuple(range(12, 26)) if args.mhc_class == "II" else (8, 9, 10, 11)
+    # Single resolution pass used by both the cached path (for bounds
+    # pushdown) and the enumeration path (for the k-mer walk).  May be
+    # None when neither --lengths nor --mhc-class was given; enumeration
+    # can't run with None, so fall back to the class-I window there.
+    resolved_lengths = _resolve_lengths(args)
+    enumeration_lengths = resolved_lengths or _CLASS_I_DEFAULT_LENGTHS
     pep_df: pd.DataFrame | None = None
     if needs_peptide_enumeration:
         try:
@@ -389,14 +414,16 @@ def handle(args: argparse.Namespace) -> None:
 
         ensure_index_built()
 
-        # hitlist 1.15.1+ length_min/length_max pushdown.  Only applied when
-        # the user explicitly passed --lengths; leaving it off preserves the
-        # historical "load everything, let --mhc-class / downstream filters
-        # do the rest" behavior so MHC-II rows aren't silently dropped by
-        # an MHC-I-flavored default.  For non-contiguous --lengths the
-        # exact-set filter below restores enumeration-path parity.
-        length_min = min(args.lengths) if args.lengths else None
-        length_max = max(args.lengths) if args.lengths else None
+        # hitlist 1.15.1+ length_min/length_max pushdown.  Applied when
+        # lengths were explicitly given OR a class was specified (in
+        # which case _resolve_lengths picked a class-appropriate window).
+        # When neither was set resolved_lengths is None and no bounds
+        # are pushed, preserving the "load everything" behavior so
+        # unqualified queries don't silently drop off-window rows.
+        # Non-contiguous --lengths are restored to exact-set semantics
+        # by the post-filter below.
+        length_min = min(resolved_lengths) if resolved_lengths else None
+        length_max = max(resolved_lengths) if resolved_lengths else None
 
         if args.include_binding_assays:
             # hitlist 1.10.0+ exposes load_all_evidence() — UNION of MS
@@ -420,8 +447,8 @@ def handle(args: argparse.Namespace) -> None:
                 length_min=length_min,
                 length_max=length_max,
             )
-        if args.lengths and not hits.empty:
-            hits = hits[hits["peptide"].str.len().isin(args.lengths)].copy()
+        if resolved_lengths and not hits.empty:
+            hits = hits[hits["peptide"].str.len().isin(resolved_lengths)].copy()
         hits = _apply_min_resolution(hits, args.min_resolution)
 
     hits = _filter_by_allele(hits, args.allele)

--- a/tsarina/cli_hits.py
+++ b/tsarina/cli_hits.py
@@ -374,6 +374,13 @@ def handle(args: argparse.Namespace) -> None:
 
         ensure_index_built()
 
+        # hitlist 1.15.1+ length_min/length_max pushdown - keeps the cached
+        # path from pulling e.g. 13-mer MHC-II rows when the user asked for
+        # 8-11.  Bounds are [min(lengths), max(lengths)]; for non-contiguous
+        # --lengths an exact-set filter below restores enumeration parity.
+        length_min = min(args.lengths) if args.lengths else None
+        length_max = max(args.lengths) if args.lengths else None
+
         if args.include_binding_assays:
             # hitlist 1.10.0+ exposes load_all_evidence() — UNION of MS
             # observations + binding-assay rows, tagged with evidence_kind.
@@ -383,6 +390,8 @@ def handle(args: argparse.Namespace) -> None:
                 gene_name=gene,
                 mhc_class=args.mhc_class,
                 species=mhc_species,
+                length_min=length_min,
+                length_max=length_max,
             )
         else:
             from hitlist.observations import load_observations
@@ -391,7 +400,11 @@ def handle(args: argparse.Namespace) -> None:
                 gene_name=gene,
                 mhc_class=args.mhc_class,
                 species=mhc_species,
+                length_min=length_min,
+                length_max=length_max,
             )
+        if args.lengths and not hits.empty:
+            hits = hits[hits["peptide"].str.len().isin(args.lengths)].copy()
         hits = _apply_min_resolution(hits, args.min_resolution)
 
     hits = _filter_by_allele(hits, args.allele)

--- a/tsarina/cli_hits.py
+++ b/tsarina/cli_hits.py
@@ -98,8 +98,17 @@ def build_parser(sub: argparse._SubParsersAction) -> argparse.ArgumentParser:
     p.add_argument(
         "--lengths",
         type=_parse_lengths,
-        default=(8, 9, 10, 11),
-        help="Peptide lengths to enumerate (default 8,9,10,11).",
+        default=None,
+        help=(
+            "Peptide lengths. On the enumeration paths (--skip-ms-evidence / "
+            "--iedb / --cedar) controls the k-mer walk; on the cached "
+            "observations path bounds the loader's length filter "
+            "(hitlist>=1.15.1). If omitted, defaults are derived from "
+            "--mhc-class: 8-11 for class I or unspecified, 12-25 for "
+            "class II. The cached path skips length bounds entirely when "
+            "--lengths is not explicitly set, so MHC-II rows are not "
+            "silently dropped."
+        ),
     )
     p.add_argument(
         "--ensembl-release",
@@ -326,10 +335,16 @@ def handle(args: argparse.Namespace) -> None:
     needs_peptide_enumeration = args.skip_ms_evidence or (
         args.iedb_path is not None or args.cedar_path is not None
     )
+    # Enumeration needs a concrete length set; the cached path does not.
+    # When --lengths is omitted, fall back to an MHC-class-appropriate
+    # default for enumeration only.
+    enumeration_lengths = args.lengths
+    if enumeration_lengths is None:
+        enumeration_lengths = tuple(range(12, 26)) if args.mhc_class == "II" else (8, 9, 10, 11)
     pep_df: pd.DataFrame | None = None
     if needs_peptide_enumeration:
         try:
-            pep_df = _enumerate_gene_peptides(gene, args.ensembl_release, args.lengths)
+            pep_df = _enumerate_gene_peptides(gene, args.ensembl_release, enumeration_lengths)
         except (ValueError, ImportError) as e:
             print(f"Error: {e}", file=sys.stderr)
             sys.exit(1)
@@ -374,10 +389,12 @@ def handle(args: argparse.Namespace) -> None:
 
         ensure_index_built()
 
-        # hitlist 1.15.1+ length_min/length_max pushdown - keeps the cached
-        # path from pulling e.g. 13-mer MHC-II rows when the user asked for
-        # 8-11.  Bounds are [min(lengths), max(lengths)]; for non-contiguous
-        # --lengths an exact-set filter below restores enumeration parity.
+        # hitlist 1.15.1+ length_min/length_max pushdown.  Only applied when
+        # the user explicitly passed --lengths; leaving it off preserves the
+        # historical "load everything, let --mhc-class / downstream filters
+        # do the rest" behavior so MHC-II rows aren't silently dropped by
+        # an MHC-I-flavored default.  For non-contiguous --lengths the
+        # exact-set filter below restores enumeration-path parity.
         length_min = min(args.lengths) if args.lengths else None
         length_max = max(args.lengths) if args.lengths else None
 

--- a/tsarina/version.py
+++ b/tsarina/version.py
@@ -10,4 +10,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "1.1.0"
+__version__ = "1.2.0"


### PR DESCRIPTION
## Summary

- Bumps hitlist pin from `>=1.14.2` to `>=1.15.1` so tsarina picks up hitlist's new `length_min` / `length_max` kwargs on `load_observations` / `load_binding` / `load_all_evidence` ([hitlist#118](https://github.com/pirl-unc/hitlist/pull/118), shipped in hitlist v1.15.1) and the `normalize_allele`-at-ingest fix ([hitlist#121](https://github.com/pirl-unc/hitlist/pull/121)).
- Wires `--lengths` through to those new kwargs on the cached (gene_name -> observations parquet) path in `cli_hits.py`. Previously `--lengths` only affected the raw-CSV-scan and `--skip-ms-evidence` paths; the cached path silently returned all lengths, so `--lengths 8,9,10,11` could pull 13-mer MHC-II rows if `--mhc-class` wasn't also set.
- Adds an exact-set post-filter so non-contiguous `--lengths` (e.g. `9,11`) don't let the `[min, max]` bound leak intermediate lengths.

## Why this is a behavior fix, not just plumbing

hitlist stores `observations.parquet` without an explicit length column; before the bump, tsarina had no ergonomic way to ask for a length window, and in practice `--lengths` was a no-op on the default query path. Users who expected symmetry with `--lengths` on the enumeration paths were getting quietly over-inclusive results. This PR closes that gap.

## Test plan

- [x] `./format.sh`
- [x] `./lint.sh`
- [x] `./test.sh` (210 passed)
- [x] New tests in `tests/test_cli_hits.py`:
  - `test_cached_path_pushes_length_bounds_to_load_observations` — MS-only loader receives `length_min=8, length_max=11`
  - `test_cached_path_pushes_length_bounds_to_load_all_evidence` — union loader parity
  - `test_cached_path_non_contiguous_lengths_exact_set_filter` — `--lengths 9,11` drops 10-mers end-to-end