### PR TITLE
v1.2.4: add MS-tiered panel command

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,29 +230,32 @@ Returns a DataFrame with columns:
 
 Prioritization is by: (1) public MS evidence strength, (2) source protein abundance, (3) predicted presentation quality, (4) absence of healthy-tissue MS evidence.
 
-## Population-spanning tables
+## CTA x HLA panel matrices
 
-Pre-computed target x HLA allele matrices for cohort-level analysis:
+Build a CTA x HLA pMHC matrix for off-the-shelf panel design:
 
-```python
-from tsarina.targets import target_peptides, target_summary
-from tsarina.alleles import get_panel
-
-# Build target table for a specific allele panel
-df = target_peptides(
-    cta=True,
-    viruses=["hpv16", "ebv"],
-    mutations=True,
-    iedb_path="mhc_ligand_full.csv",
-    require_ms_evidence=True,
-    cancer_specific=True,
-)
-
-# Summary by category
-print(target_summary(df))
+```bash
+tsarina panel -o panel.csv
 ```
 
-Available allele panels:
+Defaults:
+
+- top 25 CTAs ranked by cancer MS peptide count
+- `global51_abc_ssa` HLA-A/B/C panel
+- 8-11mer CTA-exclusive peptides
+- MHCflurry presentation scoring
+- MS-evidence-first cell selection
+
+Evidence tiers use configurable presentation percentile cutoffs:
+
+| Evidence tier | Default cutoff | Meaning |
+|---|---:|---|
+| `monoallelic_ms` | < 2.0 | Peptide observed in mono-allelic MS for that HLA |
+| `sample_allele_ms` | < 1.0 | Peptide observed in a multi-allelic sample where this HLA is best among sample alleles |
+| `unrestricted_ms` | < 0.5 | Peptide observed by MS with no usable allele assignment |
+| `predicted_only` | < 0.1 | No MS support; excluded unless `--include-predicted-only` is passed |
+
+Available HLA panels:
 
 | Panel | Alleles | Coverage |
 |---|---|---|

--- a/docs/index.md
+++ b/docs/index.md
@@ -211,29 +211,32 @@ Returns a DataFrame with columns:
 
 Prioritization is by: (1) public MS evidence strength, (2) source protein abundance, (3) predicted presentation quality, (4) absence of healthy-tissue MS evidence.
 
-## Population-spanning tables
+## CTA x HLA panel matrices
 
-Pre-computed target x HLA allele matrices for cohort-level analysis:
+Build a CTA x HLA pMHC matrix for off-the-shelf panel design:
 
-```python
-from tsarina.targets import target_peptides, target_summary
-from tsarina.alleles import get_panel
-
-# Build target table for a specific allele panel
-df = target_peptides(
-    cta=True,
-    viruses=["hpv16", "ebv"],
-    mutations=True,
-    iedb_path="mhc_ligand_full.csv",
-    require_ms_evidence=True,
-    cancer_specific=True,
-)
-
-# Summary by category
-print(target_summary(df))
+```bash
+tsarina panel -o panel.csv
 ```
 
-Available allele panels:
+Defaults:
+
+- top 25 CTAs ranked by cancer MS peptide count
+- `global51_abc_ssa` HLA-A/B/C panel
+- 8-11mer CTA-exclusive peptides
+- MHCflurry presentation scoring
+- MS-evidence-first cell selection
+
+Evidence tiers use configurable presentation percentile cutoffs:
+
+| Evidence tier | Default cutoff | Meaning |
+|---|---:|---|
+| `monoallelic_ms` | < 2.0 | Peptide observed in mono-allelic MS for that HLA |
+| `sample_allele_ms` | < 1.0 | Peptide observed in a multi-allelic sample where this HLA is best among sample alleles |
+| `unrestricted_ms` | < 0.5 | Peptide observed by MS with no usable allele assignment |
+| `predicted_only` | < 0.1 | No MS support; excluded unless `--include-predicted-only` is passed |
+
+Available HLA panels:
 
 | Panel | Alleles | Coverage |
 |---|---|---|

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,3 +1,34 @@
+# PR — Panel Command And MS Evidence Tiers (2026-04-30)
+
+## Goal
+
+Replace the user-facing `spanning` command with a clearer `panel` command that
+builds a CTA x HLA pMHC matrix from sensible defaults, while making panel cell
+selection MS-evidence-first and exposing configurable evidence-tier prediction
+cutoffs.
+
+## Plan
+
+- [x] Rename the primary CLI command to `panel` with help text:
+      "Build a CTA x HLA pMHC matrix for a population HLA panel."
+- [x] Keep `spanning` as a deprecated compatibility alias for one release.
+- [x] Change panel defaults to top 25 CTAs, `global51_abc_ssa`, lengths
+      `8,9,10,11`, MHCflurry, and MS-evidence-first selection.
+- [x] Classify candidate peptide-HLA cells into `monoallelic_ms`,
+      `sample_allele_ms`, `unrestricted_ms`, and optional `predicted_only`.
+- [x] Use default tier cutoffs of 2.0, 1.0, 0.5, and 0.1 percentile,
+      respectively, and expose them as library parameters and CLI flags.
+- [x] Ensure `predicted_only` is excluded by default and, when enabled, cannot
+      displace an MS-supported candidate.
+- [x] Add focused tests for defaults, tier classification, configurable
+      thresholds, CLI flags, and deprecated alias behavior.
+
+## Verification
+
+- [x] `./format.sh`
+- [x] `./lint.sh`
+- [x] `./test.sh` — 240 passed
+
 # PR Series — Evidence And CLI Cleanup (2026-04-30)
 
 ## Goal

