### PR TITLE
Group redundant CTA pMHC panels

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,6 +250,8 @@ Defaults:
   are explicitly requested or allowlisted
 - `NY-ESO-1` is treated as one grouped CTA target backed by `CTAG1A` and
   `CTAG1B`
+- CTAs with identical final selected pMHC panels are grouped so paralogous
+  targets do not consume multiple automatic panel slots
 - `global53_abc` HLA-A/B/C panel
 - 8-11mer CTA-exclusive peptides
 - MHCflurry presentation scoring
@@ -286,13 +288,19 @@ Coverage Per CTA" rows are sorted by selected peptide count, then HLA-hit count,
 then estimated population coverage, and split monoallelic MS pMHC support from
 sample-genotype/deconvolved MS support.
 
+Pass `--no-group-identical-cta-pmhcs` to show duplicate CTA rows separately.
+Pass `--netmhcpan-affinity` to annotate every selected pMHC row with NetMHCpan
+BA affinity nM and affinity percentile rank. This is opt-in because it requires
+the external NetMHCpan backend and adds a second scoring pass when the main
+selector is using MHCflurry.
+
 Evidence tiers use configurable presentation percentile cutoffs:
 
 | Evidence tier | Default cutoff | Meaning |
 |---|---:|---|
 | `monoallelic_ms` | < 2.0 | Peptide observed in mono-allelic MS for that HLA |
 | `sample_allele_ms` | < 1.0 | Peptide observed in a multi-allelic sample where this HLA is best among sample alleles, including sample-genotype rows that list exact HLA restrictions |
-| `unrestricted_ms` | < 0.5 | Peptide observed by MS with no usable allele assignment |
+| `unrestricted_ms` | < 0.5 | Peptide observed by class-I MS with no usable allele assignment; the selected panel HLA is assigned by prediction under this stricter cutoff |
 | `predicted_only` | < 0.1 | No MS support; excluded unless `--include-predicted-only` is passed |
 
 Available HLA panels:

--- a/docs/index.md
+++ b/docs/index.md
@@ -231,6 +231,8 @@ Defaults:
   are explicitly requested or allowlisted
 - `NY-ESO-1` is treated as one grouped CTA target backed by `CTAG1A` and
   `CTAG1B`
+- CTAs with identical final selected pMHC panels are grouped so paralogous
+  targets do not consume multiple automatic panel slots
 - `global53_abc` HLA-A/B/C panel
 - 8-11mer CTA-exclusive peptides
 - MHCflurry presentation scoring
@@ -267,13 +269,19 @@ Coverage Per CTA" rows are sorted by selected peptide count, then HLA-hit count,
 then estimated population coverage, and split monoallelic MS pMHC support from
 sample-genotype/deconvolved MS support.
 
+Pass `--no-group-identical-cta-pmhcs` to show duplicate CTA rows separately.
+Pass `--netmhcpan-affinity` to annotate every selected pMHC row with NetMHCpan
+BA affinity nM and affinity percentile rank. This is opt-in because it requires
+the external NetMHCpan backend and adds a second scoring pass when the main
+selector is using MHCflurry.
+
 Evidence tiers use configurable presentation percentile cutoffs:
 
 | Evidence tier | Default cutoff | Meaning |
 |---|---:|---|
 | `monoallelic_ms` | < 2.0 | Peptide observed in mono-allelic MS for that HLA |
 | `sample_allele_ms` | < 1.0 | Peptide observed in a multi-allelic sample where this HLA is best among sample alleles, including sample-genotype rows that list exact HLA restrictions |
-| `unrestricted_ms` | < 0.5 | Peptide observed by MS with no usable allele assignment |
+| `unrestricted_ms` | < 0.5 | Peptide observed by class-I MS with no usable allele assignment; the selected panel HLA is assigned by prediction under this stricter cutoff |
 | `predicted_only` | < 0.1 | No MS support; excluded unless `--include-predicted-only` is passed |
 
 Available HLA panels:

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -12,3 +12,5 @@
 - When describing static package data, prefer "bundled" or "packaged" over "shipped"; it is more precise and less misleading when discussing a table that will be regenerated in the next PR.
 - For HLA population coverage, do not combine same-locus alleles as independent carrier events. Sum covered allele frequencies within each locus first, convert the locus total to carrier probability, then combine across loci.
 - Name boolean evidence-table columns for the biological state they encode. Prefer semantic names like `passes_filters` over process words like `filtered`, while keeping older helper APIs as compatibility aliases when users may already depend on them.
+- When paralogous CTAs produce identical selected peptide-HLA panels, do not let each gene consume an automatic panel slot. Group them by final selected pMHC signature, preserve member-gene provenance, and backfill with distinct downstream targets.
+- Treat broad class-I MS evidence as peptide-level evidence, not allele-level evidence. If a row only says `HLA class I`, any selected allele is assigned by prediction under the unrestricted-MS cutoff.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,3 +1,48 @@
+# PR — Group Redundant CTA Panels And NetMHCpan Affinity Annotation (2026-05-05)
+
+## Goal
+
+Collapse CTA targets that yield identical selected pMHC panels so paralogous
+families do not consume multiple automatic panel slots, clarify broad
+``unrestricted_ms`` evidence, and optionally annotate every selected pMHC with
+NetMHCpan binding affinity and affinity percentile rank.
+
+## Plan
+
+- [x] Group non-empty CTAs by their final selected pMHC signature, preserving
+      member-gene provenance in output metadata and long tables.
+- [x] Make automatic ``cta_count`` count grouped non-empty CTA targets, so
+      duplicate peptide panels backfill with additional distinct targets.
+- [x] Add optional NetMHCpan BA scoring for selected pMHCs, emitting
+      NetMHCpan affinity nM and affinity percentile columns without changing
+      the default predictor path.
+- [x] Preserve affinity percentile output from topiary/mhctools predictors
+      when available.
+- [x] Update CLI, docs, and tests for grouped CTAs, ``unrestricted_ms`` meaning,
+      and the NetMHCpan annotation option.
+- [x] Bump the patch version and run ``./format.sh``, ``./lint.sh``, and
+      ``./test.sh``.
+
+## Review
+
+- Added default grouping for CTAs that have identical final selected pMHC
+  signatures; grouped outputs preserve source labels in ``cta_members`` and
+  ``cta_groups`` metadata.
+- Automatic panel backfill now counts grouped non-empty CTA targets, so duplicate
+  paralog panels do not consume multiple requested slots.
+- Added ``--netmhcpan-affinity`` / ``annotate_netmhcpan_affinity=True`` to add
+  NetMHCpan BA nM and affinity percentile rank columns for selected pMHCs.
+- Preserved affinity percentile ranks from topiary/mhctools predictors in the
+  shared scoring API; MHCflurry still avoids affinity percentile calibration and
+  returns that column empty.
+- Clarified that ``unrestricted_ms`` means class-I peptide-level MS evidence
+  with no usable allele assignment; selected HLAs are prediction-assigned under
+  the stricter unrestricted-MS cutoff.
+- Verification passed: ``./format.sh``, ``./lint.sh``, and ``./test.sh``
+  (294 tests).
+
+---
+
 # PR — CTA Filter Threshold And Column Rename (2026-05-05)
 
 ## Goal

