### PR TITLE
v1.2.1: centralize MS evidence and HLA normalization

### DIFF
--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -32,7 +32,7 @@ duplicate call paths. Keep each PR reviewable, with one version bump per PR.
 
 - [x] `./format.sh`
 - [x] `./lint.sh`
-- [x] `./test.sh` — 223 passed
+- [x] `./test.sh` — 229 passed
 
 # Audit — Hitlist Changes And Full Tsarina Pass (2026-04-29)
 

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,3 +1,138 @@
+# PR Series — Evidence And CLI Cleanup (2026-04-30)
+
+## Goal
+
+Start a stacked set of small PRs that fixes the audit issues while reducing
+duplicate call paths. Keep each PR reviewable, with one version bump per PR.
+
+## Planned Stack
+
+- [x] PR 1: Centralize public-MS loading and HLA normalization helpers; fix
+      `target_peptides()` default evidence filtering (#31) and
+      `tsarina hits --allele` normalization (#33).
+- [ ] PR 2: Rework panel matrix metrics to use the centralized helpers, fail
+      loudly when scoring is unavailable, and count literal HLA restrictions
+      instead of regex strings (#34).
+- [ ] PR 3: Refresh README/docs around hitlist data location and the default
+      human-exclusive viral helper (#32).
+
+## Design Notes
+
+- Add one public-MS loader that chooses the cached hitlist observations path by
+  default and the raw scanner path only when explicit IEDB/CEDAR paths are
+  supplied.
+- Keep binding-assay exclusion in that loader so target, export, evidence, and
+  panel paths cannot diverge.
+- Add shared MHC restriction normalization/matching helpers and call them from
+  CLI filters and panel MS metrics.
+- Preserve existing output columns where callers may depend on them; add tests
+  for each fixed behavior before opening PRs.
+
+## PR 1 Verification
+
+- [x] `./format.sh`
+- [x] `./lint.sh`
+- [x] `./test.sh` — 223 passed
+
+# Audit — Hitlist Changes And Full Tsarina Pass (2026-04-29)
+
+## Goal
+
+Inspect the current hitlist state that tsarina depends on, then read through
+tsarina end to end looking for bugs, API mismatches, stale assumptions,
+documentation drift, test gaps, and simple improvement opportunities.
+
+## Plan
+
+- [x] Inspect local hitlist checkout, installed hitlist version, and recent
+      hitlist API changes relevant to tsarina.
+- [x] Review tsarina package metadata, public modules, CLIs, tests, and task
+      notes so the audit is grounded in current code rather than prior reports.
+- [x] Trace hitlist-facing paths: data registry, observation loading, scanning,
+      aggregation, proteome k-mer delegation, and CLI filters.
+- [x] Record concrete findings with file/line references and classify them by
+      severity.
+- [x] Decide whether any findings are clearly safe to fix now; otherwise leave
+      an actionable review section.
+
+## Review
+
+### Context Checked
+
+- Local `hitlist` import points at `/Users/iskander/code/hitlist`; package
+  attribute reports `1.30.4`, while installed metadata reports `1.30.0`.
+- Sibling `hitlist` checkout is on `feat/pmhc-sample-paired` with one
+  modified file: `hitlist/pmhc_query.py`.
+- Current `tsarina` main includes PR #30 / v1.2.0:
+  hitlist `>=1.15.1`, `tsarina hits --lengths` pushdown, and
+  class-derived length defaults.
+
+### Findings
+
+1. **High — `target_peptides()` ignores the cached hitlist evidence path.**
+   `tsarina/targets.py:177-249` only attaches MS evidence when explicit
+   `iedb_path` or `cedar_path` is supplied. With defaults, both
+   `require_ms_evidence=True` and `cancer_specific=True` are no-ops.
+   When explicit raw CSVs are supplied, binding-assay rows are not dropped
+   before MS aggregation. Filed as
+   https://github.com/pirl-unc/tsarina/issues/31.
+
+2. **High — panel MS metrics are not reliable.**
+   `tsarina/panels.py:113-188` inherits the `target_peptides()` evidence
+   no-op for `ms_confirmed_only=True`; `metric="ms_peptide_count"` uses
+   regex `str.contains(allele)` against HLA strings with `*`, so literal
+   alleles such as `HLA-A*02:01` do not match; and `metric="best_percentile"`
+   silently falls back to allele-agnostic peptide counts if scoring imports
+   fail. Filed as https://github.com/pirl-unc/tsarina/issues/34.
+
+3. **Medium — `tsarina hits --allele` does not normalize user allele input.**
+   `tsarina/cli_hits.py:271-275` post-filters by exact string. Current
+   hitlist normalizes loaded `mhc_restriction` values, but tsarina does not
+   normalize requested alleles, so `--allele A*02:01` drops canonical
+   `HLA-A*02:01` rows. Filed as
+   https://github.com/pirl-unc/tsarina/issues/33.
+
+4. **Medium — legacy overlap helpers still treat scanner output as MS-only.**
+   `tsarina/viral.py:416-442` and `tsarina/mutations.py:427-449` call
+   `scan_public_ms()` and aggregate all hits without dropping
+   `is_binding_assay`. This is the same class of issue as #31 but on older
+   per-category helper APIs.
+
+5. **Medium — local `hitlist` change has per-sample edge-case bugs.**
+   `hitlist/pmhc_query.py:296-354` adds `query_by_samples()`, but a sample
+   with an empty allele list is passed through to `query()`, where empty
+   alleles mean "all alleles." The comment that empty sub-results remain
+   visible to `groupby("sample_name")` is also false: inserting a scalar
+   column into an empty frame still leaves zero rows. Filed as
+   https://github.com/pirl-unc/hitlist/issues/188.
+
+6. **Low — docs still carry stale pre-hitlist delegation details.**
+   `README.md:121-125`, `README.md:292`, `docs/index.md:102-106`, and
+   `docs/index.md:273` still mention `~/.tsarina` / `PERSEUS_DATA_DIR`
+   and foreground `cancer_specific_viral_peptides()` where the current
+   clinical default is stricter human-exclusive viral filtering. Filed as
+   https://github.com/pirl-unc/tsarina/issues/32.
+
+### Immediate Recommendation
+
+Fix #31 first. It is foundational: `target_peptides()` feeds
+`build_panel_matrix()`, the README's target-table example, and older target
+selection APIs. The most direct fix is to mirror `personalize()` /
+`export.build_ms_support_maps()`:
+
+- default path: `indexing.load_ms_evidence(peptides=..., mhc_class=...,
+  mhc_species="Homo sapiens")`
+- explicit raw path: `scan_public_ms(...)`, then drop `is_binding_assay`
+- keep source-flag aggregation shape stable for existing callers
+
+Then fix #34 with targeted panel tests.
+
+### Verification
+
+- [x] `./format.sh`
+- [x] `./lint.sh`
+- [x] `./test.sh` — 214 passed
+
 # Audit — Hitlist Alignment And TSA Goal
 
 ## Goal

--- a/tests/test_cli_hits_filters.py
+++ b/tests/test_cli_hits_filters.py
@@ -19,6 +19,18 @@ def test_filter_by_allele_exact_match():
     assert out["mhc_restriction"].tolist() == ["HLA-A*24:02"]
 
 
+def test_filter_by_allele_normalizes_user_input():
+    df = _hits(["HLA-A*02:01", "HLA-A*24:02", "HLA-B*07:02"])
+    out = _filter_by_allele(df, ["A*02:01"])
+    assert out["mhc_restriction"].tolist() == ["HLA-A*02:01"]
+
+
+def test_filter_by_allele_matches_semicolon_joined_restrictions():
+    df = _hits(["HLA-A*02:01;HLA-B*07:02", "HLA-A*24:02"])
+    out = _filter_by_allele(df, ["B*07:02"])
+    assert out["mhc_restriction"].tolist() == ["HLA-A*02:01;HLA-B*07:02"]
+
+
 def test_filter_by_allele_empty_passthrough():
     df = _hits(["HLA-A*02:01"])
     assert _filter_by_allele(df, []).equals(df)

--- a/tests/test_evidence.py
+++ b/tests/test_evidence.py
@@ -1,0 +1,59 @@
+import pandas as pd
+
+from tsarina.evidence import _compute_ms_restriction
+
+
+def test_compute_ms_restriction_uses_public_ms_loader(monkeypatch):
+    calls = {}
+    input_df = pd.DataFrame({"Symbol": ["MAGEA4", "PRAME"]})
+
+    monkeypatch.setattr(
+        "tsarina.peptides.cta_peptides",
+        lambda: pd.DataFrame(
+            {
+                "peptide": ["MSPEPTIDE", "OTHERPEP"],
+                "gene_name": ["MAGEA4", "PRAME"],
+            }
+        ),
+        raising=True,
+    )
+
+    def _fake_load_public_ms_hits(peptides, **kwargs):
+        calls["peptides"] = peptides
+        calls["kwargs"] = kwargs
+        return pd.DataFrame(
+            {
+                "peptide": ["MSPEPTIDE"],
+                "mhc_restriction": ["HLA-A*02:01"],
+                "src_cancer": [True],
+            }
+        )
+
+    def _fake_aggregate_gene_ms_safety(hits, gene_map):
+        assert hits["peptide"].tolist() == ["MSPEPTIDE"]
+        assert set(gene_map["gene_name"]) == {"MAGEA4", "PRAME"}
+        return pd.DataFrame(
+            {
+                "gene_name": ["MAGEA4"],
+                "ms_restriction": ["CANCER_ONLY"],
+                "ms_cancer_count": [1],
+            }
+        )
+
+    monkeypatch.setattr(
+        "tsarina.ms_evidence.load_public_ms_hits",
+        _fake_load_public_ms_hits,
+        raising=True,
+    )
+    monkeypatch.setattr(
+        "tsarina.tiers.aggregate_gene_ms_safety",
+        _fake_aggregate_gene_ms_safety,
+        raising=True,
+    )
+
+    out = _compute_ms_restriction(input_df, iedb_path=None, cedar_path=None)
+
+    assert calls["peptides"] == {"MSPEPTIDE", "OTHERPEP"}
+    assert calls["kwargs"]["mhc_class"] == "I"
+    assert out.loc[out["Symbol"] == "MAGEA4", "ms_restriction"].iloc[0] == "CANCER_ONLY"
+    assert out.loc[out["Symbol"] == "PRAME", "ms_restriction"].iloc[0] == "NO_MS_DATA"

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -1,0 +1,59 @@
+import pandas as pd
+
+from tsarina.export import build_ms_support_maps
+
+
+def test_build_ms_support_maps_uses_public_ms_loader(monkeypatch):
+    calls = {}
+    hits = pd.DataFrame(
+        {
+            "peptide": ["MSPEPTIDE"],
+            "mhc_restriction": ["HLA-A*02:01"],
+        }
+    )
+
+    def _fake_load_public_ms_hits(peptides, **kwargs):
+        calls["peptides"] = peptides
+        calls["kwargs"] = kwargs
+        return hits
+
+    def _fake_aggregate_per_peptide(df):
+        assert df is hits
+        return pd.DataFrame({"peptide": ["MSPEPTIDE"], "ms_hit_count": [1]})
+
+    def _fake_aggregate_per_pmhc(df):
+        assert df is hits
+        return pd.DataFrame(
+            {
+                "peptide": ["MSPEPTIDE"],
+                "mhc_restriction": ["HLA-A*02:01"],
+                "ms_hit_count": [1],
+            }
+        )
+
+    monkeypatch.setattr(
+        "tsarina.ms_evidence.load_public_ms_hits",
+        _fake_load_public_ms_hits,
+        raising=True,
+    )
+    monkeypatch.setattr(
+        "tsarina.export.aggregate_per_peptide",
+        _fake_aggregate_per_peptide,
+        raising=True,
+    )
+    monkeypatch.setattr(
+        "tsarina.export.aggregate_per_pmhc",
+        _fake_aggregate_per_pmhc,
+        raising=True,
+    )
+
+    peptide_map, pmhc_map, summary = build_ms_support_maps(
+        peptides={"MSPEPTIDE"},
+        mhc_class="I",
+    )
+
+    assert calls["peptides"] == {"MSPEPTIDE"}
+    assert calls["kwargs"]["mhc_class"] == "I"
+    assert peptide_map["MSPEPTIDE"]["ms_hit_count"] == 1
+    assert pmhc_map[("MSPEPTIDE", "HLA-A*02:01")]["ms_hit_count"] == 1
+    assert summary["peptide"].tolist() == ["MSPEPTIDE"]

--- a/tests/test_mhc.py
+++ b/tests/test_mhc.py
@@ -1,0 +1,23 @@
+from tsarina.mhc import (
+    mhc_restriction_matches_any,
+    normalize_mhc_restriction,
+    normalize_mhc_restriction_set,
+    split_mhc_restrictions,
+)
+
+
+def test_normalize_mhc_restriction_adds_hla_prefix():
+    assert normalize_mhc_restriction("A*02:01") == "HLA-A*02:01"
+
+
+def test_split_mhc_restrictions_normalizes_semicolon_joined_cell():
+    assert split_mhc_restrictions("A*02:01; HLA-B*07:02") == (
+        "HLA-A*02:01",
+        "HLA-B*07:02",
+    )
+
+
+def test_mhc_restriction_matches_any_uses_normalized_values():
+    wanted = normalize_mhc_restriction_set(["A*02:01"])
+    assert mhc_restriction_matches_any("HLA-A*02:01;HLA-B*07:02", wanted)
+    assert not mhc_restriction_matches_any("HLA-B*07:02", wanted)

--- a/tests/test_ms_evidence.py
+++ b/tests/test_ms_evidence.py
@@ -2,7 +2,11 @@ from pathlib import Path
 
 import pandas as pd
 
-from tsarina.ms_evidence import aggregate_ms_hits_by_peptide, load_public_ms_hits
+from tsarina.ms_evidence import (
+    aggregate_ms_hits_by_peptide,
+    aggregate_ms_hits_for_iedb_columns,
+    load_public_ms_hits,
+)
 
 
 def test_load_public_ms_hits_raw_path_drops_binding_assays(monkeypatch):
@@ -56,3 +60,40 @@ def test_aggregate_ms_hits_by_peptide_carries_source_flags_and_cell_lines():
     assert bool(row["ms_cancer"]) is True
     assert bool(row["ms_healthy_tissue"]) is True
     assert row["ms_cell_lines"] == "A375"
+
+
+def test_aggregate_ms_hits_by_peptide_ignores_blank_and_missing_strings():
+    hits = pd.DataFrame(
+        {
+            "peptide": ["MSPEPTIDE", "MSPEPTIDE", "MSPEPTIDE"],
+            "mhc_restriction": ["HLA-A*02:01", None, ""],
+            "cell_line_name": ["A375", None, ""],
+        }
+    )
+
+    out = aggregate_ms_hits_by_peptide(hits)
+
+    row = out.iloc[0]
+    assert row["ms_hit_count"] == 3
+    assert row["ms_alleles"] == "HLA-A*02:01"
+    assert row["ms_allele_count"] == 1
+    assert row["ms_cell_lines"] == "A375"
+
+
+def test_aggregate_ms_hits_for_iedb_columns_keeps_legacy_shape():
+    hits = pd.DataFrame(
+        {
+            "peptide": ["MSPEPTIDE"],
+            "mhc_restriction": ["HLA-A*02:01"],
+        }
+    )
+
+    out = aggregate_ms_hits_for_iedb_columns(hits)
+
+    assert out.to_dict(orient="records") == [
+        {
+            "peptide": "MSPEPTIDE",
+            "iedb_hit_count": 1,
+            "iedb_alleles": "HLA-A*02:01",
+        }
+    ]

--- a/tests/test_ms_evidence.py
+++ b/tests/test_ms_evidence.py
@@ -1,0 +1,58 @@
+from pathlib import Path
+
+import pandas as pd
+
+from tsarina.ms_evidence import aggregate_ms_hits_by_peptide, load_public_ms_hits
+
+
+def test_load_public_ms_hits_raw_path_drops_binding_assays(monkeypatch):
+    calls = {}
+
+    def _fake_resolve(iedb_path, cedar_path, require_iedb=True):
+        calls["resolve"] = (iedb_path, cedar_path, require_iedb)
+        return Path("iedb.csv"), None
+
+    def _fake_scan_public_ms(**kwargs):
+        calls["scan"] = kwargs
+        return pd.DataFrame(
+            {
+                "peptide": ["MSPEPTIDE", "BINDPEPTD"],
+                "mhc_restriction": ["HLA-A*02:01", "HLA-A*02:01"],
+                "is_binding_assay": [False, True],
+            }
+        )
+
+    monkeypatch.setattr("tsarina.datasources.resolve_dataset_paths", _fake_resolve, raising=True)
+    monkeypatch.setattr("tsarina.iedb.scan_public_ms", _fake_scan_public_ms, raising=True)
+
+    out = load_public_ms_hits(
+        peptides={"MSPEPTIDE", "BINDPEPTD"},
+        iedb_path="iedb.csv",
+        mhc_class="I",
+    )
+
+    assert calls["resolve"] == ("iedb.csv", None, True)
+    assert calls["scan"]["mhc_species"] == "Homo sapiens"
+    assert out["peptide"].tolist() == ["MSPEPTIDE"]
+
+
+def test_aggregate_ms_hits_by_peptide_carries_source_flags_and_cell_lines():
+    hits = pd.DataFrame(
+        {
+            "peptide": ["MSPEPTIDE", "MSPEPTIDE"],
+            "mhc_restriction": ["HLA-A*02:01", "HLA-B*07:02"],
+            "src_cancer": [True, False],
+            "src_healthy_tissue": [False, True],
+            "cell_line_name": ["A375", ""],
+        }
+    )
+
+    out = aggregate_ms_hits_by_peptide(hits)
+
+    row = out.iloc[0]
+    assert row["ms_hit_count"] == 2
+    assert row["ms_alleles"] == "HLA-A*02:01;HLA-B*07:02"
+    assert row["ms_allele_count"] == 2
+    assert bool(row["ms_cancer"]) is True
+    assert bool(row["ms_healthy_tissue"]) is True
+    assert row["ms_cell_lines"] == "A375"

--- a/tests/test_mutations.py
+++ b/tests/test_mutations.py
@@ -1,3 +1,5 @@
+import pandas as pd
+
 from tsarina.mutations import HOTSPOT_MUTATIONS
 
 
@@ -57,3 +59,43 @@ def test_gene_ids_are_ensembl():
 def test_transcript_ids_are_ensembl():
     for mut in HOTSPOT_MUTATIONS:
         assert mut["transcript_id"].startswith("ENST"), f"{mut['label']}: bad transcript_id"
+
+
+def test_mutant_iedb_overlap_uses_public_ms_loader(monkeypatch):
+    from tsarina.mutations import mutant_iedb_overlap
+
+    calls = {}
+    monkeypatch.setattr(
+        "tsarina.mutations.mutant_peptides",
+        lambda **kw: pd.DataFrame(
+            {
+                "peptide": ["MSPEPTIDE", "NOEVIDENC"],
+                "mutation": ["G12D", "G12D"],
+            }
+        ),
+        raising=True,
+    )
+
+    def _fake_load_public_ms_hits(peptides, **kwargs):
+        calls["peptides"] = peptides
+        calls["kwargs"] = kwargs
+        return pd.DataFrame(
+            {
+                "peptide": ["MSPEPTIDE"],
+                "mhc_restriction": ["HLA-A*02:01"],
+            }
+        )
+
+    monkeypatch.setattr(
+        "tsarina.ms_evidence.load_public_ms_hits",
+        _fake_load_public_ms_hits,
+        raising=True,
+    )
+
+    out = mutant_iedb_overlap()
+
+    assert calls["peptides"] == {"MSPEPTIDE", "NOEVIDENC"}
+    assert calls["kwargs"]["drop_binding_assays"] is True
+    hit_row = out[out["peptide"] == "MSPEPTIDE"].iloc[0]
+    assert bool(hit_row["has_iedb_hit"]) is True
+    assert hit_row["iedb_alleles"] == "HLA-A*02:01"

--- a/tests/test_targets.py
+++ b/tests/test_targets.py
@@ -1,6 +1,87 @@
 import pandas as pd
 
-from tsarina.targets import target_summary
+from tsarina.targets import target_peptides, target_summary
+
+
+def _cta_targets() -> pd.DataFrame:
+    return pd.DataFrame(
+        {
+            "peptide": ["MSPEPTIDE", "NOEVIDENC"],
+            "length": [9, 9],
+            "gene_name": ["MAGEA4", "MAGEA4"],
+            "gene_id": ["ENSG1", "ENSG1"],
+        }
+    )
+
+
+def test_target_peptides_require_ms_evidence_uses_default_loader(monkeypatch):
+    calls = {}
+
+    monkeypatch.setattr("tsarina.peptides.cta_exclusive_peptides", lambda **kw: _cta_targets())
+
+    def _fake_load_public_ms_hits(peptides, **kwargs):
+        calls["peptides"] = peptides
+        calls["kwargs"] = kwargs
+        return pd.DataFrame(
+            {
+                "peptide": ["MSPEPTIDE"],
+                "mhc_restriction": ["HLA-A*02:01"],
+                "src_cancer": [True],
+                "src_healthy_tissue": [False],
+            }
+        )
+
+    monkeypatch.setattr(
+        "tsarina.ms_evidence.load_public_ms_hits",
+        _fake_load_public_ms_hits,
+        raising=True,
+    )
+
+    out = target_peptides(
+        cta=True,
+        viruses=False,
+        mutations=False,
+        require_ms_evidence=True,
+    )
+
+    assert calls["peptides"] == {"MSPEPTIDE", "NOEVIDENC"}
+    assert calls["kwargs"]["iedb_path"] is None
+    assert calls["kwargs"]["cedar_path"] is None
+    assert calls["kwargs"]["mhc_species"] == "Homo sapiens"
+    assert out["peptide"].tolist() == ["MSPEPTIDE"]
+    assert out["has_ms_evidence"].tolist() == [True]
+    assert out["ms_hit_count"].tolist() == [1]
+
+
+def test_target_peptides_cancer_specific_uses_default_loader(monkeypatch):
+    monkeypatch.setattr("tsarina.peptides.cta_exclusive_peptides", lambda **kw: _cta_targets())
+
+    def _fake_load_public_ms_hits(peptides, **kwargs):
+        return pd.DataFrame(
+            {
+                "peptide": ["MSPEPTIDE", "NOEVIDENC"],
+                "mhc_restriction": ["HLA-A*02:01", "HLA-A*02:01"],
+                "src_cancer": [True, True],
+                "src_healthy_tissue": [False, True],
+            }
+        )
+
+    monkeypatch.setattr(
+        "tsarina.ms_evidence.load_public_ms_hits",
+        _fake_load_public_ms_hits,
+        raising=True,
+    )
+
+    out = target_peptides(
+        cta=True,
+        viruses=False,
+        mutations=False,
+        cancer_specific=True,
+    )
+
+    assert out["peptide"].tolist() == ["MSPEPTIDE"]
+    assert out["ms_cancer"].tolist() == [True]
+    assert out["ms_healthy_tissue"].tolist() == [False]
 
 
 def test_target_summary_on_empty():

--- a/tests/test_viral.py
+++ b/tests/test_viral.py
@@ -1,6 +1,6 @@
 import pandas as pd
 
-from tsarina.viral import ONCOGENIC_VIRUSES, read_fasta, viral_peptides
+from tsarina.viral import ONCOGENIC_VIRUSES, read_fasta, viral_iedb_overlap, viral_peptides
 
 
 def test_oncogenic_viruses_has_expected_keys():
@@ -60,3 +60,35 @@ def test_viral_peptides_from_fasta(tmp_path):
     df = viral_peptides(fasta_path=fasta, lengths=(8,))
     assert len(df) == 5  # 12 - 8 + 1
     assert all(df["virus"] == "custom")
+
+
+def test_viral_iedb_overlap_uses_public_ms_loader(monkeypatch):
+    calls = {}
+
+    def _fake_load_public_ms_hits(peptides, **kwargs):
+        calls["peptides"] = peptides
+        calls["kwargs"] = kwargs
+        return pd.DataFrame(
+            {
+                "peptide": ["ACDEFGHI"],
+                "mhc_restriction": ["HLA-A*02:01"],
+            }
+        )
+
+    monkeypatch.setattr(
+        "tsarina.ms_evidence.load_public_ms_hits",
+        _fake_load_public_ms_hits,
+        raising=True,
+    )
+
+    out = viral_iedb_overlap(
+        proteins={"E6": "ACDEFGHIK"},
+        lengths=(8,),
+        human_exclusive_only=False,
+    )
+
+    assert "ACDEFGHI" in calls["peptides"]
+    assert calls["kwargs"]["drop_binding_assays"] is True
+    hit_row = out[out["peptide"] == "ACDEFGHI"].iloc[0]
+    assert bool(hit_row["has_iedb_hit"]) is True
+    assert hit_row["iedb_alleles"] == "HLA-A*02:01"

--- a/tsarina/cli_hits.py
+++ b/tsarina/cli_hits.py
@@ -271,8 +271,12 @@ def _resolve_uniprot_to_gene(uniprot: str) -> str:
 def _filter_by_allele(hits: pd.DataFrame, alleles: list[str]) -> pd.DataFrame:
     if not alleles:
         return hits
-    wanted = {a.strip() for a in alleles}
-    return hits[hits["mhc_restriction"].isin(wanted)].copy()
+    from .mhc import mhc_restriction_matches_any, normalize_mhc_restriction_set
+
+    wanted = normalize_mhc_restriction_set(alleles)
+    return hits[
+        hits["mhc_restriction"].map(lambda value: mhc_restriction_matches_any(value, wanted))
+    ].copy()
 
 
 def _filter_by_serotype(hits: pd.DataFrame, serotypes: list[str]) -> pd.DataFrame:

--- a/tsarina/evidence.py
+++ b/tsarina/evidence.py
@@ -191,30 +191,16 @@ def _compute_ms_restriction(
 
     peptide_set = set(pep_df["peptide"])
 
-    if iedb_path is not None or cedar_path is not None:
-        from hitlist.scanner import scan
+    from .ms_evidence import load_public_ms_hits
 
-        from .datasources import resolve_dataset_paths
-
-        resolved_iedb, resolved_cedar = resolve_dataset_paths(iedb_path, cedar_path)
-        hits = scan(
-            peptides=peptide_set,
-            iedb_path=str(resolved_iedb),
-            cedar_path=str(resolved_cedar) if resolved_cedar else None,
-            classify_source=True,
-            mhc_species="Homo sapiens",
-            mhc_class="I",
-        )
-        if "is_binding_assay" in hits.columns:
-            hits = hits[~hits["is_binding_assay"]].copy()
-    else:
-        from .indexing import load_ms_evidence
-
-        hits = load_ms_evidence(
-            peptides=peptide_set,
-            mhc_class="I",
-            mhc_species="Homo sapiens",
-        )
+    hits = load_public_ms_hits(
+        peptides=peptide_set,
+        iedb_path=iedb_path,
+        cedar_path=cedar_path,
+        mhc_class="I",
+        classify_source=True,
+        drop_binding_assays=True,
+    )
 
     if hits.empty:
         return df

--- a/tsarina/export.py
+++ b/tsarina/export.py
@@ -32,7 +32,6 @@ from pathlib import Path
 
 import pandas as pd
 from hitlist.aggregate import aggregate_per_peptide, aggregate_per_pmhc
-from hitlist.scanner import scan
 
 
 def build_ms_support_maps(
@@ -63,28 +62,16 @@ def build_ms_support_maps(
         - **pmhc_map**: ``{(peptide, allele): {ms_hit_count, ms_ref_count, ...}}``
         - **summary_df**: Per-peptide summary DataFrame.
     """
-    if iedb_path is not None or cedar_path is not None:
-        from .datasources import resolve_dataset_paths
+    from .ms_evidence import load_public_ms_hits
 
-        resolved_iedb, resolved_cedar = resolve_dataset_paths(iedb_path, cedar_path)
-        hits = scan(
-            peptides=peptides,
-            iedb_path=str(resolved_iedb),
-            cedar_path=str(resolved_cedar) if resolved_cedar else None,
-            mhc_class=mhc_class,
-            classify_source=True,
-            mhc_species="Homo sapiens",
-        )
-        if "is_binding_assay" in hits.columns:
-            hits = hits[~hits["is_binding_assay"]].copy()
-    else:
-        from .indexing import load_ms_evidence
-
-        hits = load_ms_evidence(
-            peptides=peptides,
-            mhc_class=mhc_class,
-            mhc_species="Homo sapiens",
-        )
+    hits = load_public_ms_hits(
+        peptides=peptides,
+        iedb_path=iedb_path,
+        cedar_path=cedar_path,
+        mhc_class=mhc_class,
+        classify_source=True,
+        drop_binding_assays=True,
+    )
 
     # Per-peptide aggregation
     summary_df = aggregate_per_peptide(hits)

--- a/tsarina/mhc.py
+++ b/tsarina/mhc.py
@@ -1,0 +1,74 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Shared MHC restriction normalization and matching helpers."""
+
+from __future__ import annotations
+
+
+def _parse_hla(value: str):
+    from mhcgnomes import parse
+
+    query = value if value.upper().startswith("HLA-") else f"HLA-{value}"
+    return parse(query)
+
+
+def normalize_mhc_restriction(value: object) -> str | None:
+    """Return a canonical HLA restriction string when mhcgnomes can parse it.
+
+    Examples
+    --------
+    ``"A*02:01"`` and ``"HLA-A*02:01"`` both normalize to
+    ``"HLA-A*02:01"``.  Unparseable non-empty strings are returned stripped so
+    exact string filters still work for unusual restrictions.
+    """
+    if not isinstance(value, str):
+        return None
+    stripped = value.strip()
+    if not stripped:
+        return None
+    try:
+        parsed = _parse_hla(stripped)
+    except Exception:
+        return stripped
+    if hasattr(parsed, "to_string"):
+        return parsed.to_string()
+    return stripped
+
+
+def split_mhc_restrictions(value: object) -> tuple[str, ...]:
+    """Split a semicolon-joined restriction cell into normalized tokens."""
+    if not isinstance(value, str):
+        return ()
+    normalized = []
+    for token in value.split(";"):
+        restriction = normalize_mhc_restriction(token)
+        if restriction is not None:
+            normalized.append(restriction)
+    return tuple(normalized)
+
+
+def normalize_mhc_restriction_set(values: list[str] | tuple[str, ...] | set[str]) -> set[str]:
+    """Normalize an iterable of user-supplied MHC restrictions."""
+    normalized = set()
+    for value in values:
+        restriction = normalize_mhc_restriction(value)
+        if restriction is not None:
+            normalized.add(restriction)
+    return normalized
+
+
+def mhc_restriction_matches_any(value: object, wanted: set[str]) -> bool:
+    """Return True when a restriction cell contains any normalized target."""
+    if not wanted:
+        return True
+    return any(restriction in wanted for restriction in split_mhc_restrictions(value))

--- a/tsarina/ms_evidence.py
+++ b/tsarina/ms_evidence.py
@@ -33,6 +33,17 @@ def _peptide_set(peptides: set[str] | list[str] | tuple[str, ...]) -> set[str]:
     return set(peptides)
 
 
+def _nonempty_strings(values) -> set[str]:
+    strings = set()
+    for value in values:
+        if not isinstance(value, str):
+            continue
+        stripped = value.strip()
+        if stripped:
+            strings.add(stripped)
+    return strings
+
+
 def load_public_ms_hits(
     peptides: set[str] | list[str] | tuple[str, ...],
     *,
@@ -103,8 +114,8 @@ def aggregate_ms_hits_by_peptide(
 
     agg: dict[str, tuple] = {
         "ms_hit_count": ("peptide", "size"),
-        "ms_alleles": ("mhc_restriction", lambda x: ";".join(sorted({v for v in x if v}))),
-        "ms_allele_count": ("mhc_restriction", lambda x: len({v for v in x if v})),
+        "ms_alleles": ("mhc_restriction", lambda x: ";".join(sorted(_nonempty_strings(x)))),
+        "ms_allele_count": ("mhc_restriction", lambda x: len(_nonempty_strings(x))),
     }
     for source_col, output_col in source_flag_outputs.items():
         if source_col in hits.columns:
@@ -112,7 +123,24 @@ def aggregate_ms_hits_by_peptide(
     if cell_line_output is not None and "cell_line_name" in hits.columns:
         agg[cell_line_output] = (
             "cell_line_name",
-            lambda x: ";".join(sorted({v for v in x if v})),
+            lambda x: ";".join(sorted(_nonempty_strings(x))),
         )
 
     return hits.groupby("peptide", as_index=False).agg(**agg)
+
+
+def aggregate_ms_hits_for_iedb_columns(hits: pd.DataFrame) -> pd.DataFrame:
+    """Aggregate hits to the legacy ``iedb_*`` peptide columns."""
+    aggregated = aggregate_ms_hits_by_peptide(
+        hits,
+        source_flag_outputs={},
+        cell_line_output=None,
+    )
+    if aggregated.empty:
+        return pd.DataFrame(columns=["peptide", "iedb_hit_count", "iedb_alleles"])
+    return aggregated.rename(
+        columns={
+            "ms_hit_count": "iedb_hit_count",
+            "ms_alleles": "iedb_alleles",
+        }
+    )[["peptide", "iedb_hit_count", "iedb_alleles"]]

--- a/tsarina/ms_evidence.py
+++ b/tsarina/ms_evidence.py
@@ -1,0 +1,118 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Shared public-MS evidence loading and peptide-level aggregation."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pandas as pd
+
+SOURCE_FLAG_OUTPUTS: dict[str, str] = {
+    "src_cancer": "ms_cancer",
+    "src_healthy_tissue": "ms_healthy_tissue",
+    "src_healthy_thymus": "ms_healthy_thymus",
+    "src_healthy_reproductive": "ms_healthy_reproductive",
+    "src_cell_line": "ms_cell_line",
+    "src_ebv_lcl": "ms_ebv_lcl",
+    "src_ex_vivo": "ms_ex_vivo",
+}
+
+
+def _peptide_set(peptides: set[str] | list[str] | tuple[str, ...]) -> set[str]:
+    return set(peptides)
+
+
+def load_public_ms_hits(
+    peptides: set[str] | list[str] | tuple[str, ...],
+    *,
+    iedb_path: str | Path | None = None,
+    cedar_path: str | Path | None = None,
+    mhc_class: str | None = "I",
+    mhc_species: str | None = "Homo sapiens",
+    classify_source: bool = True,
+    min_allele_resolution: str | None = None,
+    drop_binding_assays: bool = True,
+) -> pd.DataFrame:
+    """Load public MS evidence for peptides from the canonical tsarina path.
+
+    The default path uses hitlist's cached observations parquet.  Explicit
+    ``iedb_path`` or ``cedar_path`` switches to the raw scanner for ad-hoc
+    snapshots while preserving the same species/class and binding-assay policy.
+    """
+    peptide_set = _peptide_set(peptides)
+    if iedb_path is not None or cedar_path is not None:
+        from .datasources import resolve_dataset_paths
+        from .iedb import scan_public_ms
+
+        resolved_iedb, resolved_cedar = resolve_dataset_paths(
+            iedb_path,
+            cedar_path,
+            require_iedb=iedb_path is not None,
+        )
+        hits = scan_public_ms(
+            peptides=peptide_set,
+            iedb_path=resolved_iedb,
+            cedar_path=resolved_cedar,
+            mhc_species=mhc_species,
+            mhc_class=mhc_class,
+            classify_source=classify_source,
+            min_allele_resolution=min_allele_resolution,
+        )
+    else:
+        from .indexing import load_ms_evidence
+
+        hits = load_ms_evidence(
+            peptides=peptide_set,
+            mhc_class=mhc_class,
+            mhc_species=mhc_species,
+            drop_binding_assays=drop_binding_assays,
+        )
+
+    if drop_binding_assays and "is_binding_assay" in hits.columns:
+        hits = hits[~hits["is_binding_assay"]].copy()
+    return hits.reset_index(drop=True)
+
+
+def aggregate_ms_hits_by_peptide(
+    hits: pd.DataFrame,
+    *,
+    source_flag_outputs: dict[str, str] | None = None,
+    cell_line_output: str | None = "ms_cell_lines",
+) -> pd.DataFrame:
+    """Aggregate hitlist evidence rows to one row per peptide."""
+    columns = ["peptide", "ms_hit_count", "ms_alleles", "ms_allele_count"]
+    source_flag_outputs = (
+        SOURCE_FLAG_OUTPUTS if source_flag_outputs is None else source_flag_outputs
+    )
+    columns.extend(source_flag_outputs.values())
+    if cell_line_output is not None:
+        columns.append(cell_line_output)
+    if hits.empty or "peptide" not in hits.columns:
+        return pd.DataFrame(columns=columns)
+
+    agg: dict[str, tuple] = {
+        "ms_hit_count": ("peptide", "size"),
+        "ms_alleles": ("mhc_restriction", lambda x: ";".join(sorted({v for v in x if v}))),
+        "ms_allele_count": ("mhc_restriction", lambda x: len({v for v in x if v})),
+    }
+    for source_col, output_col in source_flag_outputs.items():
+        if source_col in hits.columns:
+            agg[output_col] = (source_col, "any")
+    if cell_line_output is not None and "cell_line_name" in hits.columns:
+        agg[cell_line_output] = (
+            "cell_line_name",
+            lambda x: ";".join(sorted({v for v in x if v})),
+        )
+
+    return hits.groupby("peptide", as_index=False).agg(**agg)

--- a/tsarina/mutations.py
+++ b/tsarina/mutations.py
@@ -410,7 +410,7 @@ def mutant_iedb_overlap(
         Mutant peptide DataFrame with ``has_iedb_hit``, ``iedb_alleles``,
         ``iedb_hit_count`` columns.
     """
-    from .iedb import scan_public_ms
+    from .ms_evidence import aggregate_ms_hits_for_iedb_columns, load_public_ms_hits
 
     mdf = mutant_peptides(
         mutations=mutations,
@@ -424,11 +424,13 @@ def mutant_iedb_overlap(
         return mdf
 
     unique_peptides = set(mdf["peptide"].unique())
-    hits = scan_public_ms(
+    hits = load_public_ms_hits(
         peptides=unique_peptides,
         iedb_path=iedb_path,
         cedar_path=cedar_path,
         mhc_class=mhc_class,
+        classify_source=False,
+        drop_binding_assays=True,
     )
 
     if hits.empty:
@@ -437,14 +439,7 @@ def mutant_iedb_overlap(
         mdf["iedb_hit_count"] = 0
         return mdf
 
-    hit_summary = (
-        hits.groupby("peptide")
-        .agg(
-            iedb_hit_count=("peptide", "size"),
-            iedb_alleles=("mhc_restriction", lambda x: ";".join(sorted(set(x)))),
-        )
-        .reset_index()
-    )
+    hit_summary = aggregate_ms_hits_for_iedb_columns(hits)
 
     mdf = mdf.merge(hit_summary, on="peptide", how="left")
     mdf["has_iedb_hit"] = mdf["iedb_hit_count"].notna() & (mdf["iedb_hit_count"] > 0)

--- a/tsarina/personalize.py
+++ b/tsarina/personalize.py
@@ -374,43 +374,30 @@ def _attach_ms_evidence(
             combined[col] = default
         return combined
 
-    if iedb_path is not None or cedar_path is not None:
-        from .datasources import resolve_dataset_paths
-        from .iedb import scan_public_ms
+    from .ms_evidence import aggregate_ms_hits_by_peptide, load_public_ms_hits
 
-        resolved_iedb, resolved_cedar = resolve_dataset_paths(iedb_path, cedar_path)
-        hits = scan_public_ms(
-            peptides=set(combined["peptide"].unique()),
-            iedb_path=resolved_iedb,
-            cedar_path=resolved_cedar,
-            mhc_class=mhc_class,
-            classify_source=True,
-        )
-    else:
-        from .indexing import load_ms_evidence
-
-        hits = load_ms_evidence(
-            peptides=set(combined["peptide"].unique()),
-            mhc_class=mhc_class,
-            mhc_species="Homo sapiens",
-        )
+    hits = load_public_ms_hits(
+        peptides=set(combined["peptide"].unique()),
+        iedb_path=iedb_path,
+        cedar_path=cedar_path,
+        mhc_class=mhc_class,
+        classify_source=True,
+        drop_binding_assays=True,
+    )
 
     if hits.empty:
         for col, default in defaults.items():
             combined[col] = default
         return combined
 
-    agg_cols: dict[str, tuple] = {
-        "ms_hit_count": ("peptide", "size"),
-        "ms_alleles": ("mhc_restriction", lambda x: ";".join(sorted(set(x)))),
-        "ms_allele_count": ("mhc_restriction", lambda x: len(set(x))),
-    }
-    if "src_cancer" in hits.columns:
-        agg_cols["ms_in_cancer"] = ("src_cancer", "any")
-    if "src_healthy_tissue" in hits.columns:
-        agg_cols["ms_in_healthy_tissue"] = ("src_healthy_tissue", "any")
-
-    hit_agg = hits.groupby("peptide", as_index=False).agg(**agg_cols)
+    hit_agg = aggregate_ms_hits_by_peptide(
+        hits,
+        source_flag_outputs={
+            "src_cancer": "ms_in_cancer",
+            "src_healthy_tissue": "ms_in_healthy_tissue",
+        },
+        cell_line_output=None,
+    )
     combined = combined.merge(hit_agg, on="peptide", how="left")
 
     int_cols = {"ms_hit_count", "ms_allele_count"}

--- a/tsarina/targets.py
+++ b/tsarina/targets.py
@@ -175,69 +175,43 @@ def target_peptides(
     combined["peptide_unique_id"] = combined["peptide"]
 
     # ── IEDB/CEDAR evidence lookup ──────────────────────────────────────
-    has_iedb = iedb_path is not None or cedar_path is not None
-    if has_iedb:
-        from .iedb import scan_public_ms
+    needs_ms_evidence = require_ms_evidence or cancer_specific or iedb_path is not None
+    needs_ms_evidence = needs_ms_evidence or cedar_path is not None
+    if needs_ms_evidence:
+        from .ms_evidence import (
+            SOURCE_FLAG_OUTPUTS,
+            aggregate_ms_hits_by_peptide,
+            load_public_ms_hits,
+        )
 
-        unique_peptides = set(combined["peptide"].unique())
-        hits = scan_public_ms(
-            peptides=unique_peptides,
+        source_flag_outputs = SOURCE_FLAG_OUTPUTS if classify_source or cancer_specific else {}
+        hits = load_public_ms_hits(
+            peptides=set(combined["peptide"].unique()),
             iedb_path=iedb_path,
             cedar_path=cedar_path,
             mhc_class=mhc_class,
-            classify_source=classify_source,
+            mhc_species="Homo sapiens",
+            classify_source=classify_source or cancer_specific,
+            drop_binding_assays=True,
         )
+        hit_agg = aggregate_ms_hits_by_peptide(
+            hits,
+            source_flag_outputs=source_flag_outputs,
+            cell_line_output="ms_cell_lines" if source_flag_outputs else None,
+        )
+        combined = combined.merge(hit_agg, on="peptide", how="left")
+        combined["has_ms_evidence"] = combined["ms_hit_count"].notna() & (
+            combined["ms_hit_count"] > 0
+        )
+        combined["ms_hit_count"] = combined["ms_hit_count"].fillna(0).astype(int)
+        combined["ms_alleles"] = combined["ms_alleles"].fillna("")
+        combined["ms_allele_count"] = combined["ms_allele_count"].fillna(0).astype(int)
 
-        if not hits.empty:
-            # Aggregate per peptide
-            _SRC_COLS = [
-                "src_cancer",
-                "src_healthy_tissue",
-                "src_healthy_thymus",
-                "src_healthy_reproductive",
-                "src_cell_line",
-                "src_ebv_lcl",
-                "src_ex_vivo",
-            ]
-            src_agg = {}
-            if classify_source:
-                for sc in _SRC_COLS:
-                    if sc in hits.columns:
-                        src_agg[f"ms_{sc.removeprefix('src_')}"] = (sc, "any")
-                # Collect cell line names
-                if "cell_line_name" in hits.columns:
-                    src_agg["ms_cell_lines"] = (
-                        "cell_line_name",
-                        lambda x: ";".join(sorted({v for v in x if v})),
-                    )
-
-            hit_agg = hits.groupby("peptide", as_index=False).agg(
-                ms_hit_count=("peptide", "size"),
-                ms_alleles=("mhc_restriction", lambda x: ";".join(sorted(set(x)))),
-                ms_allele_count=("mhc_restriction", lambda x: len(set(x))),
-                **src_agg,
-            )
-
-            combined = combined.merge(hit_agg, on="peptide", how="left")
-            combined["has_ms_evidence"] = combined["ms_hit_count"].notna() & (
-                combined["ms_hit_count"] > 0
-            )
-            combined["ms_hit_count"] = combined["ms_hit_count"].fillna(0).astype(int)
-            combined["ms_alleles"] = combined["ms_alleles"].fillna("")
-            combined["ms_allele_count"] = combined["ms_allele_count"].fillna(0).astype(int)
-
-            if classify_source:
-                for sc in _SRC_COLS:
-                    col = f"ms_{sc.removeprefix('src_')}"
-                    if col in combined.columns:
-                        combined[col] = combined[col].fillna(False)
-                if "ms_cell_lines" in combined.columns:
-                    combined["ms_cell_lines"] = combined["ms_cell_lines"].fillna("")
-        else:
-            combined["has_ms_evidence"] = False
-            combined["ms_hit_count"] = 0
-            combined["ms_alleles"] = ""
-            combined["ms_allele_count"] = 0
+        for col in source_flag_outputs.values():
+            if col in combined.columns:
+                combined[col] = combined[col].where(combined[col].notna(), False).astype(bool)
+        if "ms_cell_lines" in combined.columns:
+            combined["ms_cell_lines"] = combined["ms_cell_lines"].fillna("")
 
         # ── Filters ─────────────────────────────────────────────────────
         if require_ms_evidence:

--- a/tsarina/version.py
+++ b/tsarina/version.py
@@ -10,4 +10,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "1.2.0"
+__version__ = "1.2.1"

--- a/tsarina/viral.py
+++ b/tsarina/viral.py
@@ -393,7 +393,7 @@ def viral_iedb_overlap(
         ``iedb_alleles`` (semicolon-separated MHC restrictions),
         ``iedb_hit_count``.
     """
-    from .iedb import scan_public_ms
+    from .ms_evidence import aggregate_ms_hits_for_iedb_columns, load_public_ms_hits
 
     if human_exclusive_only:
         vdf = human_exclusive_viral_peptides(
@@ -413,11 +413,13 @@ def viral_iedb_overlap(
         return vdf
 
     unique_peptides = set(vdf["peptide"].unique())
-    hits = scan_public_ms(
+    hits = load_public_ms_hits(
         peptides=unique_peptides,
         iedb_path=iedb_path,
         cedar_path=cedar_path,
         mhc_class=mhc_class,
+        classify_source=False,
+        drop_binding_assays=True,
     )
 
     if hits.empty:
@@ -427,14 +429,7 @@ def viral_iedb_overlap(
         return vdf
 
     # Aggregate IEDB hits per peptide
-    hit_summary = (
-        hits.groupby("peptide")
-        .agg(
-            iedb_hit_count=("peptide", "size"),
-            iedb_alleles=("mhc_restriction", lambda x: ";".join(sorted(set(x)))),
-        )
-        .reset_index()
-    )
+    hit_summary = aggregate_ms_hits_for_iedb_columns(hits)
 
     vdf = vdf.merge(hit_summary, on="peptide", how="left")
     vdf["has_iedb_hit"] = vdf["iedb_hit_count"].notna() & (vdf["iedb_hit_count"] > 0)


### PR DESCRIPTION
## Summary
- add shared public-MS loading that uses cached hitlist observations by default and raw scanner only for explicit IEDB/CEDAR paths
- fix target_peptides(require_ms_evidence=True / cancer_specific=True) so default calls actually attach and filter MS evidence
- add shared HLA restriction normalization/matching and use it for tsarina hits --allele

Closes #31.
Closes #33.

## Verification
- ./format.sh
- ./lint.sh
- ./test.sh (223 passed)