### PR TITLE
[codex] Use CTAG1A/CTAG1B as grouped CTA label

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,11 +245,11 @@ Defaults:
   lower-ranked candidates scanned as needed to backfill empty downstream targets
   and clinical allowlist anchors pinned ahead of lower-ranked candidates
 - automatic safety gates remove CTAs with vital-tissue RNA / unique healthy-MS
-  evidence, while allowlisting `PRAME`, `NY-ESO-1`, and `MAGEA4`
+  evidence, while allowlisting `PRAME`, `CTAG1A/CTAG1B`, and `MAGEA4`
 - automatic selection excludes MAGE-family CTAs other than `MAGEA4` unless they
   are explicitly requested or allowlisted
-- `NY-ESO-1` is treated as one grouped CTA target backed by `CTAG1A` and
-  `CTAG1B`
+- `CTAG1A/CTAG1B` is treated as one grouped CTA target, with `NY-ESO-1`
+  accepted as an input alias
 - CTAs with identical enumerated peptide sets or final selected pMHC panels are
   grouped so paralogous targets do not consume multiple automatic panel slots
 - `global53_abc` HLA-A/B/C panel
@@ -289,10 +289,10 @@ then estimated population coverage, and split monoallelic MS pMHC support from
 sample-genotype/deconvolved MS support.
 
 Peptide enumeration may expand one target label to multiple Ensembl genes
-(`NY-ESO-1` expands to `CTAG1A` and `CTAG1B`), but output target names stay
-grouped. Pass `--no-group-identical-cta-peptide-sets` to keep peptide-identical
-paralog targets separate, or `--no-group-identical-cta-pmhcs` to keep duplicate
-pMHC panels separate.
+(`CTAG1A/CTAG1B` and the `NY-ESO-1` alias expand to `CTAG1A` and `CTAG1B`),
+but output target names stay grouped. Pass `--no-group-identical-cta-peptide-sets`
+to keep peptide-identical paralog targets separate, or `--no-group-identical-cta-pmhcs`
+to keep duplicate pMHC panels separate.
 Pass `--netmhcpan-affinity` to annotate every selected pMHC row with NetMHCpan
 BA affinity nM and affinity percentile rank. This is opt-in because it requires
 the external NetMHCpan backend and adds a second scoring pass when the main

--- a/docs/index.md
+++ b/docs/index.md
@@ -226,11 +226,11 @@ Defaults:
   lower-ranked candidates scanned as needed to backfill empty downstream targets
   and clinical allowlist anchors pinned ahead of lower-ranked candidates
 - automatic safety gates remove CTAs with vital-tissue RNA / unique healthy-MS
-  evidence, while allowlisting `PRAME`, `NY-ESO-1`, and `MAGEA4`
+  evidence, while allowlisting `PRAME`, `CTAG1A/CTAG1B`, and `MAGEA4`
 - automatic selection excludes MAGE-family CTAs other than `MAGEA4` unless they
   are explicitly requested or allowlisted
-- `NY-ESO-1` is treated as one grouped CTA target backed by `CTAG1A` and
-  `CTAG1B`
+- `CTAG1A/CTAG1B` is treated as one grouped CTA target, with `NY-ESO-1`
+  accepted as an input alias
 - CTAs with identical enumerated peptide sets or final selected pMHC panels are
   grouped so paralogous targets do not consume multiple automatic panel slots
 - `global53_abc` HLA-A/B/C panel
@@ -270,10 +270,10 @@ then estimated population coverage, and split monoallelic MS pMHC support from
 sample-genotype/deconvolved MS support.
 
 Peptide enumeration may expand one target label to multiple Ensembl genes
