### PR TITLE
v1.2.5: improve panel CLI progress and report

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,7 +235,7 @@ Prioritization is by: (1) public MS evidence strength, (2) source protein abunda
 Build a CTA x HLA pMHC matrix for off-the-shelf panel design:
 
 ```bash
-tsarina panel -o panel.csv
+tsarina panel
 ```
 
 Defaults:
@@ -245,6 +245,20 @@ Defaults:
 - 8-11mer CTA-exclusive peptides
 - MHCflurry presentation scoring
 - MS-evidence-first cell selection
+- up to 3 peptides per CTA x HLA cell, ranked by MS source count, then prediction
+- readable terminal table plus coverage summary
+
+Use CSV formats for scripts:
+
+```bash
+tsarina panel --format long -o panel-long.csv
+tsarina panel --format wide -o panel-wide.csv
+```
+
+The CLI prints progress for peptide enumeration, public-MS evidence loading,
+scoring, evidence-tier construction, and final selection. Interactive terminals
+also get a `tqdm` scoring progress bar; use `--no-progress` or
+`--no-progress-bars` to suppress it.
 
 Evidence tiers use configurable presentation percentile cutoffs:
 
@@ -269,7 +283,7 @@ Regional allele frequency data from 7 geographic regions supports population-wei
 
 ## Data management
 
-Perseus manages all external data dependencies through a unified registry:
+Tsarina uses the shared hitlist data registry for external datasets:
 
 ```bash
 # See what data is available

--- a/docs/index.md
+++ b/docs/index.md
@@ -216,7 +216,7 @@ Prioritization is by: (1) public MS evidence strength, (2) source protein abunda
 Build a CTA x HLA pMHC matrix for off-the-shelf panel design:
 
 ```bash
-tsarina panel -o panel.csv
+tsarina panel
 ```
 
 Defaults:
@@ -226,6 +226,20 @@ Defaults:
 - 8-11mer CTA-exclusive peptides
 - MHCflurry presentation scoring
 - MS-evidence-first cell selection
+- up to 3 peptides per CTA x HLA cell, ranked by MS source count, then prediction
+- readable terminal table plus coverage summary
+
+Use CSV formats for scripts:
+
+```bash
+tsarina panel --format long -o panel-long.csv
+tsarina panel --format wide -o panel-wide.csv
+```
+
+The CLI prints progress for peptide enumeration, public-MS evidence loading,
+scoring, evidence-tier construction, and final selection. Interactive terminals
+also get a `tqdm` scoring progress bar; use `--no-progress` or
+`--no-progress-bars` to suppress it.
 
 Evidence tiers use configurable presentation percentile cutoffs:
 
@@ -250,7 +264,7 @@ Regional allele frequency data from 7 geographic regions supports population-wei
 
 ## Data management
 
-Perseus manages all external data dependencies through a unified registry:
+Tsarina uses the shared hitlist data registry for external datasets:
 
 ```bash
 # See what data is available

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -1,3 +1,4 @@
 # Lessons
 
 - When a user asks to re-check code after changes, do not rely on prior findings. Re-inspect the current repository state first, preferably by reviewing the latest commit/diff before reporting.
+- For interactive CLI defaults, do not assume CSV-on-stdout is acceptable for exploratory commands. If the user is expected to run a long scientific workflow directly, provide visible progress and a readable default report, while keeping machine-readable modes explicit.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,3 +1,36 @@
+# PR — Panel Progress, Table Output, And Summary (2026-04-30)
+
+## Goal
+
+Make `tsarina panel` useful as an interactive default command, not just a CSV
+generator: show meaningful progress while long scoring work runs, print a
+readable terminal table by default, keep CSV output for automation, and append
+coverage-style summary statistics.
+
+## Plan
+
+- [x] Add richer panel progress stages for CTA resolution, peptide enumeration,
+      public-MS evidence loading, scoring, candidate selection, and summary.
+- [x] Score in chunks when CLI progress bars are enabled so `tqdm` can report
+      the slow prediction stage instead of a single quiet blocking call.
+- [x] Support a configurable top-N peptide cap per CTA x HLA cell, default 3,
+      ranked by MS source count first, then MS hit count, then prediction.
+- [x] Preserve current wide/long CSV modes while adding a default text table
+      CLI mode with CTA rows ordered by CTA rank and HLA alleles ordered by
+      weighted population frequency when built-in frequency data exist.
+- [x] Add summary statistics for HLA allele count, CTA count, selected peptide
+      count, filled cells, expected population coverage per CTA, and fraction
+      of CTAs covered per HLA.
+- [x] Update CLI help/docs and bump the package patch version.
+- [x] Add focused tests for default CLI table output, progress behavior,
+      top-N selection/ranking, weighted ordering, and summary calculation.
+
+## Verification
+
+- [x] `./format.sh`
+- [x] `./lint.sh`
+- [x] `./test.sh` — 246 passed
+
 # PR — Panel Command And MS Evidence Tiers (2026-04-30)
 
 ## Goal

--- a/tests/test_cli_spanning.py
+++ b/tests/test_cli_spanning.py
@@ -46,7 +46,11 @@ def test_panel_help_exits_zero():
         "--unrestricted-ms-max-percentile",
         "--include-predicted-only",
         "--predicted-only-max-percentile",
+        "--peptides-per-cell",
         "--format",
+        "--no-summary",
+        "--no-progress",
+        "--progress-bars",
         "--predictor",
     ):
         assert flag in r.stdout, f"missing help text for {flag}"
@@ -64,7 +68,7 @@ def test_panel_unknown_format_rejected():
     r = _run_cli("panel", "--format", "grid", check=False)
     assert r.returncode != 0
     combined = r.stderr + r.stdout
-    assert "wide" in combined and "long" in combined
+    assert "table" in combined and "wide" in combined and "long" in combined
 
 
 def test_panel_unknown_predictor_rejected():

--- a/tests/test_spanning.py
+++ b/tests/test_spanning.py
@@ -20,6 +20,8 @@ call so they run without Ensembl / hitlist data / mhcflurry installed.
 
 from __future__ import annotations
 
+import io
+
 import pandas as pd
 import pytest
 
@@ -227,6 +229,7 @@ def test_lowest_percentile_peptide_wins_each_cell():
         ctas=["MAGEA4", "PRAME"],
         alleles=["HLA-A*02:01"],
         max_percentile=2.0,
+        peptides_per_cell=1,
     )
     assert df.set_index("cta").loc["MAGEA4", "HLA-A*02:01"] == "MAGEAPEP1"
     assert df.set_index("cta").loc["PRAME", "HLA-A*02:01"] == "PRAMEPEP1"
@@ -239,6 +242,7 @@ def test_max_percentile_filters_weak_cells():
         ctas=["MAGEA4", "PRAME"],
         alleles=["HLA-A*02:01", "HLA-A*24:02"],
         max_percentile=0.5,
+        peptides_per_cell=1,
     )
     indexed = df.set_index("cta")
     assert indexed.loc["MAGEA4", "HLA-A*02:01"] == "MAGEAPEP1"
@@ -389,6 +393,51 @@ def test_predicted_only_is_optional_and_last_priority(monkeypatch):
     assert ms_first.iloc[0]["evidence_tier"] == "monoallelic_ms"
 
 
