### PR TITLE
Improve panel progress and peptide filtering

### DIFF
--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -2,3 +2,5 @@
 
 - When a user asks to re-check code after changes, do not rely on prior findings. Re-inspect the current repository state first, preferably by reviewing the latest commit/diff before reporting.
 - For interactive CLI defaults, do not assume CSV-on-stdout is acceptable for exploratory commands. If the user is expected to run a long scientific workflow directly, provide visible progress and a readable default report, while keeping machine-readable modes explicit.
+- When a progress complaint includes a traceback, inspect the interrupted stack for the actual bottleneck before adding cosmetic logging. Prefer changing the slow call path when a cheaper equivalent exists.
+- When a console script can run but an import fails, check the script shebang and `sys.executable` before assuming the package is absent. CLI availability on `PATH` may come from a different virtualenv than the command being debugged.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,3 +1,34 @@
+# PR — Panel Version And Peptide Progress (2026-04-30)
+
+## Goal
+
+Make `tsarina panel` show the package version and enough progress to explain
+slow peptide enumeration. Remove the current startup bottleneck where CTA
+exclusivity builds a full human non-CTA k-mer posting index before any useful
+panel progress appears.
+
+## Plan
+
+- [x] Print `tsarina vX.Y.Z` at the start of panel progress output.
+- [x] Thread panel progress callbacks into peptide generation.
+- [x] Limit panel peptide enumeration to the selected CTA list instead of
+      generating all CTAs first.
+- [x] Replace CTA exclusivity's full non-CTA `proteome_kmer_set()` build with
+      a streaming non-CTA protein scan against the much smaller CTA peptide set.
+- [x] Add progress messages and optional tqdm bars for CTA gene enumeration and
+      non-CTA background scanning.
+- [x] Make the Topiary missing-import error name the Python interpreter that
+      cannot import it.
+- [x] Add tests for version output, peptide-stage progress, and the streaming
+      exclusivity filter.
+- [x] Bump patch version and run full verification.
+
+## Verification
+
+- [x] `./format.sh`
+- [x] `./lint.sh`
+- [x] `./test.sh` — 249 passed
+
 # PR — Panel Progress, Table Output, And Summary (2026-04-30)
 
 ## Goal

--- a/tests/test_kmer_caching.py
+++ b/tests/test_kmer_caching.py
@@ -10,22 +10,21 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Tests for tsarina's delegation to ``hitlist.proteome.proteome_kmer_set``.
+"""Tests for tsarina's proteome k-mer filtering glue.
 
-As of v1.1.0 the proteome-walk primitive lives in hitlist (shipped in
-hitlist 1.14.2).  Tsarina owns only:
+Tsarina owns:
 
 1. The tsarina-specific CTA / non-CTA gene-ID partition frozensets
    (``_non_cta_gene_ids`` / ``_cta_gene_ids``) — memoized wrappers
    around :func:`tsarina.partition.CTA_partition_gene_ids`.
-2. Thin call-site glue in ``cta_exclusive_peptides`` /
-   ``human_exclusive_viral_peptides`` / ``cancer_specific_viral_peptides``
-   that invokes the hitlist primitive with the right gene filter.
+2. Candidate-driven CTA exclusivity filtering that streams non-CTA proteins
+   against the much smaller CTA peptide set.
+3. Thin viral call-site glue in ``human_exclusive_viral_peptides`` /
+   ``cancer_specific_viral_peptides`` that invokes hitlist's primitive with
+   the right gene filter.
 
-These tests exercise the partition memoization and pin down the
-dispatch contract (hitlist gets the right ``gene_ids`` frozenset per
-caller).  The proteome walk itself is tested in hitlist's own test
-suite — tsarina doesn't re-test the primitive.
+These tests exercise partition memoization and pin down those dispatch
+contracts.  The full hitlist proteome index is tested in hitlist's own suite.
 """
 
 from __future__ import annotations
@@ -82,42 +81,122 @@ def test_gene_id_wrappers_separate_entries_per_release():
     assert r1 == r2  # stub ignores release; values are equal
 
 