--- a/tests/test_cli_spanning.py
+++ b/tests/test_cli_spanning.py
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""CLI smoke tests for ``tsarina spanning``.
+"""CLI smoke tests for ``tsarina panel`` and deprecated ``spanning`` alias.
 
 Mirrors the pattern in ``test_cli_hits.py`` / ``test_cli_personalize.py``:
 exercise the argparse surface via subprocess so flag parsing, choices
@@ -33,45 +33,57 @@ def _run_cli(*args: str, check: bool = True) -> subprocess.CompletedProcess:
     )
 
 
-def test_spanning_help_exits_zero():
-    r = _run_cli("spanning", "--help")
+def test_panel_help_exits_zero():
+    r = _run_cli("panel", "--help")
     assert r.returncode == 0
     for flag in (
         "--cta-count",
         "--ctas",
         "--panel",
         "--alleles",
-        "--max-percentile",
+        "--monoallelic-ms-max-percentile",
+        "--sample-allele-ms-max-percentile",
+        "--unrestricted-ms-max-percentile",
+        "--include-predicted-only",
+        "--predicted-only-max-percentile",
         "--format",
         "--predictor",
     ):
         assert flag in r.stdout, f"missing help text for {flag}"
 
 
-def test_spanning_unknown_panel_rejected():
-    r = _run_cli("spanning", "--panel", "does-not-exist", check=False)
+def test_panel_unknown_panel_rejected():
+    r = _run_cli("panel", "--panel", "does-not-exist", check=False)
     assert r.returncode != 0
     combined = r.stderr + r.stdout
     # argparse reports the valid choices on invalid input
     assert "iedb27_ab" in combined
 
 
-def test_spanning_unknown_format_rejected():
-    r = _run_cli("spanning", "--format", "grid", check=False)
+def test_panel_unknown_format_rejected():
+    r = _run_cli("panel", "--format", "grid", check=False)
     assert r.returncode != 0
     combined = r.stderr + r.stdout
     assert "wide" in combined and "long" in combined
 
 
-def test_spanning_unknown_predictor_rejected():
-    r = _run_cli("spanning", "--predictor", "bogus", check=False)
+def test_panel_unknown_predictor_rejected():
+    r = _run_cli("panel", "--predictor", "bogus", check=False)
     assert r.returncode != 0
     combined = r.stderr + r.stdout
     assert "mhcflurry" in combined
 
 
-def test_spanning_is_registered_in_main_help():
-    """``tsarina --help`` should list spanning as a top-level subcommand."""
+def test_panel_is_registered_in_main_help():
+    """``tsarina --help`` should list panel as the visible top-level subcommand."""
     r = _run_cli("--help")
     assert r.returncode == 0
-    assert "spanning" in r.stdout
+    assert "panel" in r.stdout
+    assert "Build a CTA x HLA pMHC matrix for a population HLA" in r.stdout
+    assert "spanning" not in r.stdout
+
+
+def test_spanning_alias_help_exits_zero():
+    r = _run_cli("spanning", "--help")
+    assert r.returncode == 0
+    assert "--include-predicted-only" in r.stdout

--- a/tests/test_spanning.py
+++ b/tests/test_spanning.py
@@ -13,9 +13,9 @@
 """Unit tests for ``tsarina.spanning.spanning_pmhc_set``.
 
 The library function pulls peptides through ``cta_exclusive_peptides``,
