### PR TITLE
Require unique vital healthy MS gate

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,7 +241,7 @@ tsarina panel
 Defaults:
 
 - top 25 CTAs ranked by cancer MS peptide count
-- automatic safety gates remove CTAs with vital-tissue RNA / healthy-MS
+- automatic safety gates remove CTAs with vital-tissue RNA / unique healthy-MS
   evidence, while allowlisting `PRAME`, `NY-ESO-1`, and `MAGEA4`
 - `NY-ESO-1` is treated as one grouped CTA target backed by `CTAG1A` and
   `CTAG1B`
@@ -267,8 +267,9 @@ also get a `tqdm` scoring progress bar; use `--no-progress` or
 Use `--selection-allowlist`, `--no-vital-tissue-filter`, and
 `--vital-tissue-max-ntpm` to tune automatic CTA safety filtering. The default
 vital RNA cutoff is 2.0 nTPM; public healthy-MS observations in vital tissues
-remain exclusionary unless allowlisted. Explicit `--ctas` accepts aliases such
-as `NY-ESO-1` and `MAGE-A4`.
+remain exclusionary only when the peptide evidence maps uniquely to that CTA,
+unless allowlisted. Explicit `--ctas` accepts aliases such as `NY-ESO-1` and
+`MAGE-A4`.
 
 Evidence tiers use configurable presentation percentile cutoffs:
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -222,7 +222,7 @@ tsarina panel
 Defaults:
 
 - top 25 CTAs ranked by cancer MS peptide count
-- automatic safety gates remove CTAs with vital-tissue RNA / healthy-MS
+- automatic safety gates remove CTAs with vital-tissue RNA / unique healthy-MS
   evidence, while allowlisting `PRAME`, `NY-ESO-1`, and `MAGEA4`
 - `NY-ESO-1` is treated as one grouped CTA target backed by `CTAG1A` and
   `CTAG1B`
@@ -248,8 +248,9 @@ also get a `tqdm` scoring progress bar; use `--no-progress` or
 Use `--selection-allowlist`, `--no-vital-tissue-filter`, and
 `--vital-tissue-max-ntpm` to tune automatic CTA safety filtering. The default
 vital RNA cutoff is 2.0 nTPM; public healthy-MS observations in vital tissues
-remain exclusionary unless allowlisted. Explicit `--ctas` accepts aliases such
-as `NY-ESO-1` and `MAGE-A4`.
+remain exclusionary only when the peptide evidence maps uniquely to that CTA,
+unless allowlisted. Explicit `--ctas` accepts aliases such as `NY-ESO-1` and
+`MAGE-A4`.
 
 Evidence tiers use configurable presentation percentile cutoffs:
 

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -715,7 +715,7 @@ Plan:
       CTAs.
 - [x] Bump version for the PR.
 - [x] Run `./format.sh`, `./lint.sh`, and `./test.sh`.
-- [ ] Open PR linked to tsarina#43; merge when CI is green and deploy.
+- [x] Open PR linked to tsarina#43; merge when CI is green and deploy.
 
 Review:
 
@@ -723,3 +723,32 @@ Review:
   (`256 passed`). Live selector check confirms `NY-ESO-1` remains selected
   without the allowlist at the new 2.0 nTPM threshold, while MAGEA4 remains
   gated by gene-level healthy-MS heart evidence unless allowlisted.
+- Shipped as PR #45 / `tsarina` v1.2.9.
+
+---
+
+## Fix Panel Healthy-MS Gene Veto (tsarina#44)
+
+Goal: stop automatic CTA selection from blacklisting a CTA as a whole based on
+healthy-MS evidence from peptides that map to multiple CTA-family genes.
+
+Plan:
+
+- [x] Change the panel safety gate so gene-level healthy-MS aggregates are only
+      a suspect list; the actual MS veto requires unique vital healthy-MS rows
+      for the CTA symbol.
+- [x] Keep the RNA vital-tissue threshold behavior from #43 unchanged.
+- [x] Add tests showing shared MAGE-family heart MS does not veto MAGEA4, while
+      unique MAGEA1 vital MS still gates MAGEA1.
+- [x] Update CLI/docs wording from generic healthy-MS veto to unique healthy-MS
+      veto.
+- [x] Bump version for the PR.
+- [x] Run `./format.sh`, `./lint.sh`, and `./test.sh`.
+- [ ] Open PR linked to tsarina#44; merge when CI is green and deploy.
+
+Review:
+
+- Local validation passed: `pytest tests/test_spanning.py tests/test_cli_spanning.py -q`
+  (`49 passed`), `./format.sh`, `./lint.sh`, and `./test.sh` (`257 passed`).
+  Live selector check confirms `MAGEA4` is selected and `MAGEA1` is excluded
+  without the allowlist, matching shared-vs-unique healthy-MS evidence.

--- a/tests/test_spanning.py
+++ b/tests/test_spanning.py
@@ -96,6 +96,19 @@ def _stub_ms_hits(peptides, **kwargs) -> pd.DataFrame:
     )
 
 
+def _stub_gene_ms_evidence(**kwargs) -> pd.DataFrame:
+    """Gene-level healthy-MS rows used by automatic CTA safety selection."""
+    return pd.DataFrame(
+        {
+            "peptide": ["MAGEA1UNIQ", "MAGEFAMSHARED", "NONVITAL"],
+            "gene_names": ["MAGEA1", "MAGEA4;MAGEA8;MAGEA1", "PRAME"],
+            "source_tissue": ["Central nervous system (CNS)", "Heart", "Blood"],
+            "src_healthy_tissue": [True, True, True],
+            "is_binding_assay": [False, False, False],
+        }
+    )
+
+
 @pytest.fixture(autouse=True)
 def _stub_pipeline(monkeypatch):
     """Wire stubs for every upstream call spanning_pmhc_set makes."""
@@ -117,6 +130,11 @@ def _stub_pipeline(monkeypatch):
     monkeypatch.setattr(
         "tsarina.ms_evidence.load_public_ms_hits",
         _stub_ms_hits,
+        raising=True,
+    )
+    monkeypatch.setattr(
+        "tsarina.indexing.load_ms_evidence",
+        _stub_gene_ms_evidence,
         raising=True,
     )
     monkeypatch.setattr(
@@ -275,7 +293,18 @@ def test_default_vital_rna_gate_allows_sub_2_ntpm():
         selection_allowlist=[],
     )
     assert "VITALRNA" in ctas
-    assert "MAGEA4" not in ctas
+
+
+def test_unique_vital_ms_gate_ignores_shared_family_peptide_evidence():
+    ctas = _resolve_ctas(
+        ctas=None,
+        cta_count=10,
+        cta_rank_by="ms_cancer_peptide_count",
+        min_restriction_confidence=("HIGH", "MODERATE"),
+        restriction_levels=None,
+        selection_allowlist=[],
+    )
+    assert "MAGEA4" in ctas
     assert "MAGEA1" not in ctas
 
 

--- a/tsarina/cli_spanning.py
+++ b/tsarina/cli_spanning.py
@@ -106,9 +106,9 @@ def _configure_parser(p: argparse.ArgumentParser) -> argparse.ArgumentParser:
         action="store_false",
         help=(
             "Disable the automatic vital-tissue expression filter. By default, panel "
-            "excludes CTAs with RNA above --vital-tissue-max-ntpm or public healthy-MS "
-            "observations in brain/CNS/cerebellum, heart, lung, liver, or pancreas, "
-            "unless allowlisted."
+            "excludes CTAs with RNA above --vital-tissue-max-ntpm or unique public "
+            "healthy-MS observations in brain/CNS/cerebellum, heart, lung, liver, or "
+            "pancreas, unless allowlisted."
         ),
     )
     p.add_argument(

--- a/tsarina/spanning.py
+++ b/tsarina/spanning.py
@@ -165,9 +165,9 @@ def spanning_pmhc_set(
         Aliases such as ``"MAGE-A4"`` and ``"CTAG1B"`` are normalized.
     exclude_vital_tissue_expression
         If True (default), automatic CTA selection excludes genes with RNA
-        above ``vital_tissue_max_ntpm`` or public healthy-MS observations in
-        brain/CNS/cerebellum, heart, lung, liver, or pancreas, unless the CTA
-        is in ``selection_allowlist``.
+        above ``vital_tissue_max_ntpm`` or unique public healthy-MS
+        observations in brain/CNS/cerebellum, heart, lung, liver, or pancreas,
+        unless the CTA is in ``selection_allowlist``.
     vital_tissue_max_ntpm
         Maximum allowed RNA nTPM in vital tissues for automatic CTA selection.
         Default 2.0.
@@ -503,11 +503,13 @@ def _resolve_ctas(
         df = df[df["restriction"].isin(wanted_levels)]
 
     if exclude_vital_tissue_expression:
-        vital_ok = ~df.apply(
-            lambda row: _has_vital_tissue_expression(row, vital_tissue_max_ntpm),
+        vital_rna = df.apply(
+            lambda row: _has_vital_tissue_rna_expression(row, vital_tissue_max_ntpm),
             axis=1,
         )
-        df = df[vital_ok | df["_is_selection_allowlisted"]]
+        vital_ms_labels = _unique_vital_healthy_ms_cta_labels(df[~df["_is_selection_allowlisted"]])
+        vital_ms = df["_cta_display"].isin(vital_ms_labels)
+        df = df[~(vital_rna | vital_ms) | df["_is_selection_allowlisted"]]
 
     if cta_rank_by in df.columns and df[cta_rank_by].notna().any():
         df = df.sort_values(cta_rank_by, ascending=False, na_position="last")
@@ -580,7 +582,7 @@ def _split_semicolon_values(value: object) -> set[str]:
     return {part.strip() for part in value.split(";") if part.strip()}
 
 
-def _has_vital_tissue_expression(row: pd.Series, max_ntpm: float) -> bool:
+def _has_vital_tissue_rna_expression(row: pd.Series, max_ntpm: float) -> bool:
     for column in _VITAL_TISSUE_RNA_COLUMNS:
         value = row.get(column)
         try:
@@ -589,11 +591,69 @@ def _has_vital_tissue_expression(row: pd.Series, max_ntpm: float) -> bool:
             continue
         if pd.notna(ntpm) and ntpm > max_ntpm:
             return True
+    return False
 
+
+def _has_vital_healthy_ms_tissue(row: pd.Series) -> bool:
     healthy_ms_tissues = {
         tissue.lower() for tissue in _split_semicolon_values(row.get("ms_healthy_somatic_tissues"))
     }
     return bool(healthy_ms_tissues & _VITAL_TISSUE_MS_NAMES)
+
+
+def _unique_vital_healthy_ms_cta_labels(candidate_df: pd.DataFrame) -> set[str]:
+    """CTA labels with unique-gene public healthy-MS evidence in vital tissue.
+
+    The bundled CTA table carries gene-level healthy-MS tissue aggregates, but
+    those aggregates can be driven by peptides shared across paralogous CTA
+    families. Use that table only as a cheap suspect list, then verify against
+    hitlist observation rows and require ``gene_names`` to map uniquely to the
+    candidate CTA symbol before vetoing the whole CTA.
+    """
+    if candidate_df.empty or "Symbol" not in candidate_df.columns:
+        return set()
+
+    suspect_symbols: set[str] = set()
+    for _, row in candidate_df.iterrows():
+        if not _has_vital_healthy_ms_tissue(row):
+            continue
+        for symbol in _cta_member_symbols(str(row.get("_cta_display", row.get("Symbol")))):
+            suspect_symbols.add(symbol)
+    if not suspect_symbols:
+        return set()
+
+    from .indexing import load_ms_evidence
+
+    hits = load_ms_evidence(
+        gene_name=sorted(suspect_symbols),
+        mhc_class="I",
+        mhc_species="Homo sapiens",
+        columns=[
+            "peptide",
+            "gene_names",
+            "source_tissue",
+            "src_healthy_tissue",
+            "is_binding_assay",
+        ],
+        drop_binding_assays=True,
+    )
+    if hits.empty:
+        return set()
+
+    veto_labels: set[str] = set()
+    for _, row in hits.iterrows():
+        if not _is_truthy(row.get("src_healthy_tissue", False)):
+            continue
+        source_tissue = str(row.get("source_tissue", "")).strip().lower()
+        if source_tissue not in _VITAL_TISSUE_MS_NAMES:
+            continue
+        row_symbols = _split_semicolon_values(row.get("gene_names"))
+        if len(row_symbols) != 1:
+            continue
+        symbol = next(iter(row_symbols))
+        if symbol in suspect_symbols:
+            veto_labels.add(_cta_display_name(symbol))
+    return veto_labels
 
 
 def _cta_rank_values(cta_list: list[str], cta_rank_by: str) -> dict[str, float | str]:

--- a/tsarina/version.py
+++ b/tsarina/version.py
@@ -10,4 +10,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "1.2.9"
+__version__ = "1.2.10"


### PR DESCRIPTION
## Summary

Closes #44.

- Treat bundled CTA-table healthy-MS tissue aggregates as a suspect list, not as a whole-gene veto by themselves.
- Veto automatic CTA selection for healthy-MS only when public observation rows show a unique-gene peptide in a vital healthy tissue.
- Preserve the #43 vital RNA threshold behavior and keep allowlisted CTA handling unchanged.
- Clarify CLI/docs wording around the unique healthy-MS gate.

## Validation

- `pytest tests/test_spanning.py tests/test_cli_spanning.py -q` (`49 passed`)
- Live selector check: without the default allowlist, `MAGEA4` remains selected from shared MAGE-family heart evidence while `MAGEA1` remains excluded by unique vital healthy-MS evidence.
- `./format.sh`
- `./lint.sh`
- `./test.sh` (`257 passed`)