+def test_peptides_per_cell_keeps_ranked_top_n():
+    long = spanning_pmhc_set(
+        ctas=["MAGEA4"],
+        alleles=["HLA-A*02:01"],
+        max_percentile=10.0,
+        peptides_per_cell=2,
+        output_format="long",
+    )
+    assert list(long["peptide"]) == ["MAGEAPEP1", "MAGEAPEP2"]
+    assert list(long["peptide_rank_in_cell"]) == [1, 2]
+
+    wide = spanning_pmhc_set(
+        ctas=["MAGEA4"],
+        alleles=["HLA-A*02:01"],
+        max_percentile=10.0,
+        peptides_per_cell=2,
+    )
+    assert wide.set_index("cta").loc["MAGEA4", "HLA-A*02:01"] == "MAGEAPEP1; MAGEAPEP2"
+
+
+def test_peptides_per_cell_ranks_ms_support_before_prediction(monkeypatch):
+    hits = pd.DataFrame(
+        {
+            "peptide": ["MAGEAPEP1", "MAGEAPEP2", "MAGEAPEP2"],
+            "mhc_restriction": ["HLA class I", "HLA class I", "HLA class I"],
+            "mhc_allele_provenance": ["unmatched", "unmatched", "unmatched"],
+            "mhc_allele_set": ["", "", ""],
+            "is_monoallelic": [False, False, False],
+            "pmid": ["111", "222", "333"],
+        }
+    )
+    monkeypatch.setattr("tsarina.ms_evidence.load_public_ms_hits", lambda peptides, **kw: hits)
+
+    long = spanning_pmhc_set(
+        ctas=["MAGEA4"],
+        alleles=["HLA-A*02:01"],
+        max_percentile=10.0,
+        peptides_per_cell=2,
+        output_format="long",
+    )
+    assert list(long["peptide"]) == ["MAGEAPEP2", "MAGEAPEP1"]
+    assert list(long["ms_hit_count"]) == [2, 1]
+    assert list(long["ms_source_count"]) == [2, 1]
+
+
 # ── Output formats ─────────────────────────────────────────────────────
 
 
@@ -397,6 +446,7 @@ def test_long_format_has_one_row_per_filled_cell():
         ctas=["MAGEA4", "PRAME"],
         alleles=["HLA-A*02:01", "HLA-A*24:02"],
         max_percentile=2.0,
+        peptides_per_cell=1,
         output_format="long",
     )
     # 2 CTAs * 2 alleles = 4 cells, all pass with max=2.0
@@ -408,12 +458,14 @@ def test_long_format_has_one_row_per_filled_cell():
         "length",
         "evidence_tier",
         "ms_hit_count",
+        "ms_source_count",
         "ms_alleles",
         "ms_pmids",
         "ms_samples",
         "presentation_percentile",
         "presentation_score",
         "affinity_nm",
+        "peptide_rank_in_cell",
     }
     # Sorted by cta then allele in the supplied order
     assert list(long["cta"]) == ["MAGEA4", "MAGEA4", "PRAME", "PRAME"]
@@ -425,6 +477,7 @@ def test_long_format_drops_filtered_cells_entirely():
         ctas=["MAGEA4"],
         alleles=["HLA-A*02:01", "HLA-A*24:02"],
         max_percentile=0.5,
+        peptides_per_cell=1,
         output_format="long",
     )
     assert len(long) == 1
@@ -434,6 +487,58 @@ def test_long_format_drops_filtered_cells_entirely():
 def test_unrecognized_output_format_raises():
     with pytest.raises(ValueError, match="output_format"):
         spanning_pmhc_set(output_format="grid")
+
+
+def test_output_attrs_include_summary_and_order_metadata():
+    long = spanning_pmhc_set(
+        ctas=["MAGEA4"],
+        alleles=["HLA-A*02:01", "HLA-A*24:02"],
+        max_percentile=10.0,
+        peptides_per_cell=2,
+        output_format="long",
+    )
+    summary = long.attrs["panel_summary"]
+    assert long.attrs["cta_order"] == ["MAGEA4"]
+    assert long.attrs["allele_order"] == ["HLA-A*02:01", "HLA-A*24:02"]
+    assert summary["hla_allele_count"] == 2
+    assert summary["cta_count"] == 1
+    assert summary["filled_cell_count"] == 2
+    assert summary["selected_peptide_count"] == 2
+    assert summary["cta_coverage"][0]["covered_hla_count"] == 2
+    assert summary["hla_coverage"][0]["covered_cta_fraction"] == 1.0
+
+
+def test_panel_alleles_are_ordered_by_weighted_frequency(monkeypatch):
+    monkeypatch.setattr(
+        "tsarina.alleles.get_panel",
+        lambda panel: ["HLA-A*24:02", "HLA-A*02:01"],
+        raising=True,
+    )
+    monkeypatch.setattr(
+        "tsarina.regions.REGION_POPULATIONS",
+        {"test-region": 1.0},
+        raising=True,
+    )
+    monkeypatch.setattr(
+        "tsarina.regions.region_allele_frequencies",
+        lambda: pd.DataFrame(
+            {
+                "region": ["test-region", "test-region"],
+                "allele": ["HLA-A*24:02", "HLA-A*02:01"],
+                "frequency": [0.1, 0.3],
+            }
+        ),
+        raising=True,
+    )
+
+    df = spanning_pmhc_set(
+        ctas=["MAGEA4"],
+        panel="test-panel",
+        max_percentile=10.0,
+        peptides_per_cell=1,
+    )
+    assert list(df.columns) == ["cta", "HLA-A*02:01", "HLA-A*24:02"]
+    assert df.attrs["allele_order"] == ["HLA-A*02:01", "HLA-A*24:02"]
 
 
 # ── Edge cases ─────────────────────────────────────────────────────────
@@ -477,19 +582,13 @@ def test_on_progress_callback_receives_three_stages():
         max_percentile=2.0,
         on_progress=messages.append,
     )
-    # Expect three stages: pre-scoring, post-scoring, summary.
-    assert len(messages) == 3
-    pre, post, summary = messages
-    # Pre-scoring mentions peptide + allele counts and predictor.
-    assert "peptides" in pre.lower() and "alleles" in pre.lower()
-    assert "mhcflurry" in pre
-    # Post-scoring mentions elapsed time.
-    assert "Scored" in post
-    assert "s" in post  # the elapsed-seconds suffix
-    # Summary mentions CTA + allele counts and filled-cell count.
-    assert "CTAs" in summary
-    assert "alleles" in summary
-    assert "filled cells" in summary
+    assert any("Panel inputs" in msg for msg in messages)
+    assert any("Enumerating CTA-exclusive peptides" in msg for msg in messages)
+    assert any("Loading public MS evidence" in msg for msg in messages)
+    assert any("Scoring" in msg and "mhcflurry" in msg for msg in messages)
+    assert any("Scored" in msg and msg.endswith("s.") for msg in messages)
+    assert any("Built MS evidence tiers" in msg for msg in messages)
+    assert any("Panel selected" in msg for msg in messages)
 
 
 def test_on_progress_pre_scoring_message_has_accurate_counts():
@@ -503,7 +602,7 @@ def test_on_progress_pre_scoring_message_has_accurate_counts():
         max_percentile=10.0,
         on_progress=messages.append,
     )
-    pre = messages[0]
+    pre = next(msg for msg in messages if msg.startswith("Scoring "))
     assert "4 peptides" in pre
     assert "3 alleles" in pre
     assert "12 predictions" in pre
@@ -513,7 +612,7 @@ def test_on_progress_summary_reports_filled_cell_count():
     """Summary message's filled-cell count should equal the count the
     output table actually carries (rows with a non-NaN peptide)."""
     messages: list[str] = []
