### PR TITLE
[codex] Avoid default MHCflurry allele chunking

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,8 +268,10 @@ tsarina panel --format wide -o panel-wide.csv
 
 The CLI prints progress for peptide enumeration, public-MS evidence loading,
 scoring, evidence-tier construction, and final selection. Interactive terminals
-also get a `tqdm` scoring progress bar; use `--no-progress` or
-`--no-progress-bars` to suppress it.
+also get a `tqdm` scoring progress bar; MHCflurry still scores all alleles in
+one batch by default because chunking repeats its allele-independent processing
+model work. Use `--score-chunk-size` only when you explicitly want chunking, or
+`--no-progress` / `--no-progress-bars` to suppress progress output.
 
 Use `--selection-allowlist`, `--no-vital-tissue-filter`,
 `--vital-tissue-max-ntpm`, and `--allow-non-magea4-mage-family` to tune

--- a/docs/index.md
+++ b/docs/index.md
@@ -249,8 +249,10 @@ tsarina panel --format wide -o panel-wide.csv
 
 The CLI prints progress for peptide enumeration, public-MS evidence loading,
 scoring, evidence-tier construction, and final selection. Interactive terminals
-also get a `tqdm` scoring progress bar; use `--no-progress` or
-`--no-progress-bars` to suppress it.
+also get a `tqdm` scoring progress bar; MHCflurry still scores all alleles in
+one batch by default because chunking repeats its allele-independent processing
+model work. Use `--score-chunk-size` only when you explicitly want chunking, or
+`--no-progress` / `--no-progress-bars` to suppress progress output.
 
 Use `--selection-allowlist`, `--no-vital-tissue-filter`,
 `--vital-tissue-max-ntpm`, and `--allow-non-magea4-mage-family` to tune

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -16,3 +16,4 @@
 - Treat broad class-I MS evidence as peptide-level evidence, not allele-level evidence. If a row only says `HLA class I`, any selected allele is assigned by prediction under the unrestricted-MS cutoff.
 - Keep CTA target labels distinct from underlying Ensembl genes in progress text. Alias/group targets such as `NY-ESO-1` can expand to multiple genes for peptide enumeration while still being one biological panel target.
 - When grouped CTA targets are made from gene symbols, default the output label to the explicit member-gene group (for example `CTAG1A/CTAG1B`) and keep clinical names like `NY-ESO-1` as accepted aliases unless the user explicitly asks for the clinical alias as canonical.
+- Do not chunk MHCflurry presentation scoring by allele by default for progress bars. Its processing predictor work is allele-independent, so allele chunking repeats expensive processing passes and can make interactive panel runs much slower.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,3 +1,33 @@
+# PR - Avoid Default MHCflurry Allele Chunking (2026-05-05)
+
+## Goal
+
+Fix the interactive ``tsarina panel`` slow path where tqdm progress bars chunk
+MHCflurry scoring by allele and repeat the allele-independent processing-model
+pass many times. Track this as https://github.com/pirl-unc/tsarina/issues/56.
+
+## Plan
+
+- [x] Default MHCflurry progress-bar scoring to one full allele batch, while
+      preserving explicit ``--score-chunk-size`` overrides.
+- [x] Update CLI/docs/tests to explain that MHCflurry chunking is opt-in
+      because it can repeat processing work.
+- [x] Bump the patch version.
+- [x] Run ``./format.sh``, ``./lint.sh``, and ``./test.sh``.
+- [ ] Open, merge, and deploy the PR.
+
+## Review
+
+- MHCflurry progress-bar scoring now defaults to one full allele batch, avoiding
+  repeated processing-model passes across allele chunks.
+- Explicit ``--score-chunk-size`` still works for MHCflurry when a user chooses
+  to trade speed for smaller scoring chunks.
+- CLI/docs now describe the MHCflurry chunking tradeoff.
+- Verification passed: ``./format.sh``, ``./lint.sh``, and ``./test.sh``
+  (297 tests).
+
+---
+
 # PR - Display CTAG1A/CTAG1B As The Canonical Group Label (2026-05-05)
 
 ## Goal

--- a/tests/test_spanning.py
+++ b/tests/test_spanning.py
@@ -1298,7 +1298,7 @@ def test_progress_bar_scores_in_chunks(monkeypatch):
     assert calls == [("HLA-A*02:01",), ("HLA-A*24:02",)]
 
 