-(`NY-ESO-1` expands to `CTAG1A` and `CTAG1B`), but output target names stay
-grouped. Pass `--no-group-identical-cta-peptide-sets` to keep peptide-identical
-paralog targets separate, or `--no-group-identical-cta-pmhcs` to keep duplicate
-pMHC panels separate.
+(`CTAG1A/CTAG1B` and the `NY-ESO-1` alias expand to `CTAG1A` and `CTAG1B`),
+but output target names stay grouped. Pass `--no-group-identical-cta-peptide-sets`
+to keep peptide-identical paralog targets separate, or `--no-group-identical-cta-pmhcs`
+to keep duplicate pMHC panels separate.
 Pass `--netmhcpan-affinity` to annotate every selected pMHC row with NetMHCpan
 BA affinity nM and affinity percentile rank. This is opt-in because it requires
 the external NetMHCpan backend and adds a second scoring pass when the main

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -15,3 +15,4 @@
 - When paralogous CTAs produce identical selected peptide-HLA panels, do not let each gene consume an automatic panel slot. Group them by final selected pMHC signature, preserve member-gene provenance, and backfill with distinct downstream targets.
 - Treat broad class-I MS evidence as peptide-level evidence, not allele-level evidence. If a row only says `HLA class I`, any selected allele is assigned by prediction under the unrestricted-MS cutoff.
 - Keep CTA target labels distinct from underlying Ensembl genes in progress text. Alias/group targets such as `NY-ESO-1` can expand to multiple genes for peptide enumeration while still being one biological panel target.
+- When grouped CTA targets are made from gene symbols, default the output label to the explicit member-gene group (for example `CTAG1A/CTAG1B`) and keep clinical names like `NY-ESO-1` as accepted aliases unless the user explicitly asks for the clinical alias as canonical.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,3 +1,32 @@
+# PR - Display CTAG1A/CTAG1B As The Canonical Group Label (2026-05-05)
+
+## Goal
+
+Use the gene-pair display label ``CTAG1A/CTAG1B`` for the grouped CTAG1 target
+instead of ``NY-ESO-1``, while continuing to accept ``NY-ESO-1`` as a clinical
+alias on input.
+
+## Plan
+
+- [x] Change the canonical CTAG1 group label in the spanning selector and CLI
+      defaults.
+- [x] Update docs and tests so output names use ``CTAG1A/CTAG1B`` and aliases
+      still normalize correctly.
+- [x] Bump the patch version.
+- [x] Run ``./format.sh``, ``./lint.sh``, and ``./test.sh``.
+- [ ] Open, merge, and deploy the PR.
+
+## Review
+
+- Canonical CTAG1 output now uses ``CTAG1A/CTAG1B`` in the default allowlist,
+  automatic panel rows, CLI defaults, and docs.
+- ``NY-ESO-1`` remains an accepted input alias and still expands to both
+  ``CTAG1A`` and ``CTAG1B`` for peptide enumeration.
+- Verification passed: ``./format.sh``, ``./lint.sh``, and ``./test.sh``
+  (296 tests).
+
+---
+
 # PR — Group CTA Targets With Identical Peptide Sets (2026-05-05)
 
 ## Goal

--- a/tests/test_spanning.py
+++ b/tests/test_spanning.py
@@ -222,9 +222,9 @@ def test_selection_allowlist_is_pinned_into_automatic_top_n():
         cta_rank_by="ms_cancer_peptide_count",
         min_restriction_confidence=("HIGH", "MODERATE"),
         restriction_levels=None,
-        selection_allowlist=["PRAME", "NY-ESO-1", "MAGEA4"],
+        selection_allowlist=["PRAME", "CTAG1A/CTAG1B", "MAGEA4"],
     )
-    assert ctas == ["MAGEA4", "PRAME", "NY-ESO-1"]
+    assert ctas == ["MAGEA4", "PRAME", "CTAG1A/CTAG1B"]
 
 
 def test_default_rank_column_prefers_cta_exclusive_cancer_ms(monkeypatch):
@@ -268,8 +268,13 @@ def test_automatic_selection_hides_empty_ctas_by_default():
         alleles=["HLA-A*02:01"],
         max_percentile=10.0,
     )
-    assert list(df["cta"]) == ["MAGEA4", "PRAME", "NY-ESO-1"]
-    assert df.attrs["input_cta_order"] == ["MAGEA4", "PRAME", "NY-ESO-1", "VITALRNA"]
+    assert list(df["cta"]) == ["MAGEA4", "PRAME", "CTAG1A/CTAG1B"]
+    assert df.attrs["input_cta_order"] == [
+        "MAGEA4",
+        "PRAME",
+        "CTAG1A/CTAG1B",
+        "VITALRNA",
+    ]
     assert df.attrs["empty_ctas"] == ["VITALRNA"]
     assert df.attrs["panel_summary"]["empty_cta_count"] == 1
 
@@ -325,11 +330,11 @@ def test_automatic_selection_backfills_empty_ctas_by_default(monkeypatch):
         max_percentile=10.0,
     )
 
-    assert list(df["cta"]) == ["MAGEA4", "PRAME", "NY-ESO-1", "BACKFILL"]
+    assert list(df["cta"]) == ["MAGEA4", "PRAME", "CTAG1A/CTAG1B", "BACKFILL"]
     assert df.attrs["input_cta_order"] == [
         "MAGEA4",
         "PRAME",
-        "NY-ESO-1",
+        "CTAG1A/CTAG1B",
         "VITALRNA",
         "BACKFILL",
     ]
@@ -343,7 +348,7 @@ def test_include_empty_ctas_preserves_automatic_failures():
         max_percentile=10.0,
         include_empty_ctas=True,
     )
-    assert list(df["cta"]) == ["MAGEA4", "PRAME", "NY-ESO-1", "VITALRNA"]
+    assert list(df["cta"]) == ["MAGEA4", "PRAME", "CTAG1A/CTAG1B", "VITALRNA"]
 
 
 def test_explicit_ctas_overrides_ranking():
@@ -354,7 +359,7 @@ def test_explicit_ctas_overrides_ranking():
         alleles=["HLA-A*02:01"],
         max_percentile=10.0,
     )
-    assert list(df["cta"]) == ["NY-ESO-1", "PRAME"]
+    assert list(df["cta"]) == ["CTAG1A/CTAG1B", "PRAME"]
 
 
 def test_explicit_ctas_accepts_clinical_aliases():
@@ -364,8 +369,8 @@ def test_explicit_ctas_accepts_clinical_aliases():
         max_percentile=10.0,
         peptides_per_cell=1,
     )
-    assert list(df["cta"]) == ["MAGEA4", "NY-ESO-1"]
-    assert df.set_index("cta").loc["NY-ESO-1", "HLA-A*02:01"] == "NYESPEPT1"
+    assert list(df["cta"]) == ["MAGEA4", "CTAG1A/CTAG1B"]
+    assert df.set_index("cta").loc["CTAG1A/CTAG1B", "HLA-A*02:01"] == "NYESPEPT1"
 
 
 def test_explicit_ctas_bypass_mage_family_gate():
@@ -377,7 +382,7 @@ def test_explicit_ctas_bypass_mage_family_gate():
     assert list(df["cta"]) == ["MAGEA1"]
 
 
-def test_nyeso_group_expands_ctag1a_and_ctag1b_for_peptide_resolution(monkeypatch):
+def test_ctag1_group_expands_ctag1a_and_ctag1b_for_peptide_resolution(monkeypatch):
     calls: list[list[str]] = []
 
     def _exclusive(**kw):
@@ -393,7 +398,7 @@ def test_nyeso_group_expands_ctag1a_and_ctag1b_for_peptide_resolution(monkeypatc
     )
 
     assert calls == [["CTAG1A", "CTAG1B"]]
-    assert list(df["cta"]) == ["NY-ESO-1"]
+    assert list(df["cta"]) == ["CTAG1A/CTAG1B"]
 
 
 def test_min_restriction_confidence_filters_low():
@@ -421,18 +426,18 @@ def test_min_restriction_confidence_none_admits_low():
     assert "BAGE" not in df["cta"].tolist()
     assert "MAGEA1" not in df["cta"].tolist()
     assert "MAGEB2" not in df["cta"].tolist()
-    assert set(df["cta"]) == {"MAGEA4", "PRAME", "VITALRNA", "NY-ESO-1"}
+    assert set(df["cta"]) == {"MAGEA4", "PRAME", "VITALRNA", "CTAG1A/CTAG1B"}
 
 
 def test_restriction_levels_filter():
-    """restriction_levels=('TESTIS',) keeps the grouped NY-ESO-1 target."""
+    """restriction_levels=('TESTIS',) keeps the grouped CTAG1 target."""
     df = spanning_pmhc_set(
         cta_count=10,
         restriction_levels=("TESTIS",),
         alleles=["HLA-A*02:01"],
         max_percentile=10.0,
     )
-    assert "NY-ESO-1" in df["cta"].tolist()
+    assert "CTAG1A/CTAG1B" in df["cta"].tolist()
 
 
 def test_vital_tissue_gate_can_be_disabled():
@@ -1342,7 +1347,7 @@ def test_cli_handler_wires_on_progress_to_stderr(monkeypatch, capsys):
         ctas=None,
         min_restriction_confidence=["HIGH", "MODERATE"],
         restriction_levels=None,
-        selection_allowlist=["PRAME", "NY-ESO-1", "MAGEA4"],
+        selection_allowlist=["PRAME", "CTAG1A/CTAG1B", "MAGEA4"],
         exclude_vital_tissue_expression=True,
         vital_tissue_max_ntpm=2.0,
         exclude_non_magea4_mage_family=True,
@@ -1376,7 +1381,7 @@ def test_cli_handler_wires_on_progress_to_stderr(monkeypatch, capsys):
 
     assert "on_progress" in captured_kwargs
     assert callable(captured_kwargs["on_progress"])
-    assert captured_kwargs["selection_allowlist"] == ("PRAME", "NY-ESO-1", "MAGEA4")
+    assert captured_kwargs["selection_allowlist"] == ("PRAME", "CTAG1A/CTAG1B", "MAGEA4")
     assert captured_kwargs["exclude_vital_tissue_expression"] is True
     assert captured_kwargs["vital_tissue_max_ntpm"] == 2.0
     assert captured_kwargs["include_empty_ctas"] is False
@@ -1462,7 +1467,7 @@ def test_cli_handler_default_table_report(monkeypatch, capsys):
         ctas=None,
         min_restriction_confidence=["HIGH", "MODERATE"],
         restriction_levels=None,
-        selection_allowlist=["PRAME", "NY-ESO-1", "MAGEA4"],
+        selection_allowlist=["PRAME", "CTAG1A/CTAG1B", "MAGEA4"],
         exclude_vital_tissue_expression=True,
         vital_tissue_max_ntpm=2.0,
         exclude_non_magea4_mage_family=True,

--- a/tsarina/cli_spanning.py
+++ b/tsarina/cli_spanning.py
@@ -36,7 +36,7 @@ _SUPPORTED_PANELS = (
 _DEFAULT_PANEL = "global53_abc"
 _DEFAULT_LENGTHS = (8, 9, 10, 11)
 _DEFAULT_CTA_RANK_BY = "ms_cta_exclusive_cancer_peptide_count"
-_DEFAULT_SELECTION_ALLOWLIST = "PRAME,NY-ESO-1,MAGEA4"
+_DEFAULT_SELECTION_ALLOWLIST = "PRAME,CTAG1A/CTAG1B,MAGEA4"
 _DEFAULT_VITAL_TISSUE_MAX_NTPM = 2.0
 
 
@@ -76,8 +76,8 @@ def _configure_parser(p: argparse.ArgumentParser) -> argparse.ArgumentParser:
         type=_split_csv,
         default=None,
         help=(
-            "Explicit gene symbols, comma-separated (e.g. 'MAGEA4,PRAME,NY-ESO-1'). "
-            "Overrides --cta-count / --cta-rank-by."
+            "Explicit gene symbols, comma-separated (e.g. "
+            "'MAGEA4,PRAME,CTAG1A/CTAG1B'). Overrides --cta-count / --cta-rank-by."
         ),
     )
     p.add_argument(

--- a/tsarina/spanning.py
+++ b/tsarina/spanning.py
@@ -56,7 +56,18 @@ _DEFAULT_SAMPLE_ALLELE_MS_MAX_PERCENTILE = 1.0
 _DEFAULT_UNRESTRICTED_MS_MAX_PERCENTILE = 0.5
 _DEFAULT_PREDICTED_ONLY_MAX_PERCENTILE = 0.1
 _DEFAULT_PEPTIDES_PER_CELL = 3
-_DEFAULT_SELECTION_ALLOWLIST = ("PRAME", "NY-ESO-1", "MAGEA4")
+_CTAG1_GROUP_LABEL = "CTAG1A/CTAG1B"
+_CTAG1_ALIASES = {
+    "NYESO1",
+    "NYESO",
+    "CTAG1",
+    "CTAG1A",
+    "CTAG1B",
+    "CTAG1AB",
+    "CTAG1ACTAG1B",
+    "CTAG1BCTAG1A",
+}
+_DEFAULT_SELECTION_ALLOWLIST = ("PRAME", _CTAG1_GROUP_LABEL, "MAGEA4")
 _DEFAULT_VITAL_TISSUE_MAX_NTPM = 2.0
 _DEFAULT_EXCLUDE_NON_MAGEA4_MAGE_FAMILY = True
 _DEFAULT_GROUP_IDENTICAL_CTA_PMHCS = True
@@ -64,7 +75,7 @@ _DEFAULT_GROUP_IDENTICAL_CTA_PEPTIDE_SETS = True
 _DEFAULT_ANNOTATE_NETMHCPAN_AFFINITY = False
 
 _CTA_GROUPS: dict[str, tuple[str, ...]] = {
-    "NY-ESO-1": ("CTAG1A", "CTAG1B"),
+    _CTAG1_GROUP_LABEL: ("CTAG1A", "CTAG1B"),
 }
 
 _VITAL_TISSUE_RNA_COLUMNS: tuple[str, ...] = (
@@ -197,8 +208,9 @@ def spanning_pmhc_set(
         ``("TESTIS", "PLACENTAL")``).  ``None`` (default) keeps all.
     selection_allowlist
         CTA names allowed through automatic safety/confidence gates. Defaults
-        to clinically anchored CTAs ``("PRAME", "NY-ESO-1", "MAGEA4")``.
-        Aliases such as ``"MAGE-A4"`` and ``"CTAG1B"`` are normalized.
+        to clinically anchored CTAs ``("PRAME", "CTAG1A/CTAG1B",
+        "MAGEA4")``. Aliases such as ``"NY-ESO-1"``, ``"MAGE-A4"``,
+        and ``"CTAG1B"`` are normalized.
     exclude_vital_tissue_expression
         If True (default), automatic CTA selection excludes genes with RNA
         above ``vital_tissue_max_ntpm`` or unique public healthy-MS
@@ -1083,8 +1095,8 @@ def _compact_cta_name(value: object) -> str:
 def _cta_display_name(symbol: object) -> str:
     token = str(symbol).strip()
     compact = _compact_cta_name(token)
-    if compact in {"NYESO1", "NYESO", "CTAG1", "CTAG1A", "CTAG1B"}:
-        return "NY-ESO-1"
+    if compact in _CTAG1_ALIASES:
+        return _CTAG1_GROUP_LABEL
     if compact.startswith("MAGEA") and compact[5:].isdigit():
         return compact
     return token
@@ -1106,8 +1118,8 @@ def _normalize_cta_labels(values: Iterable[str] | None, valid_symbols: set[str])
         compact = _compact_cta_name(value)
         if not compact:
             continue
-        if compact in {"NYESO1", "NYESO", "CTAG1", "CTAG1A", "CTAG1B"}:
-            label = "NY-ESO-1"
+        if compact in _CTAG1_ALIASES:
+            label = _CTAG1_GROUP_LABEL
         elif compact in valid_by_compact:
             label = _cta_display_name(valid_by_compact[compact])
         else:

--- a/tsarina/version.py
+++ b/tsarina/version.py
@@ -10,4 +10,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "1.2.16"
+__version__ = "1.2.17"


### PR DESCRIPTION
## Summary
- Use `CTAG1A/CTAG1B` as the canonical grouped CTAG1 CTA display label in panel selection output and CLI defaults.
- Keep `NY-ESO-1`, `CTAG1A`, and `CTAG1B` as accepted input aliases that expand to both CTAG1 genes.
- Update docs, tests, task notes, and bump the package version to `1.2.17`.

## Validation
- `./format.sh`
- `./lint.sh`
- `./test.sh` (296 passed)