-    long = spanning_pmhc_set(
+    spanning_pmhc_set(
         ctas=["MAGEA4", "PRAME"],
         alleles=["HLA-A*02:01", "HLA-A*24:02"],
         max_percentile=2.0,
@@ -521,7 +620,30 @@ def test_on_progress_summary_reports_filled_cell_count():
         on_progress=messages.append,
     )
     summary = messages[-1]
-    assert f"{len(long)} filled cells" in summary
+    assert "4/4 CTA x HLA cells" in summary
+
+
+def test_progress_bar_scores_in_chunks(monkeypatch):
+    calls: list[tuple[str, ...]] = []
+
+    def _chunked_scores(peptides, alleles, **kwargs):
+        calls.append(tuple(alleles))
+        return _stub_scores(peptides, alleles, **kwargs)
+
+    monkeypatch.setattr("tsarina.scoring.score_presentation", _chunked_scores, raising=True)
+
+    long = spanning_pmhc_set(
+        ctas=["MAGEA4"],
+        alleles=["HLA-A*02:01", "HLA-A*24:02"],
+        max_percentile=10.0,
+        peptides_per_cell=1,
+        output_format="long",
+        progress_bar=True,
+        score_chunk_size=1,
+        progress_file=io.StringIO(),
+    )
+    assert not long.empty
+    assert calls == [("HLA-A*02:01",), ("HLA-A*24:02",)]
 
 
 def test_cli_handler_wires_on_progress_to_stderr(monkeypatch, capsys):
@@ -560,10 +682,15 @@ def test_cli_handler_wires_on_progress_to_stderr(monkeypatch, capsys):
         include_predicted_only=False,
         predicted_only_max_percentile=0.1,
         max_percentile=None,
+        peptides_per_cell=3,
         iedb_path=None,
         cedar_path=None,
         format="wide",
         output=None,
+        summary=True,
+        progress=True,
+        progress_bars=False,
+        score_chunk_size=None,
     )
     cli_spanning.handle(args)
 
@@ -574,6 +701,109 @@ def test_cli_handler_wires_on_progress_to_stderr(monkeypatch, capsys):
     assert "fake-progress-message" in captured.err
     assert "fake-progress-message" not in captured.out
     assert "MAGEA4" in captured.out  # DataFrame serialized to stdout
+
+
+def test_cli_handler_default_table_report(monkeypatch, capsys):
+    import argparse
+
+    from tsarina import cli_spanning
+
+    def _fake_spanning(*args, **kwargs):
+        if kwargs.get("on_progress"):
+            kwargs["on_progress"]("fake-progress-message")
+        df = pd.DataFrame(
+            {
+                "cta": ["MAGEA4", "MAGEA4"],
+                "allele": ["HLA-A*02:01", "HLA-A*02:01"],
+                "peptide": ["MAGEAPEP2", "MAGEAPEP1"],
+                "length": [9, 9],
+                "evidence_tier": ["unrestricted_ms", "unrestricted_ms"],
+                "ms_hit_count": [2, 1],
+                "ms_source_count": [2, 1],
+                "ms_alleles": ["", ""],
+                "ms_pmids": ["222;333", "111"],
+                "ms_samples": ["", ""],
+                "presentation_percentile": [1.5, 0.1],
+                "presentation_score": [0.8, 0.9],
+                "affinity_nm": [200.0, 60.0],
+                "peptide_rank_in_cell": [1, 2],
+            }
+        )
+        df.attrs["cta_order"] = ["MAGEA4"]
+        df.attrs["allele_order"] = ["HLA-A*02:01"]
+        df.attrs["cta_rank_values"] = {"MAGEA4": 50}
+        df.attrs["allele_frequencies"] = {"HLA-A*02:01": 0.2}
+        df.attrs["panel_summary"] = {
+            "hla_allele_count": 1,
+            "cta_count": 1,
+            "selected_peptide_count": 2,
+            "selected_row_count": 2,
+            "filled_cell_count": 1,
+            "possible_cell_count": 1,
+            "filled_cell_fraction": 1.0,
+            "average_peptides_per_filled_cell": 2.0,
+            "evidence_tier_counts": {"unrestricted_ms": 2},
+            "coverage_note": "test coverage note",
+            "cta_coverage": [
+                {
+                    "cta": "MAGEA4",
+                    "covered_hla_count": 1,
+                    "selected_peptide_count": 2,
+                    "estimated_population_coverage": 0.36,
+                }
+            ],
+            "hla_coverage": [
+                {
+                    "allele": "HLA-A*02:01",
+                    "weighted_allele_frequency": 0.2,
+                    "covered_cta_count": 1,
+                    "covered_cta_fraction": 1.0,
+                    "selected_peptide_count": 2,
+                }
+            ],
+        }
+        return df
+
+    monkeypatch.setattr("tsarina.spanning.spanning_pmhc_set", _fake_spanning)
+
+    args = argparse.Namespace(
+        cta_count=25,
+        cta_rank_by="ms_cancer_peptide_count",
+        ctas=None,
+        min_restriction_confidence=["HIGH", "MODERATE"],
+        restriction_levels=None,
+        alleles=None,
+        panel="global51_abc_ssa",
+        lengths=(8, 9, 10, 11),
+        ensembl_release=112,
+        require_cta_exclusive=True,
+        predictor="mhcflurry",
+        monoallelic_ms_max_percentile=2.0,
+        sample_allele_ms_max_percentile=1.0,
+        unrestricted_ms_max_percentile=0.5,
+        include_predicted_only=False,
+        predicted_only_max_percentile=0.1,
+        max_percentile=None,
+        peptides_per_cell=3,
+        iedb_path=None,
+        cedar_path=None,
+        format="table",
+        output=None,
+        summary=True,
+        progress=True,
+        progress_bars=False,
+        score_chunk_size=None,
+    )
+    cli_spanning.handle(args)
+
+    captured = capsys.readouterr()
+    assert "fake-progress-message" in captured.err
+    assert "CTA rank" in captured.out
+    assert "Sources" in captured.out
+    assert "MAGEAPEP2" in captured.out
+    assert "Summary" in captured.out
+    assert "Expected Population Coverage Per CTA" in captured.out
+    assert "CTA Coverage Per HLA" in captured.out
 
 
 def test_size_within_target_envelope_for_default_args(monkeypatch):
@@ -743,6 +973,7 @@ def test_multi_length_best_per_cell_winner_can_be_any_length(monkeypatch):
         alleles=["HLA-A*02:01"],
         lengths=(9, 10),
         max_percentile=2.0,
+        peptides_per_cell=1,
     )
     indexed = df.set_index("cta")
     # MAGEA4: MAGEAPEP1 (9-mer, 0.1%) beats MAGEAPEP9M (10-mer, 0.3%)
@@ -768,6 +999,7 @@ def test_multi_length_long_format_preserves_winner_length(monkeypatch):
         alleles=["HLA-A*02:01"],
         lengths=(9, 10),
         max_percentile=2.0,
+        peptides_per_cell=1,
         output_format="long",
     )
     rows = {r["cta"]: r for _, r in long.iterrows()}

--- a/tsarina/cli_spanning.py
+++ b/tsarina/cli_spanning.py
@@ -19,9 +19,10 @@ from __future__ import annotations
 
 import argparse
 import sys
+from pathlib import Path
 
 _SUPPORTED_PREDICTORS = ("mhcflurry", "netmhcpan", "netmhcpan_el")
