### PR TITLE
v1.2.2: fix panel MS metrics

### DIFF
--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -10,7 +10,7 @@ duplicate call paths. Keep each PR reviewable, with one version bump per PR.
 - [x] PR 1: Centralize public-MS loading and HLA normalization helpers; fix
       `target_peptides()` default evidence filtering (#31) and
       `tsarina hits --allele` normalization (#33).
-- [ ] PR 2: Rework panel matrix metrics to use the centralized helpers, fail
+- [x] PR 2: Rework panel matrix metrics to use the centralized helpers, fail
       loudly when scoring is unavailable, and count literal HLA restrictions
       instead of regex strings (#34).
 - [ ] PR 3: Refresh README/docs around hitlist data location and the default
@@ -33,6 +33,12 @@ duplicate call paths. Keep each PR reviewable, with one version bump per PR.
 - [x] `./format.sh`
 - [x] `./lint.sh`
 - [x] `./test.sh` — 229 passed
+
+## PR 2 Verification
+
+- [x] `./format.sh`
+- [x] `./lint.sh`
+- [x] `./test.sh` — 235 passed
 
 # Audit — Hitlist Changes And Full Tsarina Pass (2026-04-29)
 

--- a/tests/test_panels.py
+++ b/tests/test_panels.py
@@ -1,2 +1,144 @@
+import pandas as pd
+import pytest
+
+
 def test_panels_module_imports():
     from tsarina import panels  # noqa: F401
+
+
+def _panel_targets() -> pd.DataFrame:
+    return pd.DataFrame(
+        {
+            "peptide": ["PEPTIDEA", "PEPTIDEB", "PEPTIDEC"],
+            "source": ["MAGEA4", "MAGEA4", "PRAME"],
+            "category": ["cta", "cta", "cta"],
+            "has_ms_evidence": [True, True, True],
+            "ms_alleles": [
+                "HLA-A*02:01;HLA-B*07:02",
+                "HLA-A*24:02",
+                "HLA-B*07:02",
+            ],
+        }
+    )
+
+
+def test_ms_peptide_count_uses_literal_normalized_alleles(monkeypatch):
+    from tsarina.panels import build_panel_matrix
+
+    calls = {}
+
+    def _fake_target_peptides(**kwargs):
+        calls.update(kwargs)
+        return _panel_targets()
+
+    monkeypatch.setattr("tsarina.targets.target_peptides", _fake_target_peptides, raising=True)
+
+    matrix = build_panel_matrix(
+        category="cta",
+        alleles=["A*02:01", "HLA-A*24:02", "HLA-B*07:02"],
+        metric="ms_peptide_count",
+    )
+
+    assert calls["attach_ms_evidence"] is True
+    magea4 = matrix[matrix["source"] == "MAGEA4"].iloc[0]
+    assert magea4["A*02:01"] == 1
+    assert magea4["HLA-A*24:02"] == 1
+    assert magea4["HLA-B*07:02"] == 1
+
+
+def test_ms_confirmed_only_still_filters_target_peptides(monkeypatch):
+    from tsarina.panels import build_panel_matrix
+
+    calls = {}
+
+    def _fake_target_peptides(**kwargs):
+        calls.update(kwargs)
+        return _panel_targets()
+
+    monkeypatch.setattr("tsarina.targets.target_peptides", _fake_target_peptides, raising=True)
+
+    build_panel_matrix(
+        category="cta",
+        alleles=["HLA-A*02:01"],
+        metric="ms_peptide_count",
+        ms_confirmed_only=True,
+    )
+
+    assert calls["require_ms_evidence"] is True
+    assert calls["attach_ms_evidence"] is True
+
+
+def test_best_percentile_import_error_propagates(monkeypatch):
+    from tsarina.panels import build_panel_matrix
+
+    monkeypatch.setattr("tsarina.targets.target_peptides", lambda **kw: _panel_targets())
+
+    def _raise_import_error(**kwargs):
+        raise ImportError("missing predictor")
+
+    monkeypatch.setattr("tsarina.scoring.score_presentation", _raise_import_error, raising=True)
+
+    with pytest.raises(ImportError, match="missing predictor"):
+        build_panel_matrix(
+            category="cta",
+            alleles=["HLA-A*02:01"],
+            metric="best_percentile",
+        )
+
+
+def test_best_percentile_uses_lowest_percentile_per_cell(monkeypatch):
+    from tsarina.panels import build_panel_matrix
+
+    monkeypatch.setattr("tsarina.targets.target_peptides", lambda **kw: _panel_targets())
+
+    def _fake_score_presentation(peptides, alleles):
+        return pd.DataFrame(
+            {
+                "peptide": ["PEPTIDEA", "PEPTIDEB", "PEPTIDEC"],
+                "allele": ["HLA-A*02:01", "HLA-A*02:01", "HLA-A*02:01"],
+                "presentation_percentile": [2.0, 0.4, 1.5],
+            }
+        )
+
+    monkeypatch.setattr(
+        "tsarina.scoring.score_presentation",
+        _fake_score_presentation,
+        raising=True,
+    )
+
+    matrix = build_panel_matrix(
+        category="cta",
+        alleles=["HLA-A*02:01"],
+        metric="best_percentile",
+    )
+
+    assert set(matrix["source"]) == {"MAGEA4", "PRAME"}
+    magea4 = matrix[matrix["source"] == "MAGEA4"].iloc[0]
+    prame = matrix[matrix["source"] == "PRAME"].iloc[0]
+    assert magea4["HLA-A*02:01"] == 0.4
+    assert prame["HLA-A*02:01"] == 1.5
+
+
+def test_viral_category_defaults_to_all_viruses(monkeypatch):
+    from tsarina.panels import build_panel_matrix
+
+    calls = {}
+
+    def _fake_target_peptides(**kwargs):
+        import pandas as pd
+
+        calls.update(kwargs)
+        return pd.DataFrame(columns=["source", "category", "peptide"])
+
+    monkeypatch.setattr("tsarina.targets.target_peptides", _fake_target_peptides, raising=True)
+
+    build_panel_matrix(category="viral", alleles=["HLA-A*02:01"])
+
+    assert calls["viruses"] is True
+
+
+def test_unknown_metric_raises():
+    from tsarina.panels import build_panel_matrix
+
+    with pytest.raises(ValueError, match="Unknown metric"):
+        build_panel_matrix(metric="not_a_metric")

--- a/tsarina/panels.py
+++ b/tsarina/panels.py
@@ -101,6 +101,12 @@ def build_panel_matrix(
         columns include ``source``, ``category``, plus one column per
         HLA allele with the selected metric.
     """
+    valid_metrics = {"peptide_count", "ms_peptide_count", "best_percentile", "has_peptide"}
+    if metric not in valid_metrics:
+        raise ValueError(
+            f"Unknown metric '{metric}'. Supported: {', '.join(sorted(valid_metrics))}."
+        )
+
     if alleles is None:
         alleles = list(IEDB27_AB)
 
@@ -110,9 +116,15 @@ def build_panel_matrix(
     include_viral = category in ("viral", "all")
     include_mutant = category in ("mutant", "all")
 
+    viral_targets: list[str] | bool
+    if include_viral:
+        viral_targets = True if viruses is None else viruses
+    else:
+        viral_targets = False
+
     df = target_peptides(
         cta=include_cta,
-        viruses=viruses if include_viral else False,
+        viruses=viral_targets,
         mutations=include_mutant,
         lengths=lengths,
         ensembl_release=ensembl_release,
@@ -120,6 +132,7 @@ def build_panel_matrix(
         cedar_path=cedar_path,
         mhc_class=mhc_class,
         require_ms_evidence=ms_confirmed_only,
+        attach_ms_evidence=metric == "ms_peptide_count",
     )
 
     if df.empty:
@@ -130,16 +143,12 @@ def build_panel_matrix(
     sources = df[["source", "category"]].drop_duplicates().sort_values(["category", "source"])
 
     if metric in ("peptide_count", "best_percentile"):
-        # Need MHCflurry scoring
-        try:
-            from .scoring import score_presentation
+        # Need MHCflurry scoring; import/setup failures must surface because
+        # allele-agnostic fallback values look valid but are scientifically wrong.
+        from .scoring import score_presentation
 
-            unique_peps = df["peptide"].unique().tolist()
-            scores = score_presentation(peptides=unique_peps, alleles=alleles)
-        except ImportError:
-            # Fall back to simple peptide count (no allele specificity)
-            scores = None
-
+        unique_peps = df["peptide"].unique().tolist()
+        scores = score_presentation(peptides=unique_peps, alleles=alleles)
         if scores is not None and not scores.empty:
             # Join scores back to source info
             pep_sources = df[["peptide", "source", "category"]].drop_duplicates()
@@ -166,9 +175,20 @@ def build_panel_matrix(
                 rows.append(row)
             return pd.DataFrame(rows)
 
+        empty_rows = []
+        for _, src_row in sources.iterrows():
+            row = {"source": src_row["source"], "category": src_row["category"]}
+            for allele in alleles:
+                row[allele] = 0 if metric == "peptide_count" else None
+            empty_rows.append(row)
+        return pd.DataFrame(empty_rows)
+
     # Simple metrics that don't need MHCflurry
     if metric == "ms_peptide_count" and "has_ms_evidence" in df.columns:
+        from .mhc import mhc_restriction_matches_any, normalize_mhc_restriction_set
+
         ms_df = df[df["has_ms_evidence"]].copy()
+        wanted_by_allele = {allele: normalize_mhc_restriction_set([allele]) for allele in alleles}
         rows = []
         for _, src_row in sources.iterrows():
             src = src_row["source"]
@@ -178,16 +198,21 @@ def build_panel_matrix(
             for allele in alleles:
                 # Count peptides with MS evidence for this allele
                 if "ms_alleles" in src_peps.columns:
-                    count = src_peps[src_peps["ms_alleles"].str.contains(allele, na=False)][
-                        "peptide"
-                    ].nunique()
+                    wanted = wanted_by_allele[allele]
+                    mask = src_peps["ms_alleles"].map(
+                        lambda value, wanted=wanted: mhc_restriction_matches_any(value, wanted)
+                    )
+                    count = src_peps[mask]["peptide"].nunique()
                 else:
                     count = 0
                 row[allele] = count
             rows.append(row)
         return pd.DataFrame(rows)
 
-    # Fallback: simple peptide count per source (allele-agnostic)
+    if metric == "ms_peptide_count":
+        raise ValueError("metric='ms_peptide_count' requires MS evidence columns.")
+
+    # Fallback: simple peptide presence per source (allele-agnostic).
     rows = []
     for _, src_row in sources.iterrows():
         src = src_row["source"]
@@ -196,6 +221,6 @@ def build_panel_matrix(
         n = src_peps["peptide"].nunique()
         row = {"source": src, "category": cat}
         for allele in alleles:
-            row[allele] = n
+            row[allele] = bool(n) if metric == "has_peptide" else n
         rows.append(row)
     return pd.DataFrame(rows)

--- a/tsarina/targets.py
+++ b/tsarina/targets.py
@@ -48,6 +48,7 @@ def target_peptides(
     cedar_path: str | Path | None = None,
     mhc_class: str | None = "I",
     require_ms_evidence: bool = False,
+    attach_ms_evidence: bool = False,
     classify_source: bool = True,
     cancer_specific: bool = False,
     require_human_exclusive_viral: bool = True,
@@ -76,6 +77,9 @@ def target_peptides(
         MHC class filter for IEDB scanning (default ``"I"``).
     require_ms_evidence
         If True, only return peptides with at least one IEDB/CEDAR hit.
+    attach_ms_evidence
+        If True, attach MS evidence columns without filtering to
+        MS-confirmed peptides.
     classify_source
         If True (default), add source context columns from IEDB
         (``src_cancer``, ``src_healthy``, etc.).
@@ -95,8 +99,9 @@ def target_peptides(
     pd.DataFrame
         Columns: ``peptide``, ``length``, ``category`` (``"cta"``,
         ``"viral"``, ``"mutant"``), ``source`` (gene name, virus name,
-        or mutation label), plus IEDB evidence columns when
-        ``iedb_path`` is provided.
+        or mutation label), plus MS evidence columns when requested via
+        ``attach_ms_evidence``, ``require_ms_evidence``,
+        ``cancer_specific``, or explicit IEDB/CEDAR paths.
     """
     frames: list[pd.DataFrame] = []
 
@@ -175,7 +180,8 @@ def target_peptides(
     combined["peptide_unique_id"] = combined["peptide"]
 
     # ── IEDB/CEDAR evidence lookup ──────────────────────────────────────
-    needs_ms_evidence = require_ms_evidence or cancer_specific or iedb_path is not None
+    needs_ms_evidence = attach_ms_evidence or require_ms_evidence or cancer_specific
+    needs_ms_evidence = needs_ms_evidence or iedb_path is not None
     needs_ms_evidence = needs_ms_evidence or cedar_path is not None
     if needs_ms_evidence:
         from .ms_evidence import (

--- a/tsarina/version.py
+++ b/tsarina/version.py
@@ -10,4 +10,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "1.2.1"
+__version__ = "1.2.2"


### PR DESCRIPTION
## Summary
- make panel ms_peptide_count force MS evidence attachment and count normalized literal HLA restrictions
- remove allele-agnostic fallback for scoring import/runtime failures in best_percentile / peptide_count paths
- validate panel metric names and align viral category default with the documented all-virus behavior
- preserve all scored panel source rows instead of returning from inside the source loop

Closes #34.

## Verification
- ./format.sh
- ./lint.sh
- ./test.sh (235 passed)