--- a/tests/test_scoring.py
+++ b/tests/test_scoring.py
@@ -136,6 +136,48 @@ def test_mhcflurry_direct_path_batches_and_skips_affinity_percentiles(monkeypatc
         "presentation_score",
         "presentation_percentile",
         "affinity_nm",
+        "affinity_percentile",
     ]
     assert set(out["allele"]) == {"HLA-A*02:01", "HLA-C*15:05"}
     assert len(out) == 4
+    assert out["affinity_percentile"].isna().all()
+
+
+def test_topiary_pivot_preserves_affinity_percentile():
+    import tsarina.scoring as scoring
+
+    topiary_result = pd.DataFrame(
+        [
+            {
+                "peptide": "SLYNTVATL",
+                "allele": "HLA-A*02:01",
+                "kind": "pMHC_presentation",
+                "score": 0.91,
+                "percentile_rank": 0.42,
+                "value": pd.NA,
+            },
+            {
+                "peptide": "SLYNTVATL",
+                "allele": "HLA-A*02:01",
+                "kind": "pMHC_affinity",
+                "score": pd.NA,
+                "percentile_rank": 0.18,
+                "value": 72.5,
+            },
+        ]
+    )
+
+    out = scoring._pivot_topiary(topiary_result)
+
+    assert list(out.columns) == [
+        "peptide",
+        "allele",
+        "presentation_score",
+        "presentation_percentile",
+        "affinity_nm",
+        "affinity_percentile",
+    ]
+    row = out.iloc[0]
+    assert row["presentation_percentile"] == 0.42
+    assert row["affinity_nm"] == 72.5
+    assert row["affinity_percentile"] == 0.18

--- a/tests/test_spanning.py
+++ b/tests/test_spanning.py
@@ -74,6 +74,7 @@ def _stub_scores(peptides, alleles, **kwargs) -> pd.DataFrame:
                     "presentation_percentile": base + allele_bump,
                     "presentation_score": 0.95 - (base + allele_bump) / 10,
                     "affinity_nm": 50.0 + (base + allele_bump) * 100,
+                    "affinity_percentile": (base + allele_bump) / 2,
                 }
             )
     return pd.DataFrame(rows)
@@ -852,6 +853,7 @@ def test_long_format_has_one_row_per_filled_cell():
     assert len(long) == 4
     assert set(long.columns) == {
         "cta",
+        "cta_members",
         "allele",
         "peptide",
         "length",
@@ -864,6 +866,9 @@ def test_long_format_has_one_row_per_filled_cell():
         "presentation_percentile",
         "presentation_score",
         "affinity_nm",
+        "affinity_percentile",
+        "netmhcpan_affinity_nm",
+        "netmhcpan_affinity_percentile",
         "peptide_rank_in_cell",
     }
     # Sorted by cta then allele in the supplied order
@@ -905,6 +910,152 @@ def test_output_attrs_include_summary_and_order_metadata():
     assert summary["selected_peptide_count"] == 2
     assert summary["cta_coverage"][0]["covered_hla_count"] == 2
     assert summary["hla_coverage"][0]["covered_cta_fraction"] == 1.0