+def test_cta_gene_ids_for_names_limits_to_requested_symbols(monkeypatch):
+    monkeypatch.setattr(
+        "tsarina.gene_sets.CTA_gene_ids",
+        lambda: {"ENSG_A", "ENSG_B", "ENSG_C"},
+        raising=True,
+    )
+    monkeypatch.setattr(
+        "tsarina.loader.cta_dataframe",
+        lambda: pd.DataFrame(
+            {
+                "Symbol": ["MAGEA4", "PRAME;PRAME_ALT", "NONCTA"],
+                "Ensembl_Gene_ID": ["ENSG_A", "ENSG_B;ENSG_C", "ENSG_D"],
+            }
+        ),
+        raising=True,
+    )
+
+    assert peptides._cta_gene_ids_for_names(["PRAME"]) == ["ENSG_B", "ENSG_C"]
+
+
 # ── Dispatch to hitlist.proteome.proteome_kmer_set ────────────────────
 
 
-def test_cta_exclusive_peptides_delegates_to_hitlist_with_non_cta_gene_ids(monkeypatch):
-    """cta_exclusive_peptides must call hitlist.proteome.proteome_kmer_set
-    with gene_ids=_non_cta_gene_ids(release), not rebuild the walk
-    locally."""
+def test_cta_exclusive_peptides_streams_candidate_overlap(monkeypatch):
+    """cta_exclusive_peptides should filter by streaming non-CTA overlaps,
+    avoiding hitlist's full proteome_kmer_set posting-index build."""
     calls: list[dict] = []
+    cta_calls: list[dict] = []
 
-    def _spy(release, lengths, gene_ids=None, **kw):
-        calls.append({"release": release, "lengths": lengths, "gene_ids": gene_ids})
-        return frozenset({"UNWANTEDK"})
+    def _hitlist_should_not_be_called(*args, **kwargs):
+        raise AssertionError("cta_exclusive_peptides should not build full hitlist k-mer set")
 
-    monkeypatch.setattr("hitlist.proteome.proteome_kmer_set", _spy, raising=True)
+    def _overlap_spy(candidate_peptides, **kw):
+        calls.append(
+            {
+                "candidate_peptides": set(candidate_peptides),
+                "ensembl_release": kw["ensembl_release"],
+                "lengths": kw["lengths"],
+            }
+        )
+        return {"UNWANTEDK"}
+
+    monkeypatch.setattr("hitlist.proteome.proteome_kmer_set", _hitlist_should_not_be_called)
     monkeypatch.setattr(
-        "tsarina.peptides.cta_peptides",
-        lambda **kw: pd.DataFrame(
+        "tsarina.peptides._non_cta_overlapping_peptides",
+        _overlap_spy,
+        raising=True,
+    )
+
+    def _cta_peptides_spy(**kw):
+        cta_calls.append(kw)
+        return pd.DataFrame(
             {
                 "peptide": ["GOODPEPTI", "UNWANTEDK"],
                 "length": [9, 9],
                 "gene_name": ["MAGEA4", "MAGEA4"],
                 "gene_id": ["E1", "E1"],
             }
-        ),
+        )
+
+    monkeypatch.setattr(
+        "tsarina.peptides.cta_peptides",
+        _cta_peptides_spy,
         raising=True,
     )
 
-    out = peptides.cta_exclusive_peptides(ensembl_release=112, lengths=(9,))
+    out = peptides.cta_exclusive_peptides(
+        ensembl_release=112,
+        lengths=(9,),
+        gene_names=["MAGEA4"],
+    )
 
+    assert cta_calls[0]["gene_names"] == ["MAGEA4"]
     assert len(calls) == 1
-    assert calls[0]["release"] == 112
+    assert calls[0]["ensembl_release"] == 112
     assert calls[0]["lengths"] == (9,)
-    assert calls[0]["gene_ids"] == frozenset({"ENSG_B", "ENSG_C"})
-    # The peptide that appeared in the hitlist-returned background set
-    # must be filtered out.
+    assert calls[0]["candidate_peptides"] == {"GOODPEPTI", "UNWANTEDK"}
+    # The peptide that appeared in the streamed non-CTA overlap set must be filtered out.
     assert list(out["peptide"]) == ["GOODPEPTI"]