-def test_progress_bar_default_mhcflurry_chunk_size_is_larger(monkeypatch):
+def test_progress_bar_default_mhcflurry_scores_one_full_allele_batch(monkeypatch):
     from tsarina.spanning import _score_presentations
 
     calls: list[tuple[str, ...]] = []
@@ -1320,7 +1320,32 @@ def test_progress_bar_default_mhcflurry_chunk_size_is_larger(monkeypatch):
     )
 
     assert not scores.empty
-    assert [len(call) for call in calls] == [8, 1]
+    assert [len(call) for call in calls] == [9]
+
+
+def test_progress_bar_explicit_mhcflurry_chunk_size_is_honored(monkeypatch):
+    from tsarina.spanning import _score_presentations
+
+    calls: list[tuple[str, ...]] = []
+
+    def _chunked_scores(peptides, alleles, **kwargs):
+        calls.append(tuple(alleles))
+        return _stub_scores(peptides, alleles, **kwargs)
+
+    monkeypatch.setattr("tsarina.scoring.score_presentation", _chunked_scores, raising=True)
+    alleles = [f"HLA-A*02:{i:02d}" for i in range(1, 6)]
+
+    scores = _score_presentations(
+        peptides=["PEPTIDE"],
+        alleles=alleles,
+        predictor="mhcflurry",
+        progress_bar=True,
+        score_chunk_size=2,
+        progress_file=io.StringIO(),
+    )
+
+    assert not scores.empty
+    assert [len(call) for call in calls] == [2, 2, 1]
 
 
 def test_cli_handler_wires_on_progress_to_stderr(monkeypatch, capsys):

--- a/tsarina/cli_spanning.py
+++ b/tsarina/cli_spanning.py
@@ -314,7 +314,8 @@ def _configure_parser(p: argparse.ArgumentParser) -> argparse.ArgumentParser:
         default=None,
         help=(
             "Number of HLA alleles per scoring chunk when progress bars are enabled "
-            "(default 8 for MHCflurry, 1 for other predictors)."
+            "(default all alleles at once for MHCflurry, 1 for other predictors). "
+            "MHCflurry chunking is opt-in because it repeats processing-model work."
         ),
     )
     p.add_argument(

--- a/tsarina/spanning.py
+++ b/tsarina/spanning.py
@@ -306,8 +306,9 @@ def spanning_pmhc_set(
         the scoring stage. Default False so library calls remain quiet.
     score_chunk_size
         Number of HLA alleles per scoring chunk when ``progress_bar`` is
-        enabled. Defaults to 8 for MHCflurry and one allele per chunk for
-        other predictors.
+        enabled. Defaults to one full allele batch for MHCflurry, since
+        allele chunking repeats its allele-independent processing model pass,
+        and one allele per chunk for other predictors.
     progress_file
         File handle for tqdm progress bars. Defaults to ``sys.stderr`` when
         ``progress_bar`` is True.
@@ -1381,8 +1382,9 @@ def _score_presentations(
     if not progress_bar:
         return score_presentation(peptides=peptides, alleles=alleles, predictor=predictor)
 
-    chunk_size = score_chunk_size or (
-        8 if predictor.lower().replace("-", "_") == "mhcflurry" else 1
+    is_mhcflurry = predictor.lower().replace("-", "_") == "mhcflurry"
+    chunk_size = (
+        score_chunk_size if score_chunk_size is not None else (len(alleles) if is_mhcflurry else 1)
     )
     if chunk_size < 1:
         raise ValueError(f"score_chunk_size must be >= 1, got {score_chunk_size!r}")

--- a/tsarina/version.py
+++ b/tsarina/version.py
@@ -10,4 +10,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "1.2.17"
+__version__ = "1.2.18"


### PR DESCRIPTION
Fixes #56.

## Summary
- Default MHCflurry progress-bar scoring to one full allele batch instead of 8-allele chunks.
- Keep explicit `--score-chunk-size` support for users who intentionally want MHCflurry chunking.
- Document why MHCflurry chunking can repeat processing-model work.
- Bump package version to `1.2.18`.

## Validation
- `./format.sh`
- `./lint.sh`
- `./test.sh` (297 passed)