-scores them via ``score_presentation``, and pivots the best result per
-(CTA, allele) cell. Tests stub each of those upstream calls so they run
-without Ensembl / mhcflurry installed.
+loads public MS evidence, scores them via ``score_presentation``, and
+pivots the best result per (CTA, allele) cell. Tests stub each upstream
+call so they run without Ensembl / hitlist data / mhcflurry installed.
 """
 
 from __future__ import annotations
@@ -68,6 +68,23 @@ def _stub_scores(peptides, alleles, **kwargs) -> pd.DataFrame:
     return pd.DataFrame(rows)
 
 
+def _stub_ms_hits(peptides, **kwargs) -> pd.DataFrame:
+    """Default test evidence: every peptide has unrestricted MS support."""
+    return pd.DataFrame(
+        {
+            "peptide": list(peptides),
+            "mhc_restriction": ["HLA class I"] * len(peptides),
+            "mhc_allele_provenance": ["unmatched"] * len(peptides),
+            "mhc_allele_set": [""] * len(peptides),
+            "is_monoallelic": [False] * len(peptides),
+            "pmid": ["1"] * len(peptides),
+            "cell_line_name": [""] * len(peptides),
+            "cell_name": [""] * len(peptides),
+            "source_tissue": [""] * len(peptides),
+        }
+    )
+
+
 @pytest.fixture(autouse=True)
 def _stub_pipeline(monkeypatch):
     """Wire stubs for every upstream call spanning_pmhc_set makes."""
@@ -84,6 +101,11 @@ def _stub_pipeline(monkeypatch):
     monkeypatch.setattr(
         "tsarina.scoring.score_presentation",
         _stub_scores,
+        raising=True,
+    )
+    monkeypatch.setattr(
+        "tsarina.ms_evidence.load_public_ms_hits",
+        _stub_ms_hits,
         raising=True,
     )
     monkeypatch.setattr(
@@ -172,13 +194,13 @@ def test_restriction_levels_filter():
 
 
 def test_panel_default_resolves_via_get_panel():
-    """Default panel='iedb27_ab' should produce a 27-column wide table
-    plus the 'cta' index column = 28 cols."""
+    """Default panel='global51_abc_ssa' should produce a 51-column wide table
+    plus the 'cta' index column = 52 cols."""
     df = spanning_pmhc_set(
         cta_count=2,
         max_percentile=10.0,
     )
-    assert df.shape[1] == 28  # 1 cta + 27 alleles
+    assert df.shape[1] == 52  # 1 cta + 51 alleles
 
 
 def test_explicit_alleles_override_panel():
@@ -223,6 +245,150 @@ def test_max_percentile_filters_weak_cells():
     assert pd.isna(indexed.loc["MAGEA4", "HLA-A*24:02"])
 
 
+def test_monoallelic_ms_tier_and_threshold(monkeypatch):
+    hits = pd.DataFrame(
+        {
+            "peptide": ["MAGEAPEP1"],
+            "mhc_restriction": ["HLA-A*02:01"],
+            "mhc_allele_provenance": ["exact"],
+            "mhc_allele_set": ["HLA-A*02:01"],
+            "is_monoallelic": [True],
+            "pmid": ["111"],
+            "cell_line_name": ["K562-A*02:01"],
+        }
+    )
+    monkeypatch.setattr("tsarina.ms_evidence.load_public_ms_hits", lambda peptides, **kw: hits)
+
+    long = spanning_pmhc_set(
+        ctas=["MAGEA4"],
+        alleles=["HLA-A*02:01"],
+        monoallelic_ms_max_percentile=0.2,
+        output_format="long",
+    )
+    assert len(long) == 1
+    row = long.iloc[0]
+    assert row["evidence_tier"] == "monoallelic_ms"
+    assert row["ms_hit_count"] == 1
+    assert row["ms_pmids"] == "111"
+
+    blocked = spanning_pmhc_set(
+        ctas=["MAGEA4"],
+        alleles=["HLA-A*02:01"],
+        monoallelic_ms_max_percentile=0.05,
+        output_format="long",
+    )
+    assert blocked.empty
+
+
+def test_sample_allele_ms_requires_best_among_sample_alleles(monkeypatch):
+    hits = pd.DataFrame(
+        {
+            "peptide": ["MAGEAPEP1"],
+            "mhc_restriction": ["HLA class I"],
+            "mhc_allele_provenance": ["sample_allele_match"],
+            "mhc_allele_set": ["HLA-A*02:01;HLA-B*07:02"],
+            "is_monoallelic": [False],
+            "pmid": ["222"],
+            "cell_line_name": ["tumor sample"],
+        }
+    )
+    monkeypatch.setattr("tsarina.ms_evidence.load_public_ms_hits", lambda peptides, **kw: hits)
+
+    long = spanning_pmhc_set(
+        ctas=["MAGEA4"],
+        alleles=["HLA-A*02:01", "HLA-B*07:02"],
+        sample_allele_ms_max_percentile=1.0,
+        output_format="long",
+    )
+    assert len(long) == 1
+    row = long.iloc[0]
+    assert row["allele"] == "HLA-A*02:01"
+    assert row["evidence_tier"] == "sample_allele_ms"
+    assert row["ms_pmids"] == "222"
+
+
+def test_unrestricted_ms_tier_uses_processing_evidence(monkeypatch):
+    hits = pd.DataFrame(
+        {
+            "peptide": ["MAGEAPEP1"],
+            "mhc_restriction": ["HLA class I"],
+            "mhc_allele_provenance": ["unmatched"],
+            "mhc_allele_set": [""],
+            "is_monoallelic": [False],
+            "pmid": ["333"],
+            "source_tissue": ["tumor"],
+        }
+    )
+    monkeypatch.setattr("tsarina.ms_evidence.load_public_ms_hits", lambda peptides, **kw: hits)
+
+    long = spanning_pmhc_set(
+        ctas=["MAGEA4"],
+        alleles=["HLA-A*02:01", "HLA-A*24:02"],
+        unrestricted_ms_max_percentile=0.5,
+        output_format="long",
+    )
+    assert len(long) == 1
+    row = long.iloc[0]
+    assert row["allele"] == "HLA-A*02:01"
+    assert row["evidence_tier"] == "unrestricted_ms"
+    assert row["ms_samples"] == "tumor"
+
+
+def test_predicted_only_is_optional_and_last_priority(monkeypatch):
+    empty_hits = pd.DataFrame(
+        columns=[
+            "peptide",
+            "mhc_restriction",
+            "mhc_allele_provenance",
+            "mhc_allele_set",
+            "is_monoallelic",
+        ]
+    )
+    monkeypatch.setattr(
+        "tsarina.ms_evidence.load_public_ms_hits", lambda peptides, **kw: empty_hits
+    )
+
+    default = spanning_pmhc_set(
+        ctas=["MAGEA4"],
+        alleles=["HLA-A*02:01"],
+        output_format="long",
+    )
+    assert default.empty
+
+    predicted = spanning_pmhc_set(
+        ctas=["MAGEA4"],
+        alleles=["HLA-A*02:01"],
+        include_predicted_only=True,
+        predicted_only_max_percentile=0.2,
+        output_format="long",
+    )
+    assert len(predicted) == 1
+    assert predicted.iloc[0]["evidence_tier"] == "predicted_only"
+
+    ms_hits = pd.DataFrame(
+        {
+            "peptide": ["MAGEAPEP2"],
+            "mhc_restriction": ["HLA-A*02:01"],
+            "mhc_allele_provenance": ["exact"],
+            "mhc_allele_set": ["HLA-A*02:01"],
+            "is_monoallelic": [True],
+            "pmid": ["444"],
+        }
+    )
+    monkeypatch.setattr("tsarina.ms_evidence.load_public_ms_hits", lambda peptides, **kw: ms_hits)
+    ms_first = spanning_pmhc_set(
+        ctas=["MAGEA4"],
+        alleles=["HLA-A*02:01"],
+        include_predicted_only=True,
+        predicted_only_max_percentile=0.2,
+        monoallelic_ms_max_percentile=2.0,
+        output_format="long",
+    )
+    assert len(ms_first) == 1
+    assert ms_first.iloc[0]["peptide"] == "MAGEAPEP2"
+    assert ms_first.iloc[0]["evidence_tier"] == "monoallelic_ms"
+
+
 # ── Output formats ─────────────────────────────────────────────────────
 
 
@@ -240,6 +406,11 @@ def test_long_format_has_one_row_per_filled_cell():
         "allele",
         "peptide",
         "length",
+        "evidence_tier",
+        "ms_hit_count",
+        "ms_alleles",
+        "ms_pmids",
+        "ms_samples",
         "presentation_percentile",
         "presentation_score",
         "affinity_nm",
@@ -378,12 +549,19 @@ def test_cli_handler_wires_on_progress_to_stderr(monkeypatch, capsys):
         min_restriction_confidence=["HIGH", "MODERATE"],
         restriction_levels=None,
         alleles=None,
-        panel="iedb27_ab",
-        lengths=(9,),
+        panel="global51_abc_ssa",
+        lengths=(8, 9, 10, 11),
         ensembl_release=112,
         require_cta_exclusive=True,
         predictor="mhcflurry",
-        max_percentile=2.0,
+        monoallelic_ms_max_percentile=2.0,
+        sample_allele_ms_max_percentile=1.0,
+        unrestricted_ms_max_percentile=0.5,
+        include_predicted_only=False,
+        predicted_only_max_percentile=0.1,
+        max_percentile=None,
+        iedb_path=None,
+        cedar_path=None,
         format="wide",
         output=None,
     )

--- a/tsarina/cli.py
+++ b/tsarina/cli.py
@@ -26,6 +26,7 @@ Usage::
 
     tsarina personalize --hla HLA-A*02:01,... --cta PRAME=87.3 -o targets.csv
     tsarina hits --gene PRAME --allele HLA-A*24:02
+    tsarina panel -o panel.csv
 """
 
 from __future__ import annotations