+
+
+def test_non_cta_overlap_streaming_finds_candidate_in_transcript(monkeypatch):
+    class _Transcript:
+        biotype = "protein_coding"
+
+        def __init__(self, protein_sequence: str):
+            self.protein_sequence = protein_sequence
+
+    class _Gene:
+        def __init__(self, transcripts):
+            self.transcripts = transcripts
+
+    class _FakeEnsembl:
+        def __init__(self, release):
+            self.release = release
+
+        def gene_by_id(self, gene_id):
+            if gene_id == "ENSG_B":
+                return _Gene([_Transcript("AAAAUNWANTEDKBBBB")])
+            if gene_id == "ENSG_C":
+                return _Gene([_Transcript("CCCCCCCCCCCC")])
+            raise ValueError(gene_id)
+
+    messages: list[str] = []
+    monkeypatch.setattr("pyensembl.EnsemblRelease", _FakeEnsembl)
+
+    seen = peptides._non_cta_overlapping_peptides(
+        {"GOODPEPTI", "UNWANTEDK"},
+        ensembl_release=112,
+        lengths=(9,),
+        on_progress=messages.append,
+    )
+
+    assert seen == {"UNWANTEDK"}
+    assert any("Scanning 2 non-CTA genes" in msg for msg in messages)
+    assert any("Found 1 CTA candidate peptides" in msg for msg in messages)
 
 
 def test_human_exclusive_viral_peptides_delegates_with_none_gene_ids(monkeypatch):