-_SUPPORTED_FORMATS = ("wide", "long")
+_SUPPORTED_FORMATS = ("table", "wide", "long")
 _SUPPORTED_PANELS = (
     "iedb27_ab",
     "iedb36_abc",
@@ -165,6 +166,15 @@ def _configure_parser(p: argparse.ArgumentParser) -> argparse.ArgumentParser:
         ),
     )
     p.add_argument(
+        "--peptides-per-cell",
+        type=int,
+        default=3,
+        help=(
+            "Maximum peptides to keep per CTA x HLA cell, ranked by MS source count, "
+            "MS hit count, then prediction percentile (default 3)."
+        ),
+    )
+    p.add_argument(
         "--iedb-path",
         default=None,
         help="Optional explicit IEDB ligand CSV; default uses cached hitlist observations.",
@@ -177,18 +187,52 @@ def _configure_parser(p: argparse.ArgumentParser) -> argparse.ArgumentParser:
     p.add_argument(
         "--format",
         choices=_SUPPORTED_FORMATS,
-        default="wide",
+        default="table",
         help=(
-            "Output format (default 'wide'). 'wide' = CTA rows x allele cols with "
-            "peptide as cell value. 'long' = one row per filled cell with peptide / "
-            "evidence tier / MS provenance / percentile / score / affinity columns."
+            "Output format (default 'table'). 'table' = readable terminal report; "
+            "'wide' = CTA rows x allele cols with selected peptides as cell values; "
+            "'long' = one row per selected peptide with evidence tier / MS provenance / "
+            "percentile / score / affinity columns."
+        ),
+    )
+    p.add_argument(
+        "--no-summary",
+        dest="summary",
+        action="store_false",
+        help="Do not append the panel coverage summary.",
+    )
+    p.add_argument(
+        "--no-progress",
+        dest="progress",
+        action="store_false",
+        help="Suppress progress messages and scoring progress bars.",
+    )
+    p.add_argument(
+        "--progress-bars",
+        dest="progress_bars",
+        action="store_true",
+        default=None,
+        help="Force tqdm progress bars for chunked scoring.",
+    )
+    p.add_argument(
+        "--no-progress-bars",
+        dest="progress_bars",
+        action="store_false",
+        help="Disable tqdm progress bars while keeping progress messages.",
+    )
+    p.add_argument(
+        "--score-chunk-size",
+        type=int,
+        default=None,
+        help=(
+            "Number of HLA alleles per scoring chunk when progress bars are enabled (default 1)."
         ),
     )
     p.add_argument(
         "-o",
         "--output",
         default=None,
-        help="Write CSV to this path (default: stdout).",
+        help="Write output to this path (CSV for wide/long, text for table; default stdout).",
     )
     return p
 
@@ -201,9 +245,10 @@ def build_parser(sub: argparse._SubParsersAction) -> argparse.ArgumentParser:
             "Produce a CTA x HLA pivot table where each cell is the best MS-supported "
             "peptide-HLA candidate for that CTA and allele. Defaults to top-25 CTAs "
             "crossed with the Global-51 HLA-A/B/C panel, 8-11mers, and tier-specific "
-            "presentation-percentile cutoffs: mono-allelic MS <=2.0, multi-allelic "
-            "sample-genotype MS <=1.0, unrestricted MS <=0.5. Prediction-only "
-            "candidates are excluded unless --include-predicted-only is supplied."
+            "presentation-percentile cutoffs: mono-allelic MS <2.0, multi-allelic "
+            "sample-genotype MS <1.0, unrestricted MS <0.5. Prediction-only "
+            "candidates are excluded unless --include-predicted-only is supplied. "
+            "The default output is a readable table plus coverage summary."
         ),
     )
     _configure_parser(p)
@@ -226,6 +271,11 @@ def handle(args: argparse.Namespace) -> None:
     def _on_progress(msg: str) -> None:
         print(msg, file=sys.stderr)
 
+    progress_bar = False
+    if args.progress:
+        progress_bar = sys.stderr.isatty() if args.progress_bars is None else args.progress_bars
+
+    output_format = "long" if args.format == "table" else args.format
     df = spanning_pmhc_set(
         cta_count=args.cta_count,
         cta_rank_by=args.cta_rank_by,
@@ -244,14 +294,201 @@ def handle(args: argparse.Namespace) -> None:
         include_predicted_only=args.include_predicted_only,
         predicted_only_max_percentile=args.predicted_only_max_percentile,
         max_percentile=args.max_percentile,
+        peptides_per_cell=args.peptides_per_cell,
         iedb_path=args.iedb_path,
         cedar_path=args.cedar_path,
-        output_format=args.format,
-        on_progress=_on_progress,
+        output_format=output_format,
+        on_progress=_on_progress if args.progress else None,
+        progress_bar=progress_bar,
+        score_chunk_size=args.score_chunk_size,
+        progress_file=sys.stderr,
     )
+
+    if args.format == "table":
+        text = format_panel_table(df)
+        if args.summary:
+            text = f"{text}\n\n{format_panel_summary(df)}"
+        if args.output:
+            Path(args.output).write_text(f"{text}\n")
+            print(f"Wrote panel report to {args.output}", file=sys.stderr)
+        else:
+            print(text)
+        return
 
     if args.output:
         df.to_csv(args.output, index=False)
         print(f"Wrote {len(df)} rows to {args.output}", file=sys.stderr)
     else:
         df.to_csv(sys.stdout, index=False)