@@ -186,7 +187,15 @@ def main() -> None:
     cli_hits.build_parser(sub)
     cli_spanning.build_parser(sub)
 
-    args = parser.parse_args()
+    argv = sys.argv[1:]
+    deprecated_spanning = bool(argv and argv[0] == "spanning")
+    if deprecated_spanning:
+        argv = ["panel", *argv[1:]]
+
+    args = parser.parse_args(argv)
+    if deprecated_spanning:
+        args.deprecated_spanning = True
+
     if args.command is None:
         parser.print_help()
         sys.exit(1)
@@ -197,7 +206,7 @@ def main() -> None:
         cli_personalize.handle(args)
     elif args.command == "hits":
         cli_hits.handle(args)
-    elif args.command == "spanning":
+    elif args.command == "panel":
         cli_spanning.handle(args)
 
 

--- a/tsarina/cli_spanning.py
+++ b/tsarina/cli_spanning.py
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""``tsarina spanning`` CLI — population-spanning CTA x HLA pMHC table.
+"""``tsarina panel`` CLI — CTA x HLA pMHC panel matrix.
 
 Wraps :func:`tsarina.spanning.spanning_pmhc_set` with argparse.
 """
@@ -29,6 +29,8 @@ _SUPPORTED_PANELS = (
     "global48_abc",
     "global51_abc_ssa",
 )
+_DEFAULT_PANEL = "global51_abc_ssa"
+_DEFAULT_LENGTHS = (8, 9, 10, 11)
 
 
 def _split_csv(value: str) -> list[str]:
@@ -42,19 +44,7 @@ def _parse_lengths(value: str) -> tuple[int, ...]:
         raise argparse.ArgumentTypeError(f"--lengths must be integers: {value!r}") from e
 
 
