### PR TITLE
v1.2.3: refresh hitlist data docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,11 +119,19 @@ See [full curation documentation](docs/curation.md) for the deflated fraction fo
 Foreign proteins from oncogenic viruses -- entirely absent from normal human tissue, making them ideal immunotherapy targets when the virus is present in the tumor.
 
 ```python
-from tsarina.viral import viral_peptides, cancer_specific_viral_peptides
+from tsarina.viral import (
+    human_exclusive_viral_peptides,
+    viral_peptides,
+)
 
-peps = viral_peptides("hpv16")                    # all peptides
-specific = cancer_specific_viral_peptides("hpv16") # exclude non-CTA human overlaps
+peps = viral_peptides("hpv16")                    # all viral peptides
+human_exclusive = human_exclusive_viral_peptides("hpv16")  # default clinical helper
 ```
+
+`personalize()` and `target_peptides()` use the human-exclusive viral helper by
+default, dropping viral k-mers that also occur anywhere in the human proteome.
+`cancer_specific_viral_peptides()` is available for exploratory workflows that
+allow overlaps with CTA proteins while excluding non-CTA overlaps.
 
 | Virus | Cancers | Key oncoproteins |
 |---|---|---|
@@ -289,7 +297,8 @@ tsarina data path iedb
 | EBV proteome | [UniProt UP000153037](https://www.uniprot.org/proteomes/UP000153037) | ~50 KB | `tsarina data fetch ebv` |
 | *(9 viral proteomes total)* | UniProt | varies | `tsarina data fetch <name>` |
 
-Storage location: `~/.tsarina/` (override with `PERSEUS_DATA_DIR` env var).
+Storage location: `~/.hitlist/` (override with `HITLIST_DATA_DIR` env var).
+`tsarina data` delegates registry and cache management to hitlist.
 
 IEDB column indices are resolved dynamically from CSV headers, with fallback to known defaults -- robust to IEDB schema changes.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -100,11 +100,19 @@ See [full curation documentation](docs/curation.md) for the deflated fraction fo
 Foreign proteins from oncogenic viruses -- entirely absent from normal human tissue, making them ideal immunotherapy targets when the virus is present in the tumor.
 
 ```python
-from tsarina.viral import viral_peptides, cancer_specific_viral_peptides
+from tsarina.viral import (
+    human_exclusive_viral_peptides,
+    viral_peptides,
+)
 
-peps = viral_peptides("hpv16")                    # all peptides
-specific = cancer_specific_viral_peptides("hpv16") # exclude non-CTA human overlaps
+peps = viral_peptides("hpv16")                    # all viral peptides
+human_exclusive = human_exclusive_viral_peptides("hpv16")  # default clinical helper
 ```
+
+`personalize()` and `target_peptides()` use the human-exclusive viral helper by
+default, dropping viral k-mers that also occur anywhere in the human proteome.
+`cancer_specific_viral_peptides()` is available for exploratory workflows that
+allow overlaps with CTA proteins while excluding non-CTA overlaps.
 
 | Virus | Cancers | Key oncoproteins |
 |---|---|---|
@@ -270,7 +278,8 @@ tsarina data path iedb
 | EBV proteome | [UniProt UP000153037](https://www.uniprot.org/proteomes/UP000153037) | ~50 KB | `tsarina data fetch ebv` |
 | *(9 viral proteomes total)* | UniProt | varies | `tsarina data fetch <name>` |
 
-Storage location: `~/.tsarina/` (override with `PERSEUS_DATA_DIR` env var).
+Storage location: `~/.hitlist/` (override with `HITLIST_DATA_DIR` env var).
+`tsarina data` delegates registry and cache management to hitlist.
 
 IEDB column indices are resolved dynamically from CSV headers, with fallback to known defaults -- robust to IEDB schema changes.
 

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -13,7 +13,7 @@ duplicate call paths. Keep each PR reviewable, with one version bump per PR.
 - [x] PR 2: Rework panel matrix metrics to use the centralized helpers, fail
       loudly when scoring is unavailable, and count literal HLA restrictions
       instead of regex strings (#34).
-- [ ] PR 3: Refresh README/docs around hitlist data location and the default
+- [x] PR 3: Refresh README/docs around hitlist data location and the default
       human-exclusive viral helper (#32).
 
 ## Design Notes
@@ -35,6 +35,12 @@ duplicate call paths. Keep each PR reviewable, with one version bump per PR.
 - [x] `./test.sh` — 229 passed
 
 ## PR 2 Verification
+
+- [x] `./format.sh`
+- [x] `./lint.sh`
+- [x] `./test.sh` — 235 passed
+
+## PR 3 Verification
 
 - [x] `./format.sh`
 - [x] `./lint.sh`

--- a/tsarina/version.py
+++ b/tsarina/version.py
@@ -10,4 +10,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "1.2.2"
+__version__ = "1.2.3"


### PR DESCRIPTION
## Summary
- update README/docs data storage from ~/.tsarina / PERSEUS_DATA_DIR to hitlist ~/.hitlist / HITLIST_DATA_DIR
- document that tsarina data delegates registry/cache management to hitlist
- foreground human_exclusive_viral_peptides as the default clinical viral helper while keeping cancer_specific_viral_peptides as exploratory

Closes #32.

## Verification
- ./format.sh
- ./lint.sh
- ./test.sh (235 passed)