+
+    if args.summary:
+        print(format_panel_summary(df), file=sys.stderr)
+
+
+def _format_percent(value: object) -> str:
+    try:
+        return f"{100.0 * float(value):.1f}%"
+    except (TypeError, ValueError):
+        return "n/a"
+
+
+def _format_rank_value(value: object) -> str:
+    try:
+        number = float(value)
+    except (TypeError, ValueError):
+        return "" if value is None else str(value)
+    if number.is_integer():
+        return str(int(number))
+    return f"{number:.2f}"
+
+
+def _format_optional_float(value: object, digits: int) -> str:
+    try:
+        number = float(value)
+    except (TypeError, ValueError):
+        return ""
+    return f"{number:.{digits}f}"
+
+
+def _pmid_count(value: object) -> str:
+    if not isinstance(value, str) or not value.strip():
+        return "0"
+    return str(len([part for part in value.split(";") if part.strip()]))
+
+
+def _plain_table(headers: list[str], rows: list[list[str]]) -> str:
+    widths = [
+        max(len(str(header)), *(len(str(row[i])) for row in rows)) if rows else len(str(header))
+        for i, header in enumerate(headers)
+    ]
+    header_line = "  ".join(str(header).ljust(widths[i]) for i, header in enumerate(headers))
+    rule_line = "  ".join("-" * width for width in widths)
+    body = ["  ".join(str(value).ljust(widths[i]) for i, value in enumerate(row)) for row in rows]
+    return "\n".join([header_line, rule_line, *body])
+
+
+def format_panel_table(df) -> str:
+    if df.empty:
+        return "No panel peptides selected."
+
+    cta_order = {cta: i for i, cta in enumerate(df.attrs.get("cta_order", []))}
+    allele_order = {allele: i for i, allele in enumerate(df.attrs.get("allele_order", []))}
+    cta_rank_values = df.attrs.get("cta_rank_values", {})
+    allele_frequencies = df.attrs.get("allele_frequencies", {})
+
+    out = df.copy()
+    out["_cta_order"] = out["cta"].map(cta_order).fillna(len(cta_order))
+    out["_allele_order"] = out["allele"].map(allele_order).fillna(len(allele_order))
+    out = out.sort_values(["_cta_order", "_allele_order", "peptide_rank_in_cell"])
+
+    rows: list[list[str]] = []
+    previous_cta = None
+    previous_cell: tuple[str, str] | None = None
+    for row in out.itertuples(index=False):
+        cta = str(row.cta)
+        allele = str(row.allele)
+        cell = (cta, allele)
+        show_cta = cta != previous_cta
+        show_allele = cell != previous_cell
+        rows.append(
+            [
+                cta if show_cta else "",
+                _format_rank_value(cta_rank_values.get(cta)) if show_cta else "",
+                allele if show_allele else "",
+                _format_percent(allele_frequencies.get(allele)) if show_allele else "",
+                str(row.peptide),
+                str(row.evidence_tier),
+                str(row.ms_source_count),
+                str(row.ms_hit_count),
+                _pmid_count(row.ms_pmids),
+                _format_optional_float(row.presentation_percentile, 3),
+                _format_optional_float(row.presentation_score, 3),
+                _format_optional_float(row.affinity_nm, 1),
+            ]
+        )
+        previous_cta = cta
+        previous_cell = cell
+
+    return _plain_table(
+        [
+            "CTA",
+            "CTA rank",
+            "HLA",
+            "HLA freq",
+            "Peptide",
+            "Tier",
+            "Sources",
+            "MS hits",
+            "PMIDs",
+            "%Rank",
+            "Score",
+            "nM",
+        ],
+        rows,
+    )
+
+
+def format_panel_summary(df) -> str:
+    summary = df.attrs.get("panel_summary")
+    if not summary:
+        return "Summary unavailable."
+
+    lines = [
+        "Summary",
+        f"  HLA alleles: {summary['hla_allele_count']}",
+        f"  CTAs: {summary['cta_count']}",
+        f"  Selected unique peptides: {summary['selected_peptide_count']}",
+        (
+            "  Filled CTA x HLA cells: "
+            f"{summary['filled_cell_count']}/{summary['possible_cell_count']} "
+            f"({_format_percent(summary['filled_cell_fraction'])})"
+        ),
+        (
+            "  Mean peptides per filled cell: "
+            f"{float(summary['average_peptides_per_filled_cell']):.2f}"
+        ),
+    ]
+
+    tier_counts = summary.get("evidence_tier_counts", {})
+    if tier_counts:
+        lines.append(
+            "  Evidence tiers: "
+            + ", ".join(f"{tier}={count}" for tier, count in sorted(tier_counts.items()))
+        )
+    lines.append(f"  Coverage note: {summary['coverage_note']}")
+
+    cta_rows = [
+        [
+            str(row["cta"]),
+            str(row["covered_hla_count"]),
+            str(row["selected_peptide_count"]),
+            _format_percent(row["estimated_population_coverage"]),
+        ]
+        for row in summary["cta_coverage"]
+    ]
+    lines.extend(
+        [
+            "",
+            "Expected Population Coverage Per CTA",
+            _plain_table(["CTA", "HLA hits", "Peptides", "Est. coverage"], cta_rows),
+        ]
+    )
+
+    hla_rows = [
+        [
+            str(row["allele"]),
+            _format_percent(row["weighted_allele_frequency"]),
+            str(row["covered_cta_count"]),
+            _format_percent(row["covered_cta_fraction"]),
+            str(row["selected_peptide_count"]),
+        ]
+        for row in summary["hla_coverage"]
+    ]
+    lines.extend(
+        [
+            "",
+            "CTA Coverage Per HLA",
+            _plain_table(["HLA", "HLA freq", "CTAs", "CTA frac", "Peptides"], hla_rows),
+        ]
+    )
+    return "\n".join(lines)

--- a/tsarina/spanning.py
+++ b/tsarina/spanning.py
@@ -39,9 +39,11 @@ Typical usage::
 
 from __future__ import annotations
 
+import sys
 import time
 from collections.abc import Callable, Iterable
 from pathlib import Path
+from typing import TextIO
 
 import pandas as pd
 
@@ -52,6 +54,7 @@ _DEFAULT_MONOALLELIC_MS_MAX_PERCENTILE = 2.0
 _DEFAULT_SAMPLE_ALLELE_MS_MAX_PERCENTILE = 1.0
 _DEFAULT_UNRESTRICTED_MS_MAX_PERCENTILE = 0.5
 _DEFAULT_PREDICTED_ONLY_MAX_PERCENTILE = 0.1
+_DEFAULT_PEPTIDES_PER_CELL = 3
 
 _EVIDENCE_TIER_RANKS: dict[str, int] = {
     "monoallelic_ms": 0,
@@ -67,6 +70,7 @@ _LONG_OUTPUT_COLUMNS: tuple[str, ...] = (
     "length",
     "evidence_tier",
     "ms_hit_count",
+    "ms_source_count",
     "ms_alleles",
     "ms_pmids",
     "ms_samples",
@@ -94,10 +98,14 @@ def spanning_pmhc_set(
     include_predicted_only: bool = False,
     predicted_only_max_percentile: float = _DEFAULT_PREDICTED_ONLY_MAX_PERCENTILE,
     max_percentile: float | None = None,
+    peptides_per_cell: int = _DEFAULT_PEPTIDES_PER_CELL,
     iedb_path: str | Path | None = None,
     cedar_path: str | Path | None = None,
     output_format: str = "wide",
     on_progress: Callable[[str], None] | None = None,
+    progress_bar: bool = False,
+    score_chunk_size: int | None = None,
+    progress_file: TextIO | None = None,
 ) -> pd.DataFrame:
     """Build a CTA x HLA pMHC panel matrix.
 
@@ -161,6 +169,10 @@ def spanning_pmhc_set(
         Deprecated compatibility shortcut. When supplied, sets all three
         MS-supported tier cutoffs to the same value. It does not enable or
         relax prediction-only candidates.
+    peptides_per_cell
+        Maximum number of ranked peptides to keep for each CTA x HLA cell.
+        Default 3. Candidates are ranked by MS source count first, then
+        MS hit count, then prediction percentile.
     iedb_path, cedar_path
         Optional explicit raw public-MS files. Defaults use hitlist's cached
         observations path.
@@ -171,12 +183,20 @@ def spanning_pmhc_set(
         percentile, score, and affinity columns.
     on_progress
         Optional callable invoked with a human-readable status string at
-        each pipeline stage (pre-scoring, post-scoring with elapsed
-        seconds, post-pivot summary).  Used by the CLI handler to emit
+        each pipeline stage.  Used by the CLI handler to emit
         stderr progress lines on multi-minute runs; library callers
         leave it ``None`` (default) for silent operation.  The library
         itself never prints — it only formats messages and hands them
         to the callback.
+    progress_bar
+        If True, score alleles in chunks and render a tqdm progress bar for
+        the scoring stage. Default False so library calls remain quiet.
+    score_chunk_size
+        Number of HLA alleles per scoring chunk when ``progress_bar`` is
+        enabled. Defaults to one allele per chunk for visible progress.
+    progress_file
+        File handle for tqdm progress bars. Defaults to ``sys.stderr`` when
+        ``progress_bar`` is True.
 
     Returns
     -------
@@ -194,6 +214,8 @@ def spanning_pmhc_set(
     """
     if output_format not in ("wide", "long"):
         raise ValueError(f"output_format must be 'wide' or 'long', got {output_format!r}")
+    if peptides_per_cell < 1:
+        raise ValueError(f"peptides_per_cell must be >= 1, got {peptides_per_cell!r}")
 
     if max_percentile is not None:
         monoallelic_ms_max_percentile = max_percentile
@@ -201,6 +223,9 @@ def spanning_pmhc_set(
         unrestricted_ms_max_percentile = max_percentile
 
     allele_list = _resolve_alleles(alleles, panel)
+    allele_frequencies = _weighted_allele_frequencies(allele_list)
+    if alleles is None:
+        allele_list = _order_alleles_by_frequency(allele_list, allele_frequencies)
     cta_list = _resolve_ctas(
         ctas=ctas,
         cta_count=cta_count,
@@ -208,10 +233,26 @@ def spanning_pmhc_set(
         min_restriction_confidence=min_restriction_confidence,
         restriction_levels=restriction_levels,
     )
+    cta_rank_values = _cta_rank_values(cta_list, cta_rank_by)
+
+    _report_progress(
+        on_progress,
+        f"Panel inputs: {len(cta_list)} CTAs x {len(allele_list)} HLA alleles; "
+        f"lengths {','.join(str(length) for length in lengths)}; "
+        f"keeping up to {peptides_per_cell} peptides per CTA x HLA cell.",
+    )
 
     if not cta_list or not allele_list:
-        return _empty_output(cta_list, allele_list, output_format)
+        return _empty_output(
+            cta_list, allele_list, output_format, allele_frequencies, cta_rank_values
+        )
 
+    _report_progress(
+        on_progress,
+        "Enumerating CTA-exclusive peptides..."
+        if require_cta_exclusive
+        else "Enumerating CTA peptides without the exclusivity gate...",
+    )
     pep_df = _resolve_peptides(
         cta_list=cta_list,
         lengths=lengths,
@@ -219,11 +260,19 @@ def spanning_pmhc_set(
         require_cta_exclusive=require_cta_exclusive,
     )
     if pep_df.empty:
-        return _empty_output(cta_list, allele_list, output_format)
+        _report_progress(on_progress, "No CTA peptides survived peptide enumeration.")
+        return _empty_output(
+            cta_list, allele_list, output_format, allele_frequencies, cta_rank_values
+        )
 
     from .ms_evidence import load_public_ms_hits
 
     unique_peptides = pep_df["peptide"].unique().tolist()
+    _report_progress(
+        on_progress,
+        f"Enumerated {len(pep_df)} CTA peptide rows ({len(unique_peptides)} unique peptides).",
+    )
+    _report_progress(on_progress, "Loading public MS evidence for enumerated peptides...")
     hits = load_public_ms_hits(
         unique_peptides,
         iedb_path=iedb_path,
@@ -231,27 +280,36 @@ def spanning_pmhc_set(
         mhc_class="I",
         mhc_species="Homo sapiens",
     )
-
-    from .scoring import score_presentation
+    _report_progress(on_progress, f"Loaded {len(hits)} public MS evidence rows.")
 
     score_alleles = _score_alleles_for_panel(allele_list, hits)
     n_predictions = len(unique_peptides) * len(score_alleles)
-    if on_progress is not None:
-        on_progress(
-            f"Scoring {len(unique_peptides)} peptides x {len(score_alleles)} alleles "
-            f"(~{n_predictions} predictions) via {predictor}..."
-        )
+    _report_progress(
+        on_progress,
+        f"Scoring {len(unique_peptides)} peptides x {len(score_alleles)} alleles "
+        f"({n_predictions} predictions) via {predictor}...",
+    )
 
     scoring_start = time.perf_counter()
-    scores = score_presentation(
-        peptides=unique_peptides, alleles=score_alleles, predictor=predictor
+    scores = _score_presentations(
+        peptides=unique_peptides,
+        alleles=score_alleles,
+        predictor=predictor,
+        progress_bar=progress_bar,
+        score_chunk_size=score_chunk_size,
+        progress_file=progress_file,
     )
     scoring_elapsed = time.perf_counter() - scoring_start
 
-    if on_progress is not None:
-        on_progress(f"Scored {n_predictions} predictions in {scoring_elapsed:.1f}s")
+    _report_progress(on_progress, f"Scored {n_predictions} predictions in {scoring_elapsed:.1f}s.")
 
     evidence_stats = _build_evidence_stats(hits, allele_list, _score_lookup(scores))
+    tier_counts = _evidence_tier_counts(evidence_stats)
+    _report_progress(
+        on_progress,
+        "Built MS evidence tiers: "
+        + ", ".join(f"{tier}={tier_counts.get(tier, 0)}" for tier in _EVIDENCE_TIER_RANKS),
+    )
     candidates = _candidate_rows(
         scores=scores,
         pep_df=pep_df,
@@ -265,22 +323,37 @@ def spanning_pmhc_set(
         },
         include_predicted_only=include_predicted_only,
     )
-    best = _best_per_cell(candidates)
+    selected = _top_per_cell(candidates, peptides_per_cell=peptides_per_cell)
+    summary = panel_summary(
+        selected=selected,
+        cta_list=cta_list,
+        allele_list=allele_list,
+        allele_frequencies=allele_frequencies,
+    )
 
-    if on_progress is not None:
-        on_progress(
-            f"Panel: {len(cta_list)} CTAs x {len(allele_list)} alleles, "
-            f"{len(best)} filled cells using MS tier cutoffs "
-            f"{monoallelic_ms_max_percentile}/{sample_allele_ms_max_percentile}/"
-            f"{unrestricted_ms_max_percentile}"
-        )
+    _report_progress(
+        on_progress,
+        f"Panel selected {summary['selected_peptide_count']} unique peptides across "
+        f"{summary['filled_cell_count']}/{summary['possible_cell_count']} CTA x HLA cells "
+        f"using MS tier cutoffs {monoallelic_ms_max_percentile}/"
+        f"{sample_allele_ms_max_percentile}/{unrestricted_ms_max_percentile}.",
+    )
 
     if output_format == "wide":
-        return _to_wide(best, cta_list, allele_list)
-    return _to_long(best, cta_list, allele_list)
+        out = _to_wide(selected, cta_list, allele_list)
+    else:
+        out = _to_long(selected, cta_list, allele_list)
+    return _attach_panel_attrs(
+        out, cta_list, allele_list, allele_frequencies, cta_rank_values, summary
+    )
 
 
 # ── Helpers ────────────────────────────────────────────────────────────
+
+
+def _report_progress(on_progress: Callable[[str], None] | None, message: str) -> None:
+    if on_progress is not None:
+        on_progress(message)
 
 
 def _resolve_alleles(
@@ -297,6 +370,45 @@ def _resolve_alleles(
     from .alleles import get_panel
 
     return list(get_panel(panel))
+
+
+def _weighted_allele_frequencies(allele_list: list[str]) -> dict[str, float]:
+    """Return population-weighted allele frequencies for known panel alleles.
+
+    The region table can contain multiple proxy populations per region. Use the
+    maximum frequency per region and allele so an extra validation proxy does
+    not overweight that region, then weight regions by population.
+    """
+    try:
+        from .regions import REGION_POPULATIONS, region_allele_frequencies
+    except ImportError:
+        return dict.fromkeys(allele_list, 0.0)
+
+    freqs = region_allele_frequencies()
+    if freqs.empty or "frequency" not in freqs.columns:
+        return dict.fromkeys(allele_list, 0.0)
+
+    freqs = freqs[freqs["allele"].isin(allele_list)].copy()
+    freqs = freqs[pd.notna(freqs["frequency"])]
+    if freqs.empty:
+        return dict.fromkeys(allele_list, 0.0)
+
+    per_region = freqs.groupby(["region", "allele"], as_index=False)["frequency"].max()
+    total_population = sum(float(population) for population in REGION_POPULATIONS.values())
+    weighted: dict[str, float] = dict.fromkeys(allele_list, 0.0)
+    for row in per_region.itertuples(index=False):
+        population = REGION_POPULATIONS.get(row.region)
+        if population is None:
+            continue
+        weighted[row.allele] += float(row.frequency) * float(population) / total_population
+    return weighted
+
+
+def _order_alleles_by_frequency(
+    allele_list: list[str],
+    allele_frequencies: dict[str, float],
+) -> list[str]:
+    return sorted(allele_list, key=lambda allele: (-allele_frequencies.get(allele, 0.0), allele))
 
 
 def _resolve_ctas(
@@ -339,6 +451,26 @@ def _resolve_ctas(
     return df["Symbol"].head(cta_count).tolist()
 
 
+def _cta_rank_values(cta_list: list[str], cta_rank_by: str) -> dict[str, float | str]:
+    from .loader import cta_dataframe
+
+    if not cta_list:
+        return {}
+
+    df = cta_dataframe()
+    if "Symbol" not in df.columns or cta_rank_by not in df.columns:
+        return {}
+
+    rank_values: dict[str, float | str] = {}
+    for symbol, value in df[df["Symbol"].isin(cta_list)][["Symbol", cta_rank_by]].itertuples(
+        index=False,
+        name=None,
+    ):
+        if pd.notna(value):
+            rank_values[str(symbol)] = value
+    return rank_values
+
+
 def _resolve_peptides(
     cta_list: list[str],
     lengths: tuple[int, ...],
@@ -376,6 +508,42 @@ def _score_alleles_for_panel(allele_list: list[str], hits: pd.DataFrame) -> list
                 out.append(allele)
                 seen.add(allele)
     return out
+
+
+def _score_presentations(
+    peptides: list[str],
+    alleles: list[str],
+    predictor: str,
+    progress_bar: bool,
+    score_chunk_size: int | None,
+    progress_file: TextIO | None,
+) -> pd.DataFrame:
+    from .scoring import score_presentation
+
+    if not progress_bar:
+        return score_presentation(peptides=peptides, alleles=alleles, predictor=predictor)
+
+    chunk_size = score_chunk_size or 1
+    if chunk_size < 1:
+        raise ValueError(f"score_chunk_size must be >= 1, got {score_chunk_size!r}")
+
+    chunks = [alleles[i : i + chunk_size] for i in range(0, len(alleles), chunk_size)]
+    frames: list[pd.DataFrame] = []
+    from tqdm import tqdm
+
+    for allele_chunk in tqdm(
+        chunks,
+        desc="Scoring pMHCs",
+        unit="allele-chunk",
+        file=progress_file or sys.stderr,
+        leave=False,
+    ):
+        frames.append(
+            score_presentation(peptides=peptides, alleles=allele_chunk, predictor=predictor)
+        )
+    if not frames:
+        return pd.DataFrame()
+    return pd.concat(frames, ignore_index=True)
 
 
 def _score_lookup(scores: pd.DataFrame) -> dict[tuple[str, str], float]:
@@ -424,12 +592,27 @@ def _add_evidence(
 
 
 def _finalize_evidence_bucket(bucket: dict[str, object]) -> dict[str, object]:
+    ms_source_count = len(bucket["ms_pmids"])
+    if ms_source_count == 0:
+        ms_source_count = len(bucket["ms_samples"])
+    if ms_source_count == 0 and int(bucket["ms_hit_count"]) > 0:
+        ms_source_count = 1
     return {
         "ms_hit_count": int(bucket["ms_hit_count"]),
+        "ms_source_count": ms_source_count,
         "ms_alleles": ";".join(sorted(bucket["ms_alleles"])),
         "ms_pmids": ";".join(sorted(bucket["ms_pmids"])),
         "ms_samples": ";".join(sorted(bucket["ms_samples"])),
     }
+
+
+def _evidence_tier_counts(
+    evidence_stats: dict[tuple[str, str | None, str], dict[str, object]],
+) -> dict[str, int]:
+    counts = dict.fromkeys(_EVIDENCE_TIER_RANKS, 0)
+    for _, _, tier in evidence_stats:
+        counts[tier] = counts.get(tier, 0) + 1
+    return counts
 
 
 def _is_truthy(value: object) -> bool:
@@ -558,6 +741,7 @@ def _candidate_rows(
             chosen_tier = "predicted_only"
             evidence = {
                 "ms_hit_count": 0,
+                "ms_source_count": 0,
                 "ms_alleles": "",
                 "ms_pmids": "",
                 "ms_samples": "",
@@ -571,6 +755,7 @@ def _candidate_rows(
                 "length": row.length,
                 "evidence_tier": chosen_tier,
                 "ms_hit_count": evidence["ms_hit_count"],
+                "ms_source_count": evidence["ms_source_count"],
                 "ms_alleles": evidence["ms_alleles"],
                 "ms_pmids": evidence["ms_pmids"],
                 "ms_samples": evidence["ms_samples"],
@@ -584,29 +769,47 @@ def _candidate_rows(
     return pd.DataFrame(rows, columns=columns)
 
 
-def _best_per_cell(candidates: pd.DataFrame) -> pd.DataFrame:
-    """For each (cta, allele), pick highest evidence tier, then best percentile."""
+def _top_per_cell(candidates: pd.DataFrame, peptides_per_cell: int) -> pd.DataFrame:
+    """For each (cta, allele), keep the top-N peptides by evidence support."""
     if candidates.empty:
         return pd.DataFrame(columns=list(_LONG_OUTPUT_COLUMNS))
 
-    sort_cols = ["_tier_rank", "presentation_percentile", "peptide", "allele"]
-    best = (
-        candidates.sort_values(sort_cols, kind="mergesort")
-        .groupby(["cta", "allele"], as_index=False)
-        .first()
-    )
-    return best[list(_LONG_OUTPUT_COLUMNS)]
+    ranked = candidates.copy()
+    cell_has_ms = ranked.groupby(["cta", "allele"])["ms_hit_count"].transform("max") > 0
+    ranked = ranked[(ranked["ms_hit_count"].astype(int) > 0) | ~cell_has_ms].copy()
+    ranked["_source_rank"] = -ranked["ms_source_count"].astype(int)
+    ranked["_hit_rank"] = -ranked["ms_hit_count"].astype(int)
+    sort_cols = [
+        "cta",
+        "allele",
+        "_source_rank",
+        "_hit_rank",
+        "presentation_percentile",
+        "_tier_rank",
+        "peptide",
+    ]
+    ranked = ranked.sort_values(sort_cols, kind="mergesort")
+    ranked["peptide_rank_in_cell"] = ranked.groupby(["cta", "allele"]).cumcount() + 1
+    selected = ranked[ranked["peptide_rank_in_cell"] <= peptides_per_cell].copy()
+    columns = [*_LONG_OUTPUT_COLUMNS, "peptide_rank_in_cell"]
+    return selected[columns].reset_index(drop=True)
 
 
 def _to_wide(
-    best: pd.DataFrame,
+    selected: pd.DataFrame,
     cta_list: list[str],
     allele_list: list[str],
 ) -> pd.DataFrame:
-    if best.empty:
+    if selected.empty:
         wide = pd.DataFrame(index=cta_list, columns=allele_list, dtype=object)
     else:
-        wide = best.pivot(index="cta", columns="allele", values="peptide")
+        cell_values = (
+            selected.sort_values(["cta", "allele", "peptide_rank_in_cell"])
+            .groupby(["cta", "allele"])["peptide"]
+            .apply("; ".join)
+            .reset_index()
+        )
+        wide = cell_values.pivot(index="cta", columns="allele", values="peptide")
         wide = wide.reindex(index=cta_list, columns=allele_list)
     wide.index.name = "cta"
     wide = wide.reset_index()
@@ -614,26 +817,176 @@ def _to_wide(
 
 
 def _to_long(
-    best: pd.DataFrame,
+    selected: pd.DataFrame,
     cta_list: list[str],
     allele_list: list[str],
 ) -> pd.DataFrame:
-    if best.empty:
-        return pd.DataFrame(columns=list(_LONG_OUTPUT_COLUMNS))
+    columns = [*_LONG_OUTPUT_COLUMNS, "peptide_rank_in_cell"]
+    if selected.empty:
+        return pd.DataFrame(columns=columns)
     cta_order = {gene: i for i, gene in enumerate(cta_list)}
     allele_order = {a: i for i, a in enumerate(allele_list)}
-    out = best.copy()
+    out = selected.copy()
     out["_cta_order"] = out["cta"].map(cta_order)
     out["_allele_order"] = out["allele"].map(allele_order)
-    out = out.sort_values(["_cta_order", "_allele_order"]).drop(
+    out = out.sort_values(["_cta_order", "_allele_order", "peptide_rank_in_cell"]).drop(
         columns=["_cta_order", "_allele_order"]
     )
-    return out[list(_LONG_OUTPUT_COLUMNS)].reset_index(drop=True)
+    return out[columns].reset_index(drop=True)
 
 
-def _empty_output(cta_list: list[str], allele_list: list[str], output_format: str) -> pd.DataFrame:
+def _carrier_probability(allele_frequency: float) -> float:
+    allele_frequency = max(0.0, min(float(allele_frequency), 1.0))
+    return 1.0 - (1.0 - allele_frequency) ** 2
+
+
+def _combined_carrier_probability(allele_frequencies: Iterable[float]) -> float:
+    miss_probability = 1.0
+    for frequency in allele_frequencies:
+        miss_probability *= 1.0 - _carrier_probability(float(frequency))
+    return max(0.0, min(1.0, 1.0 - miss_probability))
+
+
+def panel_summary(
+    selected: pd.DataFrame,
+    cta_list: list[str],
+    allele_list: list[str],
+    allele_frequencies: dict[str, float] | None = None,
+) -> dict[str, object]:
+    """Summarize a selected panel table.
+
+    Population coverage estimates use weighted regional allele frequencies and
+    a simple independent-carrier approximation. The values are intended for
+    ranking and sanity-checking panel breadth, not for clinical-grade
+    population-genetics inference.
+    """
+    allele_frequencies = allele_frequencies or dict.fromkeys(allele_list, 0.0)
+    possible_cell_count = len(cta_list) * len(allele_list)
+
+    if selected.empty:
+        filled_pairs = pd.DataFrame(columns=["cta", "allele"])
+        selected_peptide_count = 0
+    else:
+        filled_pairs = selected[["cta", "allele"]].drop_duplicates()
+        selected_peptide_count = int(selected["peptide"].nunique())
+
+    filled_cell_count = len(filled_pairs)
+    avg_peptides = 0.0 if filled_cell_count == 0 else float(len(selected) / filled_cell_count)
+
+    cta_rows = []
+    for cta in cta_list:
+        covered_alleles = (
+            filled_pairs.loc[filled_pairs["cta"] == cta, "allele"].drop_duplicates().tolist()
+            if not filled_pairs.empty
+            else []
+        )
+        cta_selected = selected[selected["cta"] == cta] if not selected.empty else selected
+        coverage = _combined_carrier_probability(
+            allele_frequencies.get(allele, 0.0) for allele in covered_alleles
+        )
+        cta_rows.append(
+            {
+                "cta": cta,
+                "covered_hla_count": len(covered_alleles),
+                "selected_peptide_count": int(cta_selected["peptide"].nunique())
+                if not cta_selected.empty
+                else 0,
+                "estimated_population_coverage": coverage,
+            }
+        )
+
+    hla_rows = []
+    total_ctas = len(cta_list)
+    for allele in allele_list:
+        covered_ctas = (
+            filled_pairs.loc[filled_pairs["allele"] == allele, "cta"].drop_duplicates().tolist()
+            if not filled_pairs.empty
+            else []
+        )
+        allele_selected = selected[selected["allele"] == allele] if not selected.empty else selected
+        hla_rows.append(
+            {
+                "allele": allele,
+                "weighted_allele_frequency": allele_frequencies.get(allele, 0.0),
+                "covered_cta_count": len(covered_ctas),
+                "covered_cta_fraction": 0.0
+                if total_ctas == 0
+                else float(len(covered_ctas) / total_ctas),
+                "selected_peptide_count": int(allele_selected["peptide"].nunique())
+                if not allele_selected.empty
+                else 0,
+            }
+        )
+
+    tier_counts: dict[str, int] = {}
+    if not selected.empty and "evidence_tier" in selected.columns:
+        tier_counts = {
+            str(tier): int(count)
+            for tier, count in selected["evidence_tier"].value_counts(sort=False).items()
+        }
+
+    return {
+        "hla_allele_count": len(allele_list),
+        "cta_count": len(cta_list),
+        "selected_peptide_count": selected_peptide_count,
+        "selected_row_count": len(selected),
+        "filled_cell_count": filled_cell_count,
+        "possible_cell_count": possible_cell_count,
+        "filled_cell_fraction": 0.0
+        if possible_cell_count == 0
+        else float(filled_cell_count / possible_cell_count),
+        "average_peptides_per_filled_cell": avg_peptides,
+        "evidence_tier_counts": tier_counts,
+        "cta_coverage": cta_rows,
+        "hla_coverage": hla_rows,
+        "coverage_note": (
+            "Estimated from weighted regional HLA allele frequencies using an "
+            "independent-carrier approximation."
+        ),
+    }
+
+
+def _attach_panel_attrs(
+    out: pd.DataFrame,
+    cta_list: list[str],
+    allele_list: list[str],
+    allele_frequencies: dict[str, float],
+    cta_rank_values: dict[str, float | str],
+    summary: dict[str, object],
+) -> pd.DataFrame:
+    out.attrs["cta_order"] = list(cta_list)
+    out.attrs["allele_order"] = list(allele_list)
+    out.attrs["allele_frequencies"] = dict(allele_frequencies)
+    out.attrs["cta_rank_values"] = dict(cta_rank_values)
+    out.attrs["panel_summary"] = summary
+    return out
+
+
+def _empty_output(
+    cta_list: list[str],
+    allele_list: list[str],
+    output_format: str,
+    allele_frequencies: dict[str, float] | None = None,
+    cta_rank_values: dict[str, float | str] | None = None,
+) -> pd.DataFrame:
     if output_format == "wide":
         wide = pd.DataFrame(index=cta_list, columns=allele_list, dtype=object)
         wide.index.name = "cta"
-        return wide.reset_index()
-    return pd.DataFrame(columns=list(_LONG_OUTPUT_COLUMNS))
+        out = wide.reset_index()
+    else:
+        out = pd.DataFrame(columns=[*_LONG_OUTPUT_COLUMNS, "peptide_rank_in_cell"])
+    allele_frequencies = allele_frequencies or dict.fromkeys(allele_list, 0.0)
+    summary = panel_summary(
+        selected=pd.DataFrame(columns=[*_LONG_OUTPUT_COLUMNS, "peptide_rank_in_cell"]),
+        cta_list=cta_list,
+        allele_list=allele_list,
+        allele_frequencies=allele_frequencies,
+    )
+    return _attach_panel_attrs(
+        out,
+        cta_list,
+        allele_list,
+        allele_frequencies,
+        cta_rank_values or {},
+        summary,
+    )

--- a/tsarina/version.py
+++ b/tsarina/version.py
@@ -10,4 +10,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "1.2.4"
+__version__ = "1.2.5"


### PR DESCRIPTION
## Summary

- Make `tsarina panel` default to a readable terminal table plus coverage summary while preserving `--format wide` and `--format long` CSV modes.
- Add richer progress messages and optional tqdm chunked scoring for long panel runs.
- Keep up to `--peptides-per-cell` candidates per CTA x HLA cell, ranked by MS source count, MS hit count, then prediction percentile, with predicted-only remaining last-priority fillers.
- Order named-panel HLA alleles by weighted population frequency and attach summary metadata for CTA/HLA coverage.
- Refresh README/docs for the new panel defaults and hitlist data registry wording.

## Verification

- `./format.sh`
- `./lint.sh`
- `./test.sh` — 246 passed