### PR TITLE
Relax panel vital RNA threshold

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,8 +265,10 @@ also get a `tqdm` scoring progress bar; use `--no-progress` or
 `--no-progress-bars` to suppress it.
 
 Use `--selection-allowlist`, `--no-vital-tissue-filter`, and
-`--vital-tissue-max-ntpm` to tune automatic CTA safety filtering. Explicit
-`--ctas` accepts aliases such as `NY-ESO-1` and `MAGE-A4`.
+`--vital-tissue-max-ntpm` to tune automatic CTA safety filtering. The default
+vital RNA cutoff is 2.0 nTPM; public healthy-MS observations in vital tissues
+remain exclusionary unless allowlisted. Explicit `--ctas` accepts aliases such
+as `NY-ESO-1` and `MAGE-A4`.
 
 Evidence tiers use configurable presentation percentile cutoffs:
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -246,8 +246,10 @@ also get a `tqdm` scoring progress bar; use `--no-progress` or
 `--no-progress-bars` to suppress it.
 
 Use `--selection-allowlist`, `--no-vital-tissue-filter`, and
-`--vital-tissue-max-ntpm` to tune automatic CTA safety filtering. Explicit
-`--ctas` accepts aliases such as `NY-ESO-1` and `MAGE-A4`.
+`--vital-tissue-max-ntpm` to tune automatic CTA safety filtering. The default
+vital RNA cutoff is 2.0 nTPM; public healthy-MS observations in vital tissues
+remain exclusionary unless allowlisted. Explicit `--ctas` accepts aliases such
+as `NY-ESO-1` and `MAGE-A4`.
 
 Evidence tiers use configurable presentation percentile cutoffs:
 

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -4,3 +4,4 @@
 - For interactive CLI defaults, do not assume CSV-on-stdout is acceptable for exploratory commands. If the user is expected to run a long scientific workflow directly, provide visible progress and a readable default report, while keeping machine-readable modes explicit.
 - When a progress complaint includes a traceback, inspect the interrupted stack for the actual bottleneck before adding cosmetic logging. Prefer changing the slow call path when a cheaper equivalent exists.
 - When a console script can run but an import fails, check the script shebang and `sys.executable` before assuming the package is absent. CLI availability on `PATH` may come from a different virtualenv than the command being debugged.
+- When explaining CTA panel gates, distinguish the original adaptive HPA restriction filter from later panel-specific safety vetoes. Report the exact source columns and installed CLI import path/version before concluding a selector default is behaving as intended.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -694,3 +694,32 @@ across 90 IEDB rows in 2.6 s end-to-end (vs. multi-minute CSV scan).
 - [x] `tests/test_indexing.py` — 5 new tests (build skip/trigger/force,
       peptide filter, binding-assay drop). All 132 tests + 1 skip green.
 - [x] `./format.sh && ./lint.sh && ./test.sh` all pass.
+
+---
+
+## Fix Panel Vital RNA Threshold (tsarina#43)
+
+Goal: make `tsarina panel` use a biologically consistent default vital-tissue
+RNA gate. The current `0.0` nTPM default treats HPA sub-1 nTPM background as a
+hard veto, even though the CTA curation model uses deflated RNA and considers
+somatic RNA detected at higher thresholds.
+
+Plan:
+
+- [x] Change the default `--vital-tissue-max-ntpm` / API default from `0.0`
+      to `2.0`.
+- [x] Update docstrings, CLI help, README/docs language, and tests so the
+      documented default matches behavior.
+- [x] Add focused tests showing sub-2 nTPM vital RNA does not exclude CTAs by
+      default, while healthy-MS vital tissue evidence still gates non-allowlisted
+      CTAs.
+- [x] Bump version for the PR.
+- [x] Run `./format.sh`, `./lint.sh`, and `./test.sh`.
+- [ ] Open PR linked to tsarina#43; merge when CI is green and deploy.
+
+Review:
+
+- Local validation passed: `./format.sh`, `./lint.sh`, and `./test.sh`
+  (`256 passed`). Live selector check confirms `NY-ESO-1` remains selected
+  without the allowlist at the new 2.0 nTPM threshold, while MAGEA4 remains
+  gated by gene-level healthy-MS heart evidence unless allowlisted.