-def build_parser(sub: argparse._SubParsersAction) -> argparse.ArgumentParser:
-    p = sub.add_parser(
-        "spanning",
-        help="Build a population-spanning CTA x HLA pMHC table.",
-        description=(
-            "Produce a CTA x HLA pivot table where each cell is the best-presented "
-            "peptide for that CTA on that HLA allele. Defaults to top-25 CTAs (ranked "
-            "by ms_cancer_peptide_count) crossed with the IEDB-27 panel at 9-mer "
-            "length and a 2.0%% presentation-percentile cutoff — typically yielding "
-            "200-400 filled cells, suitable as a baseline spanning set for off-the-"
-            "shelf vaccine / TCR programs."
-        ),
-    )
+def _configure_parser(p: argparse.ArgumentParser) -> argparse.ArgumentParser:
     p.add_argument(
         "--cta-count",
         type=int,
@@ -106,14 +96,14 @@ def build_parser(sub: argparse._SubParsersAction) -> argparse.ArgumentParser:
     p.add_argument(
         "--panel",
         choices=_SUPPORTED_PANELS,
-        default="iedb27_ab",
-        help="Named panel from tsarina.alleles (default 'iedb27_ab').",
+        default=_DEFAULT_PANEL,
+        help=f"Named panel from tsarina.alleles (default '{_DEFAULT_PANEL}').",
     )
     p.add_argument(
         "--lengths",
         type=_parse_lengths,
-        default=(9,),
-        help="Peptide lengths to enumerate (default 9).",
+        default=_DEFAULT_LENGTHS,
+        help="Peptide lengths to enumerate (default 8,9,10,11).",
     )
     p.add_argument(
         "--ensembl-release",
@@ -134,10 +124,55 @@ def build_parser(sub: argparse._SubParsersAction) -> argparse.ArgumentParser:
         help="mhctools predictor (default mhcflurry).",
     )
     p.add_argument(
-        "--max-percentile",
+        "--monoallelic-ms-max-percentile",
         type=float,
         default=2.0,
-        help="Maximum presentation percentile for a cell to be filled (default 2.0).",
+        help="Max percentile for mono-allelic MS-supported pMHCs (default 2.0).",
+    )
+    p.add_argument(
+        "--sample-allele-ms-max-percentile",
+        type=float,
+        default=1.0,
+        help=(
+            "Max percentile for multi-allelic sample-genotype MS support where the "
+            "panel allele is best among sample alleles (default 1.0)."
+        ),
+    )
+    p.add_argument(
+        "--unrestricted-ms-max-percentile",
+        type=float,
+        default=0.5,
+        help="Max percentile for peptide-level MS support without usable allele (default 0.5).",
+    )
+    p.add_argument(
+        "--include-predicted-only",
+        action="store_true",
+        help="Allow prediction-only candidates as last-priority fillers.",
+    )
+    p.add_argument(
+        "--predicted-only-max-percentile",
+        type=float,
+        default=0.1,
+        help="Max percentile for prediction-only candidates when enabled (default 0.1).",
+    )
+    p.add_argument(
+        "--max-percentile",
+        type=float,
+        default=None,
+        help=(
+            "Deprecated shortcut: set all MS-supported tier cutoffs to this value. "
+            "Does not enable predicted-only candidates."
+        ),
+    )
+    p.add_argument(
+        "--iedb-path",
+        default=None,
+        help="Optional explicit IEDB ligand CSV; default uses cached hitlist observations.",
+    )
+    p.add_argument(
+        "--cedar-path",
+        default=None,
+        help="Optional explicit CEDAR CSV; default uses cached hitlist observations.",
     )
     p.add_argument(
         "--format",
@@ -146,7 +181,7 @@ def build_parser(sub: argparse._SubParsersAction) -> argparse.ArgumentParser:
         help=(
             "Output format (default 'wide'). 'wide' = CTA rows x allele cols with "
             "peptide as cell value. 'long' = one row per filled cell with peptide / "
-            "length / percentile / score / affinity columns."
+            "evidence tier / MS provenance / percentile / score / affinity columns."
         ),
     )
     p.add_argument(
@@ -158,8 +193,29 @@ def build_parser(sub: argparse._SubParsersAction) -> argparse.ArgumentParser:
     return p
 
 
+def build_parser(sub: argparse._SubParsersAction) -> argparse.ArgumentParser:
+    p = sub.add_parser(
+        "panel",
+        help="Build a CTA x HLA pMHC matrix for a population HLA panel.",
+        description=(
+            "Produce a CTA x HLA pivot table where each cell is the best MS-supported "
+            "peptide-HLA candidate for that CTA and allele. Defaults to top-25 CTAs "
+            "crossed with the Global-51 HLA-A/B/C panel, 8-11mers, and tier-specific "
+            "presentation-percentile cutoffs: mono-allelic MS <=2.0, multi-allelic "
+            "sample-genotype MS <=1.0, unrestricted MS <=0.5. Prediction-only "
+            "candidates are excluded unless --include-predicted-only is supplied."
+        ),
+    )
+    _configure_parser(p)
+
+    return p
+
+
 def handle(args: argparse.Namespace) -> None:
     from .spanning import spanning_pmhc_set
+
+    if getattr(args, "deprecated_spanning", False):
+        print("Warning: `tsarina spanning` is deprecated; use `tsarina panel`.", file=sys.stderr)
 
     min_restriction_confidence: tuple[str, ...] | None
     if any(v.upper() == "ANY" for v in args.min_restriction_confidence):
@@ -182,7 +238,14 @@ def handle(args: argparse.Namespace) -> None:
         ensembl_release=args.ensembl_release,
         require_cta_exclusive=args.require_cta_exclusive,
         predictor=args.predictor,
+        monoallelic_ms_max_percentile=args.monoallelic_ms_max_percentile,
+        sample_allele_ms_max_percentile=args.sample_allele_ms_max_percentile,
+        unrestricted_ms_max_percentile=args.unrestricted_ms_max_percentile,
+        include_predicted_only=args.include_predicted_only,
+        predicted_only_max_percentile=args.predicted_only_max_percentile,
         max_percentile=args.max_percentile,
+        iedb_path=args.iedb_path,
+        cedar_path=args.cedar_path,
         output_format=args.format,
         on_progress=_on_progress,
     )

--- a/tsarina/spanning.py
+++ b/tsarina/spanning.py
@@ -10,17 +10,21 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Population-spanning pMHC sets for off-the-shelf vaccine / TCR programs.
+"""CTA x HLA pMHC panel matrices for off-the-shelf vaccine / TCR programs.
 
-A *spanning set* is a small panel of peptide-HLA pairs designed to
-maximize patient coverage across a population: the most common cancer-
-testis antigens (CTAs) crossed with the most frequent HLA class I
-alleles, with each (CTA, HLA) cell filled by the single best-presented
-peptide that the CTA's protein offers for that allele.
+A panel is a matrix of CTA source proteins crossed with a population HLA
+allele panel. Each (CTA, HLA) cell is filled by the best peptide-HLA candidate
+that satisfies the configured public-MS evidence tier and prediction cutoff.
+
+The default is MS-evidence-first: mono-allelic MS evidence is allowed the
+least stringent prediction cutoff, multi-allelic sample-genotype evidence is
+stricter, unrestricted MS evidence is stricter still, and prediction-only
+candidates are excluded unless explicitly requested.
 
 The output is a wide pivot table — CTA rows, HLA columns, peptide at the
-intersection — plus an optional long format that preserves percentile,
-presentation score, and affinity for downstream filtering.
+intersection — plus an optional long format that preserves evidence tier,
+MS provenance, percentile, presentation score, and affinity for downstream
+filtering.
 
 Typical usage::
 
@@ -28,8 +32,8 @@ Typical usage::
 
     table = spanning_pmhc_set(
         cta_count=25,
-        panel="iedb27_ab",
-        max_percentile=2.0,
+        panel="global51_abc_ssa",
+        lengths=(8, 9, 10, 11),
     )
 """
 
@@ -37,16 +41,35 @@ from __future__ import annotations
 
 import time
 from collections.abc import Callable, Iterable
+from pathlib import Path
 
 import pandas as pd
 
 _DEFAULT_RANK_COLUMN = "ms_cancer_peptide_count"
+_DEFAULT_PANEL = "global51_abc_ssa"
+_DEFAULT_LENGTHS = (8, 9, 10, 11)
+_DEFAULT_MONOALLELIC_MS_MAX_PERCENTILE = 2.0
+_DEFAULT_SAMPLE_ALLELE_MS_MAX_PERCENTILE = 1.0
+_DEFAULT_UNRESTRICTED_MS_MAX_PERCENTILE = 0.5
+_DEFAULT_PREDICTED_ONLY_MAX_PERCENTILE = 0.1
+
+_EVIDENCE_TIER_RANKS: dict[str, int] = {
+    "monoallelic_ms": 0,
+    "sample_allele_ms": 1,
+    "unrestricted_ms": 2,
+    "predicted_only": 3,
+}
 
 _LONG_OUTPUT_COLUMNS: tuple[str, ...] = (
     "cta",
     "allele",
     "peptide",
     "length",
+    "evidence_tier",
+    "ms_hit_count",
+    "ms_alleles",
+    "ms_pmids",
+    "ms_samples",
     "presentation_percentile",
     "presentation_score",
     "affinity_nm",
@@ -60,16 +83,23 @@ def spanning_pmhc_set(
     min_restriction_confidence: Iterable[str] | None = ("HIGH", "MODERATE"),
     restriction_levels: Iterable[str] | None = None,
     alleles: Iterable[str] | None = None,
-    panel: str | None = "iedb27_ab",
-    lengths: tuple[int, ...] = (9,),
+    panel: str | None = _DEFAULT_PANEL,
+    lengths: tuple[int, ...] = _DEFAULT_LENGTHS,
     ensembl_release: int = 112,
     require_cta_exclusive: bool = True,
     predictor: str = "mhcflurry",
-    max_percentile: float = 2.0,
+    monoallelic_ms_max_percentile: float = _DEFAULT_MONOALLELIC_MS_MAX_PERCENTILE,
+    sample_allele_ms_max_percentile: float = _DEFAULT_SAMPLE_ALLELE_MS_MAX_PERCENTILE,
+    unrestricted_ms_max_percentile: float = _DEFAULT_UNRESTRICTED_MS_MAX_PERCENTILE,
+    include_predicted_only: bool = False,
+    predicted_only_max_percentile: float = _DEFAULT_PREDICTED_ONLY_MAX_PERCENTILE,
+    max_percentile: float | None = None,
+    iedb_path: str | Path | None = None,
+    cedar_path: str | Path | None = None,
     output_format: str = "wide",
     on_progress: Callable[[str], None] | None = None,
 ) -> pd.DataFrame:
-    """Build a CTA x HLA spanning pMHC table.
+    """Build a CTA x HLA pMHC panel matrix.
 
     Parameters
     ----------
@@ -97,10 +127,9 @@ def spanning_pmhc_set(
         Explicit allele list.  Overrides ``panel``.
     panel
         Named panel from :mod:`tsarina.alleles`.  Default
-        ``"iedb27_ab"`` (27 globally-common HLA-A/B alleles).
+        ``"global51_abc_ssa"`` (51 globally broad HLA-A/B/C alleles).
     lengths
-        Peptide lengths (default 9-mers — the dominant class I length and
-        the most therapeutically relevant for vaccine / TCR design).
+        Peptide lengths (default 8-11-mers for MHC class I).
     ensembl_release
         Ensembl release for peptide enumeration (default 112).
     require_cta_exclusive
@@ -111,11 +140,30 @@ def spanning_pmhc_set(
     predictor
         mhctools predictor key.  ``"mhcflurry"`` (default), ``"netmhcpan"``,
         or ``"netmhcpan_el"``.
+    monoallelic_ms_max_percentile
+        Maximum percentile for a peptide-HLA candidate with mono-allelic
+        MS support for that allele. Default 2.0.
+    sample_allele_ms_max_percentile
+        Maximum percentile for a candidate observed in a multi-allelic sample
+        whose genotype contains the HLA allele and whose predicted percentile
+        is best among that sample's alleles. Default 1.0.
+    unrestricted_ms_max_percentile
+        Maximum percentile for a candidate whose peptide has MS evidence but
+        no usable allele assignment. Default 0.5.
+    include_predicted_only
+        If True, allow prediction-only candidates. They are ranked below all
+        MS-supported candidates and therefore only fill otherwise-empty cells.
+        Default False.
+    predicted_only_max_percentile
+        Maximum percentile for prediction-only candidates when enabled.
+        Default 0.1.
     max_percentile
-        Maximum presentation percentile for a cell to be filled.  Cells
-        whose best peptide exceeds this threshold are left blank in wide
-        output (or absent in long output).  Default 2.0% — the standard
-        MHC class I "presented" threshold.
+        Deprecated compatibility shortcut. When supplied, sets all three
+        MS-supported tier cutoffs to the same value. It does not enable or
+        relax prediction-only candidates.
+    iedb_path, cedar_path
+        Optional explicit raw public-MS files. Defaults use hitlist's cached
+        observations path.
     output_format
         ``"wide"`` (default) — pivot with CTA rows, allele columns, and
         the chosen peptide as the cell value.
@@ -147,6 +195,11 @@ def spanning_pmhc_set(
     if output_format not in ("wide", "long"):
         raise ValueError(f"output_format must be 'wide' or 'long', got {output_format!r}")
 
+    if max_percentile is not None:
+        monoallelic_ms_max_percentile = max_percentile
+        sample_allele_ms_max_percentile = max_percentile
+        unrestricted_ms_max_percentile = max_percentile
+
     allele_list = _resolve_alleles(alleles, panel)
     cta_list = _resolve_ctas(
         ctas=ctas,
@@ -168,29 +221,58 @@ def spanning_pmhc_set(
     if pep_df.empty:
         return _empty_output(cta_list, allele_list, output_format)
 
-    from .scoring import score_presentation
+    from .ms_evidence import load_public_ms_hits
 
     unique_peptides = pep_df["peptide"].unique().tolist()
-    n_predictions = len(unique_peptides) * len(allele_list)
+    hits = load_public_ms_hits(
+        unique_peptides,
+        iedb_path=iedb_path,
+        cedar_path=cedar_path,
+        mhc_class="I",
+        mhc_species="Homo sapiens",
+    )
+
+    from .scoring import score_presentation
+
+    score_alleles = _score_alleles_for_panel(allele_list, hits)
+    n_predictions = len(unique_peptides) * len(score_alleles)
     if on_progress is not None:
         on_progress(
-            f"Scoring {len(unique_peptides)} peptides x {len(allele_list)} alleles "
+            f"Scoring {len(unique_peptides)} peptides x {len(score_alleles)} alleles "
             f"(~{n_predictions} predictions) via {predictor}..."
         )
 
     scoring_start = time.perf_counter()
-    scores = score_presentation(peptides=unique_peptides, alleles=allele_list, predictor=predictor)
+    scores = score_presentation(
+        peptides=unique_peptides, alleles=score_alleles, predictor=predictor
+    )
     scoring_elapsed = time.perf_counter() - scoring_start
 
     if on_progress is not None:
         on_progress(f"Scored {n_predictions} predictions in {scoring_elapsed:.1f}s")
 
-    best = _best_per_cell(scores, pep_df, max_percentile)
+    evidence_stats = _build_evidence_stats(hits, allele_list, _score_lookup(scores))
+    candidates = _candidate_rows(
+        scores=scores,
+        pep_df=pep_df,
+        allele_list=allele_list,
+        evidence_stats=evidence_stats,
+        cutoffs={
+            "monoallelic_ms": monoallelic_ms_max_percentile,
+            "sample_allele_ms": sample_allele_ms_max_percentile,
+            "unrestricted_ms": unrestricted_ms_max_percentile,
+            "predicted_only": predicted_only_max_percentile,
+        },
+        include_predicted_only=include_predicted_only,
+    )
+    best = _best_per_cell(candidates)
 
     if on_progress is not None:
         on_progress(
-            f"Spanning set: {len(cta_list)} CTAs x {len(allele_list)} alleles, "
-            f"{len(best)} filled cells at percentile <= {max_percentile}"
+            f"Panel: {len(cta_list)} CTAs x {len(allele_list)} alleles, "
+            f"{len(best)} filled cells using MS tier cutoffs "
+            f"{monoallelic_ms_max_percentile}/{sample_allele_ms_max_percentile}/"
+            f"{unrestricted_ms_max_percentile}"
         )
 
     if output_format == "wide":
@@ -276,54 +358,244 @@ def _resolve_peptides(
     return all_peps[all_peps["gene_name"].isin(cta_list)].copy()
 
 
-def _best_per_cell(
+def _score_alleles_for_panel(allele_list: list[str], hits: pd.DataFrame) -> list[str]:
+    """Return panel alleles plus sample-genotype alleles needed for best-of-sample checks."""
+    from .mhc import split_mhc_restrictions
+
+    out = list(dict.fromkeys(allele_list))
+    seen = set(out)
+    if hits.empty or "mhc_allele_set" not in hits.columns:
+        return out
+
+    for _, row in hits.iterrows():
+        if str(row.get("mhc_allele_provenance", "")).strip() != "sample_allele_match":
+            continue
+        value = row.get("mhc_allele_set", "")
+        for allele in split_mhc_restrictions(value):
+            if allele.startswith("HLA-") and "*" in allele and allele not in seen:
+                out.append(allele)
+                seen.add(allele)
+    return out
+
+
+def _score_lookup(scores: pd.DataFrame) -> dict[tuple[str, str], float]:
+    if scores.empty or "presentation_percentile" not in scores.columns:
+        return {}
+    return {
+        (str(row.peptide), str(row.allele)): float(row.presentation_percentile)
+        for row in scores.itertuples(index=False)
+        if pd.notna(row.presentation_percentile)
+    }
+
+
+def _new_evidence_bucket() -> dict[str, object]:
+    return {
+        "ms_hit_count": 0,
+        "ms_alleles": set(),
+        "ms_pmids": set(),
+        "ms_samples": set(),
+    }
+
+
+def _add_evidence(
+    stats: dict[tuple[str, str | None, str], dict[str, object]],
+    key: tuple[str, str | None, str],
+    row: pd.Series,
+) -> None:
+    bucket = stats.setdefault(key, _new_evidence_bucket())
+    bucket["ms_hit_count"] = int(bucket["ms_hit_count"]) + 1
+    for source_col, output_key in (
+        ("mhc_restriction", "ms_alleles"),
+        ("pmid", "ms_pmids"),
+    ):
+        value = row.get(source_col)
+        if isinstance(value, str):
+            stripped = value.strip()
+            if stripped:
+                bucket[output_key].add(stripped)
+        elif pd.notna(value):
+            bucket[output_key].add(str(value))
+    for source_col in ("cell_line_name", "cell_name", "source_tissue"):
+        value = row.get(source_col)
+        if isinstance(value, str):
+            stripped = value.strip()
+            if stripped:
+                bucket["ms_samples"].add(stripped)
+
+
+def _finalize_evidence_bucket(bucket: dict[str, object]) -> dict[str, object]:
+    return {
+        "ms_hit_count": int(bucket["ms_hit_count"]),
+        "ms_alleles": ";".join(sorted(bucket["ms_alleles"])),
+        "ms_pmids": ";".join(sorted(bucket["ms_pmids"])),
+        "ms_samples": ";".join(sorted(bucket["ms_samples"])),
+    }
+
+
+def _is_truthy(value: object) -> bool:
+    if isinstance(value, bool):
+        return value
+    if pd.isna(value):
+        return False
+    return str(value).strip().lower() in {"true", "1", "yes"}
+
+
+def _is_best_sample_allele(
+    peptide: str,
+    allele: str,
+    sample_alleles: set[str],
+    score_lookup: dict[tuple[str, str], float],
+) -> bool:
+    allele_score = score_lookup.get((peptide, allele))
+    if allele_score is None:
+        return False
+    sample_scores = [
+        score_lookup[(peptide, sample_allele)]
+        for sample_allele in sample_alleles
+        if (peptide, sample_allele) in score_lookup
+    ]
+    if not sample_scores:
+        return False
+    return allele_score <= min(sample_scores) + 1e-12
+
+
+def _build_evidence_stats(
+    hits: pd.DataFrame,
+    allele_list: list[str],
+    score_lookup: dict[tuple[str, str], float],
+) -> dict[tuple[str, str | None, str], dict[str, object]]:
+    """Build evidence buckets keyed by peptide, allele, and evidence tier."""
+    from .mhc import split_mhc_restrictions
+
+    stats: dict[tuple[str, str | None, str], dict[str, object]] = {}
+    if hits.empty or "peptide" not in hits.columns:
+        return stats
+
+    panel_alleles = set(allele_list)
+    for _, row in hits.iterrows():
+        peptide_value = row.get("peptide")
+        if not isinstance(peptide_value, str) or not peptide_value.strip():
+            continue
+        peptide = peptide_value.strip()
+        restrictions = set(split_mhc_restrictions(row.get("mhc_restriction", "")))
+        exact_panel_alleles = {
+            allele for allele in restrictions if allele in panel_alleles and "*" in allele
+        }
+        is_monoallelic = _is_truthy(row.get("is_monoallelic", False))
+        matched = False
+
+        if is_monoallelic and exact_panel_alleles:
+            for allele in exact_panel_alleles:
+                _add_evidence(stats, (peptide, allele, "monoallelic_ms"), row)
+            matched = True
+        elif exact_panel_alleles:
+            for allele in exact_panel_alleles:
+                _add_evidence(stats, (peptide, allele, "sample_allele_ms"), row)
+            matched = True
+        else:
+            sample_alleles = set(split_mhc_restrictions(row.get("mhc_allele_set", "")))
+            provenance = str(row.get("mhc_allele_provenance", "")).strip()
+            if provenance == "sample_allele_match" and sample_alleles:
+                for allele in sorted(panel_alleles & sample_alleles):
+                    if _is_best_sample_allele(peptide, allele, sample_alleles, score_lookup):
+                        _add_evidence(stats, (peptide, allele, "sample_allele_ms"), row)
+                        matched = True
+
+        has_specific_restriction = any(
+            allele.startswith("HLA-") and "*" in allele for allele in restrictions
+        )
+        if not matched and not has_specific_restriction:
+            _add_evidence(stats, (peptide, None, "unrestricted_ms"), row)
+
+    return {
+        key: _finalize_evidence_bucket(bucket)
+        for key, bucket in stats.items()
+        if int(bucket["ms_hit_count"]) > 0
+    }
+
+
+def _candidate_rows(
     scores: pd.DataFrame,
     pep_df: pd.DataFrame,
-    max_percentile: float,
+    allele_list: list[str],
+    evidence_stats: dict[tuple[str, str | None, str], dict[str, object]],
+    cutoffs: dict[str, float],
+    include_predicted_only: bool,
 ) -> pd.DataFrame:
-    """For each (cta, allele), pick the lowest-percentile peptide above
-    the max_percentile cutoff."""
+    columns = [*_LONG_OUTPUT_COLUMNS, "_tier_rank"]
     if scores.empty or "presentation_percentile" not in scores.columns:
-        return pd.DataFrame(
-            columns=[
-                "cta",
-                "allele",
-                "peptide",
-                "length",
-                "presentation_percentile",
-                "presentation_score",
-                "affinity_nm",
-            ]
-        )
+        return pd.DataFrame(columns=columns)
 
     pep_meta = (
         pep_df[["peptide", "gene_name", "length"]]
-        .drop_duplicates(subset="peptide")
+        .drop_duplicates(subset=["peptide", "gene_name", "length"])
         .rename(columns={"gene_name": "cta"})
     )
-    scored = scores.merge(pep_meta, on="peptide", how="inner")
+    scored = scores[scores["allele"].isin(allele_list)].merge(pep_meta, on="peptide", how="inner")
+    if scored.empty:
+        return pd.DataFrame(columns=columns)
 
-    sort_cols = ["presentation_percentile", "peptide", "allele"]
+    rows = []
+    for row in scored.itertuples(index=False):
+        peptide = str(row.peptide)
+        allele = str(row.allele)
+        percentile = float(row.presentation_percentile)
+        chosen_tier = None
+        evidence = None
+        for tier in ("monoallelic_ms", "sample_allele_ms", "unrestricted_ms"):
+            key = (peptide, allele, tier)
+            if tier == "unrestricted_ms" and key not in evidence_stats:
+                key = (peptide, None, tier)
+            tier_evidence = evidence_stats.get(key)
+            if tier_evidence is not None and percentile < cutoffs[tier]:
+                chosen_tier = tier
+                evidence = tier_evidence
+                break
+
+        if chosen_tier is None:
+            if not include_predicted_only or percentile >= cutoffs["predicted_only"]:
+                continue
+            chosen_tier = "predicted_only"
+            evidence = {
+                "ms_hit_count": 0,
+                "ms_alleles": "",
+                "ms_pmids": "",
+                "ms_samples": "",
+            }
+
+        rows.append(
+            {
+                "cta": row.cta,
+                "allele": allele,
+                "peptide": peptide,
+                "length": row.length,
+                "evidence_tier": chosen_tier,
+                "ms_hit_count": evidence["ms_hit_count"],
+                "ms_alleles": evidence["ms_alleles"],
+                "ms_pmids": evidence["ms_pmids"],
+                "ms_samples": evidence["ms_samples"],
+                "presentation_percentile": percentile,
+                "presentation_score": getattr(row, "presentation_score", pd.NA),
+                "affinity_nm": getattr(row, "affinity_nm", pd.NA),
+                "_tier_rank": _EVIDENCE_TIER_RANKS[chosen_tier],
+            }
+        )
+
+    return pd.DataFrame(rows, columns=columns)
+
+
+def _best_per_cell(candidates: pd.DataFrame) -> pd.DataFrame:
+    """For each (cta, allele), pick highest evidence tier, then best percentile."""
+    if candidates.empty:
+        return pd.DataFrame(columns=list(_LONG_OUTPUT_COLUMNS))
+
+    sort_cols = ["_tier_rank", "presentation_percentile", "peptide", "allele"]
     best = (
-        scored.sort_values(sort_cols, kind="mergesort")
+        candidates.sort_values(sort_cols, kind="mergesort")
         .groupby(["cta", "allele"], as_index=False)
         .first()
     )
-    best = best[best["presentation_percentile"] <= max_percentile].copy()
-    for col in ("presentation_score", "affinity_nm"):
-        if col not in best.columns:
-            best[col] = pd.NA
-    return best[
-        [
-            "cta",
-            "allele",
-            "peptide",
-            "length",
-            "presentation_percentile",
-            "presentation_score",
-            "affinity_nm",
-        ]
-    ]
+    return best[list(_LONG_OUTPUT_COLUMNS)]
 
 
 def _to_wide(

--- a/tsarina/version.py
+++ b/tsarina/version.py
@@ -10,4 +10,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "1.2.3"
+__version__ = "1.2.4"


### PR DESCRIPTION
## Summary
- add visible `tsarina panel` command and keep `tsarina spanning` as a deprecated compatibility alias
- change panel defaults to Global-51, 8-11mers, MS-evidence-first selection, and strict tier cutoffs
- classify panel candidates as monoallelic_ms, sample_allele_ms, unrestricted_ms, or optional predicted_only with parameterized CLI/library thresholds
- document the new defaults and evidence tiers

## Verification
- ./format.sh
- ./lint.sh
- ./test.sh (240 passed)