@@ -203,10 +282,8 @@ def test_cancer_specific_viral_peptides_delegates_twice_non_cta_and_cta(monkeypa
     assert bool(unique_row["in_cta_protein"]) is False
 
 
-def test_non_cta_gene_ids_frozenset_is_reused_across_callers(monkeypatch):
-    """Both cta_exclusive_peptides and cancer_specific_viral_peptides
-    query the non-CTA partition.  They should pass the SAME frozenset
-    instance so hitlist's cache keying is stable across callers."""
+def test_cancer_specific_viral_peptides_reuses_non_cta_frozenset(monkeypatch):
+    """The viral path still passes the memoized non-CTA frozenset to hitlist."""
     received_gene_ids: list[frozenset] = []
 
     def _spy(release, lengths, gene_ids=None, **kw):
@@ -215,18 +292,6 @@ def test_non_cta_gene_ids_frozenset_is_reused_across_callers(monkeypatch):
         return frozenset()
 
     monkeypatch.setattr("hitlist.proteome.proteome_kmer_set", _spy, raising=True)
-    monkeypatch.setattr(
-        "tsarina.peptides.cta_peptides",
-        lambda **kw: pd.DataFrame(
-            {
-                "peptide": ["X" * 9],
-                "length": [9],
-                "gene_name": ["MAGEA4"],
-                "gene_id": ["E1"],
-            }
-        ),
-        raising=True,
-    )
     monkeypatch.setattr(
         "tsarina.viral.viral_peptides",
         lambda **kw: pd.DataFrame(
@@ -240,10 +305,7 @@ def test_non_cta_gene_ids_frozenset_is_reused_across_callers(monkeypatch):
         raising=True,
     )
 
-    peptides.cta_exclusive_peptides(ensembl_release=112, lengths=(9,))
     viral.cancer_specific_viral_peptides(virus="test", lengths=(9,), ensembl_release=112)
 
-    assert len(received_gene_ids) == 2
-    # Both callers receive the SAME frozenset object (not just equal —
-    # identical), so hitlist's cache treats them as one lookup.
-    assert received_gene_ids[0] is received_gene_ids[1]
+    assert len(received_gene_ids) == 1
+    assert received_gene_ids[0] is peptides._non_cta_gene_ids(112)

--- a/tests/test_scoring.py
+++ b/tests/test_scoring.py
@@ -1,3 +1,5 @@
+import sys
+
 import pytest
 
 from tsarina.scoring import (
@@ -34,5 +36,6 @@ def test_score_presentation_import_error(monkeypatch):
     monkeypatch.setattr(builtins, "__import__", _block_topiary)
     from tsarina.scoring import score_presentation
 
-    with pytest.raises(ImportError, match="topiary"):
+    with pytest.raises(ImportError, match="Python running tsarina") as excinfo:
         score_presentation(peptides=["SLYNTVATL"], alleles=["HLA-A*02:01"])
+    assert sys.executable in str(excinfo.value)

--- a/tests/test_spanning.py
+++ b/tests/test_spanning.py
@@ -582,6 +582,7 @@ def test_on_progress_callback_receives_three_stages():
         max_percentile=2.0,
         on_progress=messages.append,
     )
+    assert messages[0].startswith("tsarina v")
     assert any("Panel inputs" in msg for msg in messages)
     assert any("Enumerating CTA-exclusive peptides" in msg for msg in messages)
     assert any("Loading public MS evidence" in msg for msg in messages)
@@ -589,6 +590,26 @@ def test_on_progress_callback_receives_three_stages():
     assert any("Scored" in msg and msg.endswith("s.") for msg in messages)
     assert any("Built MS evidence tiers" in msg for msg in messages)
     assert any("Panel selected" in msg for msg in messages)
+
+
+def test_on_progress_threads_into_peptide_resolution(monkeypatch):
+    messages: list[str] = []
+
+    def _exclusive(**kw):
+        kw["on_progress"]("inner-peptide-progress")
+        assert kw["progress_bar"] is False
+        assert kw["gene_names"] == ["MAGEA4"]
+        return _stub_peptides()
+
+    monkeypatch.setattr("tsarina.peptides.cta_exclusive_peptides", _exclusive, raising=True)
+
+    spanning_pmhc_set(
+        ctas=["MAGEA4"],
+        alleles=["HLA-A*02:01"],
+        max_percentile=2.0,
+        on_progress=messages.append,
+    )
+    assert "inner-peptide-progress" in messages
 
 
 def test_on_progress_pre_scoring_message_has_accurate_counts():
@@ -867,10 +888,12 @@ def test_require_cta_exclusive_true_calls_exclusive(monkeypatch):
 
     def _exclusive(**kw):
         calls["exclusive"] += 1
+        assert kw["gene_names"] == ["MAGEA4"]
         return _stub_peptides()
 
     def _non_exclusive(**kw):
         calls["non_exclusive"] += 1
+        assert kw["gene_names"] == ["MAGEA4"]
         return _stub_peptides()
 
     monkeypatch.setattr("tsarina.peptides.cta_exclusive_peptides", _exclusive, raising=True)
@@ -892,10 +915,12 @@ def test_require_cta_exclusive_false_calls_cta_peptides(monkeypatch):
 
     def _exclusive(**kw):
         calls["exclusive"] += 1
+        assert kw["gene_names"] == ["MAGEA4"]
         return _stub_peptides()
 
     def _non_exclusive(**kw):
         calls["non_exclusive"] += 1
+        assert kw["gene_names"] == ["MAGEA4"]
         return _stub_peptides()
 
     monkeypatch.setattr("tsarina.peptides.cta_exclusive_peptides", _exclusive, raising=True)

--- a/tsarina/peptides.py
+++ b/tsarina/peptides.py
@@ -27,14 +27,73 @@ Typical usage::
 
 from __future__ import annotations
 
+import sys
+from collections.abc import Callable, Iterable, Iterator
 from functools import lru_cache
-from typing import Union
+from typing import TextIO, Union
 
 import pandas as pd
 
 AA20 = set("ACDEFGHIKLMNPQRSTVWY")
 
 DEFAULT_PEPTIDE_LENGTHS = (8, 9, 10, 11)
+
+
+def _report_progress(on_progress: Callable[[str], None] | None, message: str) -> None:
+    if on_progress is not None:
+        on_progress(message)
+
+
+def _progress_iter(
+    values: Iterable,
+    *,
+    desc: str,
+    progress_bar: bool,
+    progress_file: TextIO | None,
+) -> Iterator:
+    if not progress_bar:
+        yield from values
+        return
+
+    from tqdm import tqdm
+
+    yield from tqdm(values, desc=desc, unit="gene", file=progress_file or sys.stderr, leave=False)
+
+
+def _split_semicolon_values(value: object) -> list[str]:
+    if not isinstance(value, str):
+        return []
+    return [part.strip() for part in value.split(";") if part.strip()]
+
+
+def _cta_gene_ids_for_names(gene_names: Iterable[str] | None) -> list[str]:
+    from .gene_sets import CTA_gene_ids
+
+    all_cta_ids = CTA_gene_ids()
+    if gene_names is None:
+        return sorted(all_cta_ids)
+
+    wanted = {str(name).strip() for name in gene_names if str(name).strip()}
+    if not wanted:
+        return []
+
+    from .loader import cta_dataframe
+
+    df = cta_dataframe()
+    if "Symbol" not in df.columns or "Ensembl_Gene_ID" not in df.columns:
+        return []
+
+    selected: set[str] = set()
+    for symbol_cell, id_cell in df[["Symbol", "Ensembl_Gene_ID"]].itertuples(
+        index=False,
+        name=None,
+    ):
+        if wanted.isdisjoint(_split_semicolon_values(symbol_cell)):
+            continue
+        selected.update(
+            gene_id for gene_id in _split_semicolon_values(id_cell) if gene_id in all_cta_ids
+        )
+    return sorted(selected)
 
 
 @lru_cache(maxsize=4)
@@ -65,6 +124,10 @@ def cta_peptides(
     ensembl_release: int = 112,
     lengths: tuple[int, ...] = DEFAULT_PEPTIDE_LENGTHS,
     flank_length: int = 15,
+    gene_names: Iterable[str] | None = None,
+    on_progress: Callable[[str], None] | None = None,
+    progress_bar: bool = False,
+    progress_file: TextIO | None = None,
 ) -> pd.DataFrame:
     """Generate all peptides from expressed CTA canonical protein sequences.
 
@@ -77,6 +140,14 @@ def cta_peptides(
     flank_length
         Number of flanking residues to include for processing prediction
         (default 15).
+    gene_names
+        Optional CTA gene symbols to enumerate. Defaults to all expressed CTAs.
+    on_progress
+        Optional progress callback.
+    progress_bar
+        If True, show a tqdm bar while walking CTA genes.
+    progress_file
+        File handle for tqdm output. Defaults to ``sys.stderr``.
 
     Returns
     -------
@@ -87,13 +158,21 @@ def cta_peptides(
     """
     from pyensembl import EnsemblRelease
 
-    from .gene_sets import CTA_gene_ids
-
     ensembl = EnsemblRelease(ensembl_release)
-    cta_ids = CTA_gene_ids()
+    cta_ids = _cta_gene_ids_for_names(gene_names)
+    _report_progress(
+        on_progress,
+        f"Generating CTA peptide candidates from {len(cta_ids)} CTA genes "
+        f"(Ensembl {ensembl_release})...",
+    )
 
     rows: list[dict] = []
-    for gene_id in sorted(cta_ids):
+    for gene_id in _progress_iter(
+        cta_ids,
+        desc="CTA genes",
+        progress_bar=progress_bar,
+        progress_file=progress_file,
+    ):
         try:
             gene = ensembl.gene_by_id(gene_id)
         except ValueError:
@@ -141,19 +220,94 @@ def cta_peptides(
                     }
                 )
 
-    return pd.DataFrame(rows)
+    out = pd.DataFrame(rows)
+    _report_progress(
+        on_progress,
+        f"Generated {len(out)} CTA peptide rows "
+        f"({out['peptide'].nunique() if not out.empty else 0} unique peptides).",
+    )
+    return out
+
+
+def _non_cta_overlapping_peptides(
+    candidate_peptides: set[str],
+    *,
+    ensembl_release: int,
+    lengths: tuple[int, ...],
+    on_progress: Callable[[str], None] | None = None,
+    progress_bar: bool = False,
+    progress_file: TextIO | None = None,
+) -> set[str]:
+    """Find candidate peptides that appear in non-CTA protein-coding transcripts.
+
+    This intentionally streams non-CTA proteins and checks membership in the
+    CTA candidate set. It avoids building hitlist's full human k-mer posting
+    index when tsarina only needs to subtract a much smaller set of CTA
+    candidate peptides.
+    """
+    if not candidate_peptides:
+        return set()
+
+    from pyensembl import EnsemblRelease
+
+    non_cta_gene_ids = sorted(_non_cta_gene_ids(ensembl_release))
+    _report_progress(
+        on_progress,
+        f"Scanning {len(non_cta_gene_ids)} non-CTA genes for overlapping "
+        f"{','.join(str(length) for length in lengths)}-mers...",
+    )
+    ensembl = EnsemblRelease(ensembl_release)
+    seen: set[str] = set()
+    for gene_id in _progress_iter(
+        non_cta_gene_ids,
+        desc="Non-CTA genes",
+        progress_bar=progress_bar,
+        progress_file=progress_file,
+    ):
+        try:
+            gene = ensembl.gene_by_id(gene_id)
+        except ValueError:
+            continue
+        for transcript in gene.transcripts:
+            if getattr(transcript, "biotype", "") != "protein_coding":
+                continue
+            try:
+                protein = transcript.protein_sequence
+            except Exception:
+                continue
+            if not protein:
+                continue
+            protein_len = len(protein)
+            for length in lengths:
+                end = protein_len - length + 1
+                for i in range(end):
+                    peptide = protein[i : i + length]
+                    if peptide in candidate_peptides:
+                        seen.add(peptide)
+        if len(seen) == len(candidate_peptides):
+            break
+
+    _report_progress(
+        on_progress,
+        f"Found {len(seen)} CTA candidate peptides that also occur in non-CTA proteins.",
+    )
+    return seen
 
 
 def cta_exclusive_peptides(
     ensembl_release: int = 112,
     lengths: tuple[int, ...] = DEFAULT_PEPTIDE_LENGTHS,
+    gene_names: Iterable[str] | None = None,
+    on_progress: Callable[[str], None] | None = None,
+    progress_bar: bool = False,
+    progress_file: TextIO | None = None,
 ) -> pd.DataFrame:
     """Return CTA peptides that do NOT appear in any non-CTA protein.
 
     This filters the output of :func:`cta_peptides` to only include
     peptides whose sequence is exclusive to CTA proteins -- i.e., the
     peptide is not found as a substring of any non-CTA protein-coding
-    gene's canonical protein sequence.
+    transcript sequence.
 
     Parameters
     ----------
@@ -161,6 +315,14 @@ def cta_exclusive_peptides(
         Ensembl release (default 112).
     lengths
         Peptide lengths to generate (default 8, 9, 10, 11).
+    gene_names
+        Optional CTA gene symbols to enumerate. Defaults to all expressed CTAs.
+    on_progress
+        Optional progress callback.
+    progress_bar
+        If True, show tqdm bars while walking CTA and non-CTA genes.
+    progress_file
+        File handle for tqdm output. Defaults to ``sys.stderr``.
 
     Returns
     -------
@@ -169,23 +331,39 @@ def cta_exclusive_peptides(
 
     Notes
     -----
-    The non-CTA k-mer set is computed and cached by
-    :func:`hitlist.proteome.proteome_kmer_set`.  First call pays the
-    Ensembl walk once; subsequent calls with the same
-    ``(ensembl_release, lengths)`` return immediately.  The cache is
-    shared across any sibling pirl-unc package that calls the same
-    primitive in the same process.
+    The non-CTA background scan is candidate-driven: tsarina first generates
+    CTA k-mers, then streams non-CTA protein-coding transcripts and records
+    only overlaps with those CTA candidates. This avoids building a full human
+    k-mer posting index when the caller only needs to subtract CTA overlaps.
     """
-    from hitlist.proteome import proteome_kmer_set
-
-    noncta_peptides = proteome_kmer_set(
-        release=ensembl_release,
-        lengths=tuple(lengths),
-        gene_ids=_non_cta_gene_ids(ensembl_release),
+    cta_df = cta_peptides(
+        ensembl_release=ensembl_release,
+        lengths=lengths,
+        gene_names=gene_names,
+        on_progress=on_progress,
+        progress_bar=progress_bar,
+        progress_file=progress_file,
     )
-    cta_df = cta_peptides(ensembl_release=ensembl_release, lengths=lengths)
+    if cta_df.empty:
+        return cta_df
+
+    candidate_peptides = set(cta_df["peptide"])
+    noncta_peptides = _non_cta_overlapping_peptides(
+        candidate_peptides,
+        ensembl_release=ensembl_release,
+        lengths=tuple(lengths),
+        on_progress=on_progress,
+        progress_bar=progress_bar,
+        progress_file=progress_file,
+    )
     mask = ~cta_df["peptide"].isin(noncta_peptides)
-    return cta_df[mask].reset_index(drop=True)
+    out = cta_df[mask].reset_index(drop=True)
+    _report_progress(
+        on_progress,
+        f"CTA exclusivity filter kept {len(out)} peptide rows "
+        f"({out['peptide'].nunique() if not out.empty else 0} unique peptides).",
+    )
+    return out
 
 
 def build_pmhc_table(

--- a/tsarina/scoring.py
+++ b/tsarina/scoring.py
@@ -72,6 +72,8 @@ Thresholds commonly used for filtering:
 
 from __future__ import annotations
 
+import sys
+
 import pandas as pd
 
 AFFINITY_THRESHOLDS_NM: tuple[int, ...] = (50, 150, 500)
@@ -169,7 +171,10 @@ def score_presentation(
         from topiary import TopiaryPredictor
     except ImportError as e:
         raise ImportError(
-            "Topiary is required for scoring. Install with: pip install topiary"
+            "Topiary is required for scoring but is not importable by the Python "
+            f"running tsarina ({sys.executable}). Install topiary into that "
+            "interpreter, or run tsarina with the environment where topiary is "
+            "installed (for example: python -m tsarina.cli panel)."
         ) from e
 
     predictor_cls = _resolve_predictor_class(predictor)

--- a/tsarina/spanning.py
+++ b/tsarina/spanning.py
@@ -222,6 +222,10 @@ def spanning_pmhc_set(
         sample_allele_ms_max_percentile = max_percentile
         unrestricted_ms_max_percentile = max_percentile
 
+    from .version import __version__
+
+    _report_progress(on_progress, f"tsarina v{__version__}")
+
     allele_list = _resolve_alleles(alleles, panel)
     allele_frequencies = _weighted_allele_frequencies(allele_list)
     if alleles is None:
@@ -258,6 +262,9 @@ def spanning_pmhc_set(
         lengths=lengths,
         ensembl_release=ensembl_release,
         require_cta_exclusive=require_cta_exclusive,
+        on_progress=on_progress,
+        progress_bar=progress_bar,
+        progress_file=progress_file,
     )
     if pep_df.empty:
         _report_progress(on_progress, "No CTA peptides survived peptide enumeration.")
@@ -476,15 +483,32 @@ def _resolve_peptides(
     lengths: tuple[int, ...],
     ensembl_release: int,
     require_cta_exclusive: bool,
+    on_progress: Callable[[str], None] | None = None,
+    progress_bar: bool = False,
+    progress_file: TextIO | None = None,
 ) -> pd.DataFrame:
     if require_cta_exclusive:
         from .peptides import cta_exclusive_peptides
 
-        all_peps = cta_exclusive_peptides(ensembl_release=ensembl_release, lengths=tuple(lengths))
+        all_peps = cta_exclusive_peptides(
+            ensembl_release=ensembl_release,
+            lengths=tuple(lengths),
+            gene_names=cta_list,
+            on_progress=on_progress,
+            progress_bar=progress_bar,
+            progress_file=progress_file,
+        )
     else:
         from .peptides import cta_peptides
 
-        all_peps = cta_peptides(ensembl_release=ensembl_release, lengths=tuple(lengths))
+        all_peps = cta_peptides(
+            ensembl_release=ensembl_release,
+            lengths=tuple(lengths),
+            gene_names=cta_list,
+            on_progress=on_progress,
+            progress_bar=progress_bar,
+            progress_file=progress_file,
+        )
     if all_peps.empty:
         return all_peps
     return all_peps[all_peps["gene_name"].isin(cta_list)].copy()

--- a/tsarina/version.py
+++ b/tsarina/version.py
@@ -10,4 +10,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "1.2.5"
+__version__ = "1.2.6"


### PR DESCRIPTION
## Summary

- Print the tsarina version at the start of `tsarina panel` progress output.
- Thread panel progress callbacks and tqdm bars into CTA peptide enumeration and non-CTA overlap scanning.
- Limit panel peptide enumeration to the selected CTA list before scoring.
- Replace CTA exclusivity's full non-CTA `proteome_kmer_set()` posting-index build with a candidate-driven non-CTA transcript scan.
- Make Topiary import failures include the Python interpreter running tsarina, so virtualenv mismatches are clear.

## Validation

- `./format.sh`
- `./lint.sh`
- `./test.sh` — 249 passed

## Notes

The local `tsarina` failure reported during testing was an environment mismatch: `/opt/homebrew/bin/tsarina` uses Homebrew Python 3.9, while `topiary` is installed in the shared Python 3.12 virtualenv. This PR improves the diagnostic, but the local environment still needs the shared-env console script installed with `python -m pip install -e /Users/iskander/code/tsarina` if `tsarina` should run from that env.