--- a/tests/test_spanning.py
+++ b/tests/test_spanning.py
@@ -121,25 +121,41 @@ def _stub_pipeline(monkeypatch):
     )
     monkeypatch.setattr(
         "tsarina.gene_sets.CTA_gene_names",
-        lambda: {"MAGEA4", "PRAME", "CTAG1A", "CTAG1B", "MAGEA1", "BAGE"},
+        lambda: {"MAGEA4", "PRAME", "CTAG1A", "CTAG1B", "MAGEA1", "VITALRNA", "BAGE"},
         raising=True,
     )
     # Stub the bundled CTA dataframe so cta_count / rank_by paths work.
     cta_csv = pd.DataFrame(
         {
-            "Symbol": ["MAGEA1", "MAGEA4", "PRAME", "CTAG1A", "CTAG1B", "BAGE"],
-            "Ensembl_Gene_ID": ["E0", "E1", "E2", "E3A", "E3B", "E4"],
-            "filtered": ["true", "true", "true", "true", "true", "true"],
-            "never_expressed": ["false", "false", "false", "false", "false", "true"],
-            "restriction_confidence": ["HIGH", "HIGH", "LOW", "HIGH", "MODERATE", "LOW"],
-            "restriction": ["TESTIS", "TESTIS", "TESTIS", "TESTIS", "TESTIS", "TESTIS"],
-            "ms_cancer_peptide_count": [60, 50, 30, 10, 10, 0],
-            "rna_brain_max_ntpm": [0, 0, 0.2, 0.1, 0.7, 0],
-            "rna_heart_max_ntpm": [0, 0, 0.3, 0, 0, 0],
-            "rna_lung_max_ntpm": [0, 0, 0.2, 0, 0, 0],
-            "rna_liver_max_ntpm": [0, 0, 0.1, 0, 0, 0],
-            "rna_pancreas_max_ntpm": [0, 0, 0.1, 0, 0, 0],
-            "ms_healthy_somatic_tissues": ["heart", "heart", "blood", "", "", ""],
+            "Symbol": [
+                "MAGEA1",
+                "MAGEA4",
+                "PRAME",
+                "VITALRNA",
+                "CTAG1A",
+                "CTAG1B",
+                "BAGE",
+            ],
+            "Ensembl_Gene_ID": ["E0", "E1", "E2", "E5", "E3A", "E3B", "E4"],
+            "filtered": ["true", "true", "true", "true", "true", "true", "true"],
+            "never_expressed": ["false", "false", "false", "false", "false", "false", "true"],
+            "restriction_confidence": [
+                "HIGH",
+                "HIGH",
+                "LOW",
+                "HIGH",
+                "HIGH",
+                "MODERATE",
+                "LOW",
+            ],
+            "restriction": ["TESTIS", "TESTIS", "TESTIS", "TESTIS", "TESTIS", "TESTIS", "TESTIS"],
+            "ms_cancer_peptide_count": [60, 50, 30, 20, 10, 10, 0],
+            "rna_brain_max_ntpm": [0, 0, 0.2, 1.5, 0.1, 0.7, 0],
+            "rna_heart_max_ntpm": [0, 0, 0.3, 0, 0, 0, 0],
+            "rna_lung_max_ntpm": [0, 0, 0.2, 0, 0, 0, 0],
+            "rna_liver_max_ntpm": [0, 0, 0.1, 0, 0, 0, 0],
+            "rna_pancreas_max_ntpm": [0, 0, 0.1, 0, 0, 0, 0],
+            "ms_healthy_somatic_tissues": ["heart", "heart", "blood", "", "", "", ""],
         }
     )
     monkeypatch.setattr("tsarina.loader.cta_dataframe", lambda: cta_csv, raising=True)
@@ -150,8 +166,7 @@ def _stub_pipeline(monkeypatch):
 
 def test_top_n_ranking_by_default_column():
     """MAGEA1 has the highest raw count but is dropped by the vital-tissue gate.
-    PRAME is LOW-confidence/vital-RNA-positive but retained by the default
-    clinical allowlist."""
+    PRAME is LOW-confidence but retained by the default clinical allowlist."""
     df = spanning_pmhc_set(
         cta_count=2,
         alleles=["HLA-A*02:01"],
@@ -224,7 +239,7 @@ def test_min_restriction_confidence_none_admits_low():
     )
     assert "BAGE" not in df["cta"].tolist()
     assert "MAGEA1" not in df["cta"].tolist()
-    assert set(df["cta"]) == {"MAGEA4", "PRAME", "NY-ESO-1"}
+    assert set(df["cta"]) == {"MAGEA4", "PRAME", "VITALRNA", "NY-ESO-1"}
 
 
 def test_restriction_levels_filter():
@@ -248,6 +263,33 @@ def test_vital_tissue_gate_can_be_disabled():
         exclude_vital_tissue_expression=False,
     )
     assert ctas == ["MAGEA1"]
+
+
+def test_default_vital_rna_gate_allows_sub_2_ntpm():
+    ctas = _resolve_ctas(
+        ctas=None,
+        cta_count=10,
+        cta_rank_by="ms_cancer_peptide_count",
+        min_restriction_confidence=("HIGH", "MODERATE"),
+        restriction_levels=None,
+        selection_allowlist=[],
+    )
+    assert "VITALRNA" in ctas
+    assert "MAGEA4" not in ctas
+    assert "MAGEA1" not in ctas
+
+
+def test_vital_rna_gate_threshold_is_parameterizable():
+    ctas = _resolve_ctas(
+        ctas=None,
+        cta_count=10,
+        cta_rank_by="ms_cancer_peptide_count",
+        min_restriction_confidence=("HIGH", "MODERATE"),
+        restriction_levels=None,
+        selection_allowlist=[],
+        vital_tissue_max_ntpm=1.0,
+    )
+    assert "VITALRNA" not in ctas
 
 
 # ── Allele resolution ──────────────────────────────────────────────────
@@ -751,7 +793,7 @@ def test_cli_handler_wires_on_progress_to_stderr(monkeypatch, capsys):
         restriction_levels=None,
         selection_allowlist=["PRAME", "NY-ESO-1", "MAGEA4"],
         exclude_vital_tissue_expression=True,
-        vital_tissue_max_ntpm=0.0,
+        vital_tissue_max_ntpm=2.0,
         alleles=None,
         panel="global51_abc_ssa",
         lengths=(8, 9, 10, 11),
@@ -780,7 +822,7 @@ def test_cli_handler_wires_on_progress_to_stderr(monkeypatch, capsys):
     assert callable(captured_kwargs["on_progress"])
     assert captured_kwargs["selection_allowlist"] == ("PRAME", "NY-ESO-1", "MAGEA4")
     assert captured_kwargs["exclude_vital_tissue_expression"] is True
-    assert captured_kwargs["vital_tissue_max_ntpm"] == 0.0
+    assert captured_kwargs["vital_tissue_max_ntpm"] == 2.0
 
     captured = capsys.readouterr()
     assert "fake-progress-message" in captured.err
@@ -859,7 +901,7 @@ def test_cli_handler_default_table_report(monkeypatch, capsys):
         restriction_levels=None,
         selection_allowlist=["PRAME", "NY-ESO-1", "MAGEA4"],
         exclude_vital_tissue_expression=True,
-        vital_tissue_max_ntpm=0.0,
+        vital_tissue_max_ntpm=2.0,
         alleles=None,
         panel="global51_abc_ssa",
         lengths=(8, 9, 10, 11),

--- a/tsarina/cli_spanning.py
+++ b/tsarina/cli_spanning.py
@@ -33,6 +33,7 @@ _SUPPORTED_PANELS = (
 _DEFAULT_PANEL = "global51_abc_ssa"
 _DEFAULT_LENGTHS = (8, 9, 10, 11)
 _DEFAULT_SELECTION_ALLOWLIST = "PRAME,NY-ESO-1,MAGEA4"
+_DEFAULT_VITAL_TISSUE_MAX_NTPM = 2.0
 
 
 def _split_csv(value: str) -> list[str]:
@@ -113,8 +114,11 @@ def _configure_parser(p: argparse.ArgumentParser) -> argparse.ArgumentParser:
     p.add_argument(
         "--vital-tissue-max-ntpm",
         type=float,
-        default=0.0,
-        help="Maximum allowed RNA nTPM in vital tissues for automatic CTA selection (default 0.0).",
+        default=_DEFAULT_VITAL_TISSUE_MAX_NTPM,
+        help=(
+            "Maximum allowed RNA nTPM in vital tissues for automatic CTA selection "
+            f"(default {_DEFAULT_VITAL_TISSUE_MAX_NTPM})."
+        ),
     )
     p.add_argument(
         "--alleles",

--- a/tsarina/spanning.py
+++ b/tsarina/spanning.py
@@ -56,7 +56,7 @@ _DEFAULT_UNRESTRICTED_MS_MAX_PERCENTILE = 0.5
 _DEFAULT_PREDICTED_ONLY_MAX_PERCENTILE = 0.1
 _DEFAULT_PEPTIDES_PER_CELL = 3
 _DEFAULT_SELECTION_ALLOWLIST = ("PRAME", "NY-ESO-1", "MAGEA4")
-_DEFAULT_VITAL_TISSUE_MAX_NTPM = 0.0
+_DEFAULT_VITAL_TISSUE_MAX_NTPM = 2.0
 
 _CTA_GROUPS: dict[str, tuple[str, ...]] = {
     "NY-ESO-1": ("CTAG1A", "CTAG1B"),
@@ -170,7 +170,7 @@ def spanning_pmhc_set(
         is in ``selection_allowlist``.
     vital_tissue_max_ntpm
         Maximum allowed RNA nTPM in vital tissues for automatic CTA selection.
-        Default 0.0.
+        Default 2.0.
     alleles
         Explicit allele list.  Overrides ``panel``.
     panel

--- a/tsarina/version.py
+++ b/tsarina/version.py
@@ -10,4 +10,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "1.2.8"
+__version__ = "1.2.9"


### PR DESCRIPTION
## Summary

Closes #43.

- Change the default panel vital RNA threshold from 0.0 to 2.0 nTPM in the API and CLI.
- Keep the vital healthy-MS tissue veto unchanged; this PR only relaxes RNA background handling.
- Update panel docs/help text to document the 2.0 nTPM default.
- Add tests proving sub-2 nTPM vital RNA no longer excludes a CTA by default, while vital healthy-MS evidence still gates non-allowlisted CTAs.
- Bump version to 1.2.9.

## Notes

The MAGEA4 heart MS evidence still acts at the gene-selection level today, not at a per-peptide level. That behavior is tracked separately in #44 because the current evidence is from shared MAGE-family peptides (MAGEA4;MAGEA8;MAGEA1) rather than unique MAGEA4 peptides.

## Validation

- pytest tests/test_spanning.py tests/test_cli_spanning.py -q — 48 passed
- python -m tsarina.cli panel --help shows --vital-tissue-max-ntpm default 2.0
- live _resolve_ctas(..., selection_allowlist=[]) includes NY-ESO-1 at the new 2.0 threshold but not at the old 0.0 threshold
- ./format.sh
- ./lint.sh
- ./test.sh — 256 passed