+
+
+def test_identical_selected_pmhc_ctas_are_grouped(monkeypatch):
+    peptides = pd.DataFrame(
+        {
+            "peptide": ["SHAREDPEP", "SHAREDPEP", "PRAMEPEP1"],
+            "length": [9, 9, 9],
+            "gene_name": ["SPANXD", "SPANXA1", "PRAME"],
+            "gene_id": ["E10", "E11", "E2"],
+        }
+    )
+    monkeypatch.setattr(
+        "tsarina.peptides.cta_exclusive_peptides",
+        lambda **kw: peptides,
+        raising=True,
+    )
+    monkeypatch.setattr(
+        "tsarina.gene_sets.CTA_gene_names",
+        lambda: {"SPANXD", "SPANXA1", "PRAME"},
+        raising=True,
+    )
+    monkeypatch.setattr(
+        "tsarina.loader.cta_dataframe",
+        lambda: pd.DataFrame(
+            {
+                "Symbol": ["SPANXD", "SPANXA1", "PRAME"],
+                "ms_cta_exclusive_cancer_peptide_count": [3, 2, 1],
+            }
+        ),
+        raising=True,
+    )
+
+    long = spanning_pmhc_set(
+        ctas=["SPANXD", "SPANXA1", "PRAME"],
+        alleles=["HLA-A*02:01"],
+        max_percentile=10.0,
+        peptides_per_cell=1,
+        output_format="long",
+    )
+
+    assert long.attrs["cta_order"] == ["SPANXD/SPANXA1", "PRAME"]
+    assert long.attrs["cta_groups"] == [
+        {"cta": "SPANXD/SPANXA1", "members": ["SPANXD", "SPANXA1"]},
+        {"cta": "PRAME", "members": ["PRAME"]},
+    ]
+    grouped = long[long["cta"] == "SPANXD/SPANXA1"].iloc[0]
+    assert grouped["cta_members"] == "SPANXD;SPANXA1"
+    assert grouped["peptide"] == "SHAREDPEP"
+    assert long.attrs["panel_summary"]["grouped_cta_member_count"] == 1
+
+
+def test_automatic_backfill_counts_distinct_cta_pmhc_groups(monkeypatch):
+    peptides = pd.DataFrame(
+        {
+            "peptide": ["SHAREDPEP", "SHAREDPEP", "DISTINCT1"],
+            "length": [9, 9, 9],
+            "gene_name": ["DUP1", "DUP2", "DISTINCT"],
+            "gene_id": ["E10", "E11", "E12"],
+        }
+    )
+    cta_csv = pd.DataFrame(
+        {
+            "Symbol": ["DUP1", "DUP2", "DISTINCT"],
+            "filtered": ["true", "true", "true"],
+            "never_expressed": ["false", "false", "false"],
+            "restriction_confidence": ["HIGH", "HIGH", "HIGH"],
+            "restriction": ["TESTIS", "TESTIS", "TESTIS"],
+            "ms_cta_exclusive_cancer_peptide_count": [30, 20, 10],
+            "ms_healthy_somatic_tissues": ["", "", ""],
+        }
+    )
+    monkeypatch.setattr(
+        "tsarina.peptides.cta_exclusive_peptides",
+        lambda **kw: peptides,
+        raising=True,
+    )
+    monkeypatch.setattr(
+        "tsarina.gene_sets.CTA_gene_names",
+        lambda: {"DUP1", "DUP2", "DISTINCT"},
+        raising=True,
+    )
+    monkeypatch.setattr("tsarina.loader.cta_dataframe", lambda: cta_csv, raising=True)
+
+    long = spanning_pmhc_set(
+        cta_count=2,
+        alleles=["HLA-A*02:01"],
+        selection_allowlist=(),
+        exclude_vital_tissue_expression=False,
+        max_percentile=10.0,
+        peptides_per_cell=1,
+        output_format="long",
+    )
+
+    assert long.attrs["cta_order"] == ["DUP1/DUP2", "DISTINCT"]
+    assert set(long["cta"]) == {"DUP1/DUP2", "DISTINCT"}
+    assert long.attrs["panel_summary"]["input_cta_count"] == 3
+
+
+def test_netmhcpan_affinity_annotation_scores_selected_pmhcs(monkeypatch):
+    calls: list[dict[str, object]] = []
+
+    def _score_with_netmhcpan_annotation(peptides, alleles, predictor="mhcflurry", **kwargs):
+        calls.append(
+            {
+                "predictor": predictor,
+                "peptides": tuple(peptides),
+                "alleles": tuple(alleles),
+            }
+        )
+        rows = []
+        for pep in peptides:
+            for allele in alleles:
+                is_netmhcpan = predictor == "netmhcpan"
+                rows.append(
+                    {
+                        "peptide": pep,
+                        "allele": allele,
+                        "presentation_percentile": 0.1,
+                        "presentation_score": 0.95,
+                        "affinity_nm": 25.0 if is_netmhcpan else 150.0,
+                        "affinity_percentile": 0.03 if is_netmhcpan else pd.NA,
+                    }
+                )
+        return pd.DataFrame(rows)
+
+    monkeypatch.setattr(
+        "tsarina.scoring.score_presentation",
+        _score_with_netmhcpan_annotation,
+        raising=True,
+    )
+
+    long = spanning_pmhc_set(
+        ctas=["MAGEA4"],
+        alleles=["HLA-A*02:01"],
+        max_percentile=10.0,
+        peptides_per_cell=1,
+        output_format="long",
+        annotate_netmhcpan_affinity=True,
+    )
+
+    assert [call["predictor"] for call in calls] == ["mhcflurry", "netmhcpan"]
+    assert calls[1]["peptides"] == ("MAGEAPEP1",)
+    row = long.iloc[0]
+    assert row["affinity_nm"] == 150.0
+    assert row["netmhcpan_affinity_nm"] == 25.0
+    assert row["netmhcpan_affinity_percentile"] == 0.03
 
 
 def test_panel_alleles_are_ordered_by_weighted_frequency(monkeypatch):
@@ -1132,6 +1283,8 @@ def test_cli_handler_wires_on_progress_to_stderr(monkeypatch, capsys):
         predicted_only_max_percentile=0.1,
         max_percentile=None,
         peptides_per_cell=3,
+        group_identical_cta_pmhcs=True,
+        annotate_netmhcpan_affinity=False,
         iedb_path=None,
         cedar_path=None,
         format="wide",
@@ -1150,6 +1303,8 @@ def test_cli_handler_wires_on_progress_to_stderr(monkeypatch, capsys):
     assert captured_kwargs["exclude_vital_tissue_expression"] is True
     assert captured_kwargs["vital_tissue_max_ntpm"] == 2.0
     assert captured_kwargs["include_empty_ctas"] is False
+    assert captured_kwargs["group_identical_cta_pmhcs"] is True
+    assert captured_kwargs["annotate_netmhcpan_affinity"] is False
 
     captured = capsys.readouterr()
     assert "fake-progress-message" in captured.err
@@ -1180,6 +1335,9 @@ def test_cli_handler_default_table_report(monkeypatch, capsys):
                 "presentation_percentile": [1.5, 0.1],
                 "presentation_score": [0.8, 0.9],
                 "affinity_nm": [200.0, 60.0],
+                "affinity_percentile": [0.9, 0.2],
+                "netmhcpan_affinity_nm": [pd.NA, pd.NA],
+                "netmhcpan_affinity_percentile": [pd.NA, pd.NA],
                 "peptide_rank_in_cell": [1, 2],
             }
         )
@@ -1243,6 +1401,8 @@ def test_cli_handler_default_table_report(monkeypatch, capsys):
         predicted_only_max_percentile=0.1,
         max_percentile=None,
         peptides_per_cell=3,
+        group_identical_cta_pmhcs=True,
+        annotate_netmhcpan_affinity=False,
         iedb_path=None,
         cedar_path=None,
         format="table",
@@ -1415,6 +1575,7 @@ def _stub_scores_multi_length(peptides, alleles, **kwargs) -> pd.DataFrame:
                     "presentation_percentile": pct,
                     "presentation_score": 0.95 - pct / 10,
                     "affinity_nm": 50.0 + pct * 100,
+                    "affinity_percentile": pct / 2,
                 }
             )
     return pd.DataFrame(rows)

--- a/tsarina/cli_spanning.py
+++ b/tsarina/cli_spanning.py
@@ -18,6 +18,7 @@ Wraps :func:`tsarina.spanning.spanning_pmhc_set` with argparse.
 from __future__ import annotations
 
 import argparse
+import math
 import sys
 from pathlib import Path
 
@@ -224,6 +225,25 @@ def _configure_parser(p: argparse.ArgumentParser) -> argparse.ArgumentParser:
         ),
     )
     p.add_argument(
+        "--no-group-identical-cta-pmhcs",
+        dest="group_identical_cta_pmhcs",
+        action="store_false",
+        help=(
+            "Do not collapse CTA targets that produce identical selected pMHC panels. "
+            "By default, redundant non-empty CTA rows are grouped and lower-ranked "
+            "distinct candidates are backfilled."
+        ),
+    )
+    p.add_argument(
+        "--netmhcpan-affinity",
+        dest="annotate_netmhcpan_affinity",
+        action="store_true",
+        help=(
+            "Annotate every selected pMHC row with NetMHCpan BA affinity nM and "
+            "affinity percentile rank. Requires the external NetMHCpan backend."
+        ),
+    )
+    p.add_argument(
         "--iedb-path",
         default=None,
         help="Optional explicit IEDB ligand CSV; default uses cached hitlist observations.",
@@ -308,6 +328,7 @@ def build_parser(sub: argparse._SubParsersAction) -> argparse.ArgumentParser:
             "multi-allelic "
             "sample-genotype MS <1.0, unrestricted MS <0.5. Prediction-only "
             "candidates are excluded unless --include-predicted-only is supplied. "
+            "CTAs with identical selected pMHC panels are grouped by default. "
             "The default output is a readable table plus coverage summary."
         ),
     )
@@ -359,6 +380,8 @@ def handle(args: argparse.Namespace) -> None:
         predicted_only_max_percentile=args.predicted_only_max_percentile,
         max_percentile=args.max_percentile,
         peptides_per_cell=args.peptides_per_cell,
+        group_identical_cta_pmhcs=args.group_identical_cta_pmhcs,
+        annotate_netmhcpan_affinity=args.annotate_netmhcpan_affinity,
         iedb_path=args.iedb_path,
         cedar_path=args.cedar_path,
         output_format=output_format,
@@ -412,6 +435,8 @@ def _format_optional_float(value: object, digits: int) -> str:
         number = float(value)
     except (TypeError, ValueError):
         return ""
+    if math.isnan(number):
+        return ""
     return f"{number:.{digits}f}"
 
 
@@ -445,6 +470,12 @@ def format_panel_table(df) -> str:
     out["_cta_order"] = out["cta"].map(cta_order).fillna(len(cta_order))
     out["_allele_order"] = out["allele"].map(allele_order).fillna(len(allele_order))
     out = out.sort_values(["_cta_order", "_allele_order", "peptide_rank_in_cell"])
+    show_netmhcpan_affinity = {"netmhcpan_affinity_nm", "netmhcpan_affinity_percentile"} <= set(
+        out.columns
+    ) and (
+        out["netmhcpan_affinity_nm"].notna().any()
+        or out["netmhcpan_affinity_percentile"].notna().any()
+    )
 
     rows: list[list[str]] = []
     previous_cta = None
@@ -455,42 +486,49 @@ def format_panel_table(df) -> str:
         cell = (cta, allele)
         show_cta = cta != previous_cta
         show_allele = cell != previous_cell
-        rows.append(
-            [
-                cta if show_cta else "",
-                _format_rank_value(cta_rank_values.get(cta)) if show_cta else "",
-                allele if show_allele else "",
-                _format_percent(allele_frequencies.get(allele)) if show_allele else "",
-                str(row.peptide),
-                str(row.evidence_tier),
-                str(row.ms_source_count),
-                str(row.ms_hit_count),
-                _pmid_count(row.ms_pmids),
-                _format_optional_float(row.presentation_percentile, 3),
-                _format_optional_float(row.presentation_score, 3),
-                _format_optional_float(row.affinity_nm, 1),
-            ]
-        )
+        table_row = [
+            cta if show_cta else "",
+            _format_rank_value(cta_rank_values.get(cta)) if show_cta else "",
+            allele if show_allele else "",
+            _format_percent(allele_frequencies.get(allele)) if show_allele else "",
+            str(row.peptide),
+            str(row.evidence_tier),
+            str(row.ms_source_count),
+            str(row.ms_hit_count),
+            _pmid_count(row.ms_pmids),
+            _format_optional_float(row.presentation_percentile, 3),
+            _format_optional_float(row.presentation_score, 3),
+            _format_optional_float(row.affinity_nm, 1),
+        ]
+        if show_netmhcpan_affinity:
+            table_row.extend(
+                [
+                    _format_optional_float(row.netmhcpan_affinity_percentile, 3),
+                    _format_optional_float(row.netmhcpan_affinity_nm, 1),
+                ]
+            )
+        rows.append(table_row)
         previous_cta = cta
         previous_cell = cell
 
-    return _plain_table(
-        [
-            "CTA",
-            "CTA rank",
-            "HLA",
-            "HLA freq",
-            "Peptide",
-            "Tier",
-            "Sources",
-            "MS hits",
-            "PMIDs",
-            "%Rank",
-            "Score",
-            "nM",
-        ],
-        rows,
-    )
+    headers = [
+        "CTA",
+        "CTA rank",
+        "HLA",
+        "HLA freq",
+        "Peptide",
+        "Tier",
+        "Sources",
+        "MS hits",
+        "PMIDs",
+        "%Rank",
+        "Score",
+        "nM",
+    ]
+    if show_netmhcpan_affinity:
+        headers.extend(["NetMHCpan %Rank", "NetMHCpan nM"])
+
+    return _plain_table(headers, rows)
 
 
 def format_panel_summary(df) -> str:
@@ -523,6 +561,9 @@ def format_panel_summary(df) -> str:
     empty_count = int(summary.get("empty_cta_count", 0))
     if empty_count and not summary.get("include_empty_ctas", True):
         lines.append(f"  Omitted CTAs with no selected pMHCs: {empty_count}")
+    grouped_member_count = int(summary.get("grouped_cta_member_count", 0))
+    if grouped_member_count:
+        lines.append(f"  Grouped redundant CTA members: {grouped_member_count}")
     lines.append(f"  Coverage note: {summary['coverage_note']}")
 
     cta_rows = [

--- a/tsarina/scoring.py
+++ b/tsarina/scoring.py
@@ -16,8 +16,8 @@ MHCflurry is handled directly so tsarina can request only the values it uses
 and batch peptide-allele presentation predictions efficiently. Other backends
 still use topiary + mhctools' uniform DataFrame interface. This module exposes
 a thin tsarina-shaped API over both paths: one column per kind of prediction
-(``presentation_score``, ``presentation_percentile``, ``affinity_nm``), wide
-rather than long.
+(``presentation_score``, ``presentation_percentile``, ``affinity_nm``,
+``affinity_percentile``), wide rather than long.
 
 Typical usage::
 
@@ -88,6 +88,7 @@ _SCORE_COLUMNS = [
     "presentation_score",
     "presentation_percentile",
     "affinity_nm",
+    "affinity_percentile",
 ]
 _MHCFLURRY_PRESENTATION_PREDICTOR: object | None = None
 
@@ -158,6 +159,7 @@ def _score_mhcflurry(peptides: list[str], alleles: list[str]) -> pd.DataFrame:
             "presentation_score": result.get("presentation_score", pd.NA),
             "presentation_percentile": result.get("presentation_percentile", pd.NA),
             "affinity_nm": result.get("affinity", pd.NA),
+            "affinity_percentile": pd.NA,
         }
     )
     return out[_SCORE_COLUMNS].reset_index(drop=True)
@@ -203,12 +205,19 @@ def _pivot_topiary(result: pd.DataFrame) -> pd.DataFrame:
     presentation = result[result["kind"] == "pMHC_presentation"][
         ["peptide", "allele", "score", "percentile_rank"]
     ].rename(columns={"score": "presentation_score", "percentile_rank": "presentation_percentile"})
-    affinity = result[result["kind"] == "pMHC_affinity"][["peptide", "allele", "value"]].rename(
-        columns={"value": "affinity_nm"}
+
+    affinity_columns = ["peptide", "allele", "value"]
+    if "percentile_rank" in result.columns:
+        affinity_columns.append("percentile_rank")
+    affinity = result[result["kind"] == "pMHC_affinity"][affinity_columns].rename(
+        columns={"value": "affinity_nm", "percentile_rank": "affinity_percentile"}
     )
 
     out = presentation.merge(affinity, on=["peptide", "allele"], how="outer")
-    return out[[c for c in _SCORE_COLUMNS if c in out.columns]].reset_index(drop=True)
+    for column in _SCORE_COLUMNS:
+        if column not in out.columns:
+            out[column] = pd.NA
+    return out[_SCORE_COLUMNS].reset_index(drop=True)
 
 
 def score_presentation(
@@ -237,8 +246,9 @@ def score_presentation(
     -------
     pd.DataFrame
         Columns: ``peptide``, ``allele``, ``presentation_score``,
-        ``presentation_percentile``, ``affinity_nm``.  A backend that does
-        not emit a given kind leaves that column NaN.
+        ``presentation_percentile``, ``affinity_nm``, and
+        ``affinity_percentile``.  A backend that does not emit a given kind
+        leaves that column NaN.
     """
     if _predictor_key(predictor) == "mhcflurry":
         return _score_mhcflurry(peptides, alleles)

--- a/tsarina/spanning.py
+++ b/tsarina/spanning.py
@@ -59,6 +59,8 @@ _DEFAULT_PEPTIDES_PER_CELL = 3
 _DEFAULT_SELECTION_ALLOWLIST = ("PRAME", "NY-ESO-1", "MAGEA4")
 _DEFAULT_VITAL_TISSUE_MAX_NTPM = 2.0
 _DEFAULT_EXCLUDE_NON_MAGEA4_MAGE_FAMILY = True
+_DEFAULT_GROUP_IDENTICAL_CTA_PMHCS = True
+_DEFAULT_ANNOTATE_NETMHCPAN_AFFINITY = False
 
 _CTA_GROUPS: dict[str, tuple[str, ...]] = {
     "NY-ESO-1": ("CTAG1A", "CTAG1B"),
@@ -92,6 +94,7 @@ _EVIDENCE_TIER_RANKS: dict[str, int] = {
 
 _LONG_OUTPUT_COLUMNS: tuple[str, ...] = (
     "cta",
+    "cta_members",
     "allele",
     "peptide",
     "length",
@@ -104,6 +107,22 @@ _LONG_OUTPUT_COLUMNS: tuple[str, ...] = (
     "presentation_percentile",
     "presentation_score",
     "affinity_nm",
+    "affinity_percentile",
+    "netmhcpan_affinity_nm",
+    "netmhcpan_affinity_percentile",
+)
+
+_PMHC_SIGNATURE_COLUMNS: tuple[str, ...] = (
+    "allele",
+    "peptide",
+    "length",
+    "evidence_tier",
+    "ms_hit_count",
+    "ms_source_count",
+    "ms_alleles",
+    "ms_pmids",
+    "ms_samples",
+    "peptide_rank_in_cell",
 )
 
 
@@ -130,6 +149,8 @@ def spanning_pmhc_set(
     predicted_only_max_percentile: float = _DEFAULT_PREDICTED_ONLY_MAX_PERCENTILE,
     max_percentile: float | None = None,
     peptides_per_cell: int = _DEFAULT_PEPTIDES_PER_CELL,
+    group_identical_cta_pmhcs: bool = _DEFAULT_GROUP_IDENTICAL_CTA_PMHCS,
+    annotate_netmhcpan_affinity: bool = _DEFAULT_ANNOTATE_NETMHCPAN_AFFINITY,
     iedb_path: str | Path | None = None,
     cedar_path: str | Path | None = None,
     output_format: str = "wide",
@@ -227,6 +248,15 @@ def spanning_pmhc_set(
         Maximum number of ranked peptides to keep for each CTA x HLA cell.
         Default 3. Candidates are ranked by MS source count first, then
         MS hit count, then prediction percentile.
+    group_identical_cta_pmhcs
+        If True (default), non-empty CTAs with identical final selected pMHC
+        rows are collapsed into one output target. The long output preserves
+        semicolon-separated source labels in ``cta_members``.
+    annotate_netmhcpan_affinity
+        If True, run a NetMHCpan binding-affinity pass on selected pMHC rows
+        and add ``netmhcpan_affinity_nm`` plus
+        ``netmhcpan_affinity_percentile``. This is opt-in because NetMHCpan is
+        an external dependency and slower than the default MHCflurry path.
     iedb_path, cedar_path
         Optional explicit raw public-MS files. Defaults use hitlist's cached
         observations path.
@@ -388,11 +418,16 @@ def spanning_pmhc_set(
         )
         nonempty_ctas = _nonempty_ctas_in_order(processed_cta_list, selected_so_far)
         if automatic_backfill:
+            nonempty_cta_groups, _ = _cta_group_order(
+                nonempty_ctas,
+                selected_so_far,
+                group_identical_cta_pmhcs=group_identical_cta_pmhcs,
+            )
             _report_progress(
                 on_progress,
-                f"Backfill status: {len(nonempty_ctas)}/{cta_count} non-empty CTAs.",
+                f"Backfill status: {len(nonempty_cta_groups)}/{cta_count} non-empty CTA targets.",
             )
-            if len(nonempty_ctas) >= cta_count:
+            if len(nonempty_cta_groups) >= cta_count:
                 break
 
     selected = (
@@ -402,16 +437,41 @@ def spanning_pmhc_set(
     )
     if automatic_backfill:
         nonempty_ctas = _nonempty_ctas_in_order(processed_cta_list, selected)
-        output_cta_list = nonempty_ctas[:cta_count]
-        output_cta_set = set(output_cta_list)
+        grouped_cta_list, cta_groups = _cta_group_order(
+            nonempty_ctas,
+            selected,
+            group_identical_cta_pmhcs=group_identical_cta_pmhcs,
+        )
+        output_cta_list = grouped_cta_list[:cta_count]
+        output_cta_set = _cta_group_member_set(cta_groups[:cta_count])
         nonempty_cta_set = set(nonempty_ctas)
         empty_ctas = [cta for cta in processed_cta_list if cta not in nonempty_cta_set]
         selected = selected[selected["cta"].isin(output_cta_set)].reset_index(drop=True)
+        cta_groups = cta_groups[:cta_count]
     else:
-        output_cta_list, empty_ctas = _output_cta_list(
+        ungrouped_output_cta_list, empty_ctas = _output_cta_list(
             processed_cta_list,
             selected,
             include_empty_ctas=keep_empty_ctas,
+        )
+        output_cta_list, cta_groups = _cta_group_order(
+            ungrouped_output_cta_list,
+            selected,
+            group_identical_cta_pmhcs=group_identical_cta_pmhcs,
+        )
+        selected = selected[selected["cta"].isin(_cta_group_member_set(cta_groups))].reset_index(
+            drop=True
+        )
+    selected = _apply_cta_groups(selected, cta_groups)
+    cta_rank_values = _cta_rank_values_with_groups(cta_rank_values, cta_groups)
+    if annotate_netmhcpan_affinity:
+        selected = _annotate_netmhcpan_affinity(
+            selected=selected,
+            predictor=predictor,
+            on_progress=on_progress,
+            progress_bar=progress_bar,
+            score_chunk_size=score_chunk_size,
+            progress_file=progress_file,
         )
     summary = panel_summary(
         selected=selected,
@@ -425,6 +485,12 @@ def spanning_pmhc_set(
     summary["empty_cta_count"] = len(empty_ctas)
     summary["empty_ctas"] = empty_ctas
     summary["include_empty_ctas"] = keep_empty_ctas
+    summary["group_identical_cta_pmhcs"] = group_identical_cta_pmhcs
+    summary["cta_groups"] = cta_groups
+    summary["grouped_cta_member_count"] = sum(
+        max(0, len(group["members"]) - 1) for group in cta_groups
+    )
+    summary["annotate_netmhcpan_affinity"] = annotate_netmhcpan_affinity
 
     _report_progress(
         on_progress,
@@ -437,6 +503,12 @@ def spanning_pmhc_set(
         _report_progress(
             on_progress,
             f"Omitted {len(empty_ctas)} scanned CTA candidates with no selected pMHCs.",
+        )
+    grouped_member_count = int(summary.get("grouped_cta_member_count", 0))
+    if grouped_member_count:
+        _report_progress(
+            on_progress,
+            f"Grouped {grouped_member_count} redundant CTA member(s) with identical selected pMHCs.",
         )
 
     if output_format == "wide":
@@ -454,6 +526,7 @@ def spanning_pmhc_set(
         frequency_audit,
         input_cta_list=processed_cta_list,
         empty_ctas=empty_ctas,
+        cta_groups=cta_groups,
     )
 
 
@@ -474,6 +547,208 @@ def _nonempty_ctas_in_order(cta_list: list[str], selected: pd.DataFrame) -> list
         return []
     nonempty = set(selected["cta"].dropna().astype(str))
     return [cta for cta in cta_list if cta in nonempty]
+
+
+def _signature_value(value: object) -> str:
+    if pd.isna(value):
+        return ""
+    if isinstance(value, float):
+        return f"{value:.12g}"
+    return str(value)
+
+
+def _selected_pmhc_signature(selected: pd.DataFrame, cta: str) -> tuple[tuple[str, ...], ...]:
+    if selected.empty or "cta" not in selected.columns:
+        return ()
+    cta_selected = selected[selected["cta"] == cta]
+    if cta_selected.empty:
+        return ()
+    columns = [column for column in _PMHC_SIGNATURE_COLUMNS if column in cta_selected.columns]
+    records = []
+    for row in cta_selected[columns].itertuples(index=False, name=None):
+        records.append(tuple(_signature_value(value) for value in row))
+    return tuple(sorted(records))
+
+
+def _cta_group_label(members: tuple[str, ...]) -> str:
+    if len(members) == 1:
+        return members[0]
+    return "/".join(members)
+
+
+def _cta_group_order(
+    cta_list: list[str],
+    selected: pd.DataFrame,
+    group_identical_cta_pmhcs: bool,
+) -> tuple[list[str], list[dict[str, object]]]:
+    if not cta_list:
+        return [], []
+
+    groups: list[list[str]] = []
+    signature_to_group_index: dict[tuple[tuple[str, ...], ...], int] = {}
+    for cta in cta_list:
+        signature = _selected_pmhc_signature(selected, cta)
+        if group_identical_cta_pmhcs and signature:
+            group_index = signature_to_group_index.get(signature)
+            if group_index is not None:
+                groups[group_index].append(cta)
+                continue
+            signature_to_group_index[signature] = len(groups)
+        groups.append([cta])
+
+    grouped = []
+    labels = []
+    for members in groups:
+        member_tuple = tuple(members)
+        label = _cta_group_label(member_tuple)
+        labels.append(label)
+        grouped.append({"cta": label, "members": list(member_tuple)})
+    return labels, grouped
+
+
+def _cta_group_member_set(cta_groups: list[dict[str, object]]) -> set[str]:
+    members: set[str] = set()
+    for group in cta_groups:
+        for member in group.get("members", []):
+            members.add(str(member))
+    return members
+
+
+def _apply_cta_groups(selected: pd.DataFrame, cta_groups: list[dict[str, object]]) -> pd.DataFrame:
+    out = selected.copy()
+    for column in _LONG_OUTPUT_COLUMNS:
+        if column not in out.columns:
+            out[column] = pd.NA
+    if "peptide_rank_in_cell" not in out.columns:
+        out["peptide_rank_in_cell"] = pd.NA
+    if out.empty or "cta" not in out.columns:
+        return out[[*_LONG_OUTPUT_COLUMNS, "peptide_rank_in_cell"]]
+
+    member_to_label: dict[str, str] = {}
+    member_to_members: dict[str, str] = {}
+    for group in cta_groups:
+        label = str(group["cta"])
+        members = [str(member) for member in group.get("members", [])]
+        member_text = ";".join(members) if members else label
+        for member in members:
+            member_to_label[member] = label
+            member_to_members[member] = member_text
+
+    out["cta_members"] = out["cta"].map(member_to_members).fillna(out["cta"])
+    out["cta"] = out["cta"].map(member_to_label).fillna(out["cta"])
+    dedupe_columns = [
+        column
+        for column in [*_LONG_OUTPUT_COLUMNS, "peptide_rank_in_cell"]
+        if column in out.columns
+    ]
+    out = out.drop_duplicates(subset=dedupe_columns).reset_index(drop=True)
+    return out[[*_LONG_OUTPUT_COLUMNS, "peptide_rank_in_cell"]]
+
+
+def _cta_rank_values_with_groups(
+    cta_rank_values: dict[str, float | str],
+    cta_groups: list[dict[str, object]],
+) -> dict[str, float | str]:
+    out = dict(cta_rank_values)
+    for group in cta_groups:
+        label = str(group["cta"])
+        values = [
+            cta_rank_values[member]
+            for member in group.get("members", [])
+            if member in cta_rank_values
+        ]
+        numeric_values = []
+        for value in values:
+            try:
+                numeric_values.append(float(value))
+            except (TypeError, ValueError):
+                continue
+        if numeric_values:
+            out[label] = max(numeric_values)
+        elif values:
+            out[label] = values[0]
+    return out
+
+
+def _predictor_key(predictor: str) -> str:
+    return predictor.lower().replace("-", "_")
+
+
+def _ensure_score_columns(scores: pd.DataFrame) -> pd.DataFrame:
+    out = scores.copy()
+    for column in (
+        "peptide",
+        "allele",
+        "presentation_score",
+        "presentation_percentile",
+        "affinity_nm",
+        "affinity_percentile",
+    ):
+        if column not in out.columns:
+            out[column] = pd.NA
+    return out
+
+
+def _annotate_netmhcpan_affinity(
+    selected: pd.DataFrame,
+    predictor: str,
+    on_progress: Callable[[str], None] | None,
+    progress_bar: bool,
+    score_chunk_size: int | None,
+    progress_file: TextIO | None,
+) -> pd.DataFrame:
+    out = selected.copy()
+    for column in ("netmhcpan_affinity_nm", "netmhcpan_affinity_percentile"):
+        if column not in out.columns:
+            out[column] = pd.NA
+    if out.empty:
+        return out
+
+    if _predictor_key(predictor) in {"netmhcpan", "netmhcpan_ba"}:
+        out["netmhcpan_affinity_nm"] = out.get("affinity_nm", pd.NA)
+        out["netmhcpan_affinity_percentile"] = out.get("affinity_percentile", pd.NA)
+        return out
+
+    peptide_list = out["peptide"].dropna().astype(str).drop_duplicates().tolist()
+    allele_list = out["allele"].dropna().astype(str).drop_duplicates().tolist()
+    n_predictions = len(peptide_list) * len(allele_list)
+    _report_progress(
+        on_progress,
+        f"Annotating {len(out)} selected pMHC row(s) with NetMHCpan BA "
+        f"({n_predictions} prediction grid entries)...",
+    )
+    scoring_start = time.perf_counter()
+    scores = _ensure_score_columns(
+        _score_presentations(
+            peptides=peptide_list,
+            alleles=allele_list,
+            predictor="netmhcpan",
+            progress_bar=progress_bar,
+            score_chunk_size=score_chunk_size,
+            progress_file=progress_file,
+        )
+    )
+    scoring_elapsed = time.perf_counter() - scoring_start
+    _report_progress(on_progress, f"NetMHCpan BA annotation finished in {scoring_elapsed:.1f}s.")
+
+    annotation = (
+        scores[["peptide", "allele", "affinity_nm", "affinity_percentile"]]
+        .drop_duplicates(subset=["peptide", "allele"])
+        .rename(
+            columns={
+                "affinity_nm": "netmhcpan_affinity_nm",
+                "affinity_percentile": "netmhcpan_affinity_percentile",
+            }
+        )
+    )
+    out["_row_order"] = range(len(out))
+    out = out.drop(columns=["netmhcpan_affinity_nm", "netmhcpan_affinity_percentile"]).merge(
+        annotation,
+        on=["peptide", "allele"],
+        how="left",
+    )
+    out = out.sort_values("_row_order").drop(columns=["_row_order"]).reset_index(drop=True)
+    return out
 
 
 def _select_cta_batch(
@@ -541,13 +816,15 @@ def _select_cta_batch(
     )
 
     scoring_start = time.perf_counter()
-    scores = _score_presentations(
-        peptides=unique_peptides,
-        alleles=score_alleles,
-        predictor=predictor,
-        progress_bar=progress_bar,
-        score_chunk_size=score_chunk_size,
-        progress_file=progress_file,
+    scores = _ensure_score_columns(
+        _score_presentations(
+            peptides=unique_peptides,
+            alleles=score_alleles,
+            predictor=predictor,
+            progress_bar=progress_bar,
+            score_chunk_size=score_chunk_size,
+            progress_file=progress_file,
+        )
     )
     scoring_elapsed = time.perf_counter() - scoring_start
 
@@ -1190,6 +1467,7 @@ def _candidate_rows(
         rows.append(
             {
                 "cta": row.cta,
+                "cta_members": row.cta,
                 "allele": allele,
                 "peptide": peptide,
                 "length": row.length,
@@ -1202,6 +1480,9 @@ def _candidate_rows(
                 "presentation_percentile": percentile,
                 "presentation_score": getattr(row, "presentation_score", pd.NA),
                 "affinity_nm": getattr(row, "affinity_nm", pd.NA),
+                "affinity_percentile": getattr(row, "affinity_percentile", pd.NA),
+                "netmhcpan_affinity_nm": pd.NA,
+                "netmhcpan_affinity_percentile": pd.NA,
                 "_tier_rank": _EVIDENCE_TIER_RANKS[chosen_tier],
             }
         )
@@ -1354,6 +1635,10 @@ def panel_summary(
             else []
         )
         cta_selected = selected[selected["cta"] == cta] if not selected.empty else selected
+        if not cta_selected.empty and "cta_members" in cta_selected.columns:
+            cta_members = str(cta_selected["cta_members"].dropna().astype(str).iloc[0])
+        else:
+            cta_members = cta
         tier_row_counts = _selected_tier_row_counts(cta_selected)
         coverage = _combined_carrier_probability(
             {allele: allele_frequencies.get(allele, 0.0) for allele in covered_alleles}
@@ -1361,6 +1646,7 @@ def panel_summary(
         cta_rows.append(
             {
                 "cta": cta,
+                "cta_members": cta_members,
                 "covered_hla_count": len(covered_alleles),
                 "selected_peptide_count": int(cta_selected["peptide"].nunique())
                 if not cta_selected.empty
@@ -1445,10 +1731,12 @@ def _attach_panel_attrs(
     frequency_audit: pd.DataFrame | None = None,
     input_cta_list: list[str] | None = None,
     empty_ctas: list[str] | None = None,
+    cta_groups: list[dict[str, object]] | None = None,
 ) -> pd.DataFrame:
     out.attrs["cta_order"] = list(cta_list)
     out.attrs["input_cta_order"] = list(input_cta_list or cta_list)
     out.attrs["empty_ctas"] = list(empty_ctas or [])
+    out.attrs["cta_groups"] = list(cta_groups or [])
     out.attrs["allele_order"] = list(allele_list)
     out.attrs["allele_frequencies"] = dict(allele_frequencies)
     out.attrs["allele_frequency_sources"] = dict(allele_frequency_sources or {})
@@ -1492,6 +1780,11 @@ def _empty_output(
     summary["empty_cta_count"] = len(empty_ctas)
     summary["empty_ctas"] = empty_ctas
     summary["include_empty_ctas"] = include_empty_ctas
+    cta_groups = [{"cta": cta, "members": [cta]} for cta in cta_list]
+    summary["group_identical_cta_pmhcs"] = False
+    summary["cta_groups"] = cta_groups
+    summary["grouped_cta_member_count"] = 0
+    summary["annotate_netmhcpan_affinity"] = False
     return _attach_panel_attrs(
         out,
         cta_list,
@@ -1503,4 +1796,5 @@ def _empty_output(
         frequency_audit,
         input_cta_list=input_cta_list,
         empty_ctas=empty_ctas,
+        cta_groups=cta_groups,
     )

--- a/tsarina/version.py
+++ b/tsarina/version.py
@@ -10,4 +10,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "1.2.14"
+__version__ = "1.2.15"


### PR DESCRIPTION
## Summary

- Collapse non-empty CTAs with identical final selected pMHC signatures, preserving source labels in cta_members and cta_groups metadata.
- Make automatic CTA backfill count grouped non-empty targets so duplicate paralog panels do not consume multiple requested slots.
- Add opt-in NetMHCpan BA annotation for selected pMHCs via --netmhcpan-affinity / annotate_netmhcpan_affinity=True, including affinity nM and affinity percentile columns.
- Preserve affinity percentile ranks from topiary/mhctools predictor output while keeping MHCflurry affinity percentile calibration disabled.
- Document unrestricted_ms as class-I peptide-level MS evidence whose HLA assignment is prediction-based under the stricter cutoff.

## Verification

- ./format.sh
- ./lint.sh
- ./test.sh (294 passed)
