### PR TITLE
Sort CTA panel summary by estimated coverage first

### DIFF
--- a/tests/test_spanning.py
+++ b/tests/test_spanning.py
@@ -678,27 +678,6 @@ def test_vital_rna_gate_threshold_is_parameterizable():
     assert "VITALRNA" not in ctas
 
 
-def test_panel_summary_sorts_ctas_by_estimated_coverage():
-    selected = pd.DataFrame(
-        {
-            "cta": ["LOW", "HIGH", "HIGH"],
-            "allele": ["HLA-A*02:01", "HLA-A*02:01", "HLA-A*24:02"],
-            "peptide": ["LOWPEP", "HIGHPEP1", "HIGHPEP2"],
-            "evidence_tier": ["unrestricted_ms", "unrestricted_ms", "unrestricted_ms"],
-        }
-    )
-    summary = panel_summary(
-        selected=selected,
-        cta_list=["ZERO", "LOW", "HIGH"],
-        allele_list=["HLA-A*02:01", "HLA-A*24:02"],
-        allele_frequencies={"HLA-A*02:01": 0.2, "HLA-A*24:02": 0.1},
-    )
-    assert [row["cta"] for row in summary["cta_coverage"]] == ["HIGH", "LOW", "ZERO"]
-    by_cta = {row["cta"]: row for row in summary["cta_coverage"]}
-    assert by_cta["HIGH"]["estimated_population_coverage"] == pytest.approx(0.51)
-    assert by_cta["LOW"]["estimated_population_coverage"] == pytest.approx(0.36)
-
-
 def test_panel_summary_coverage_outranks_peptide_count():
     selected = pd.DataFrame(
         {

--- a/tests/test_spanning.py
+++ b/tests/test_spanning.py
@@ -678,7 +678,7 @@ def test_vital_rna_gate_threshold_is_parameterizable():
     assert "VITALRNA" not in ctas
 
 
-def test_panel_summary_sorts_ctas_by_selected_peptides():
+def test_panel_summary_sorts_ctas_by_estimated_coverage():
     selected = pd.DataFrame(
         {
             "cta": ["LOW", "HIGH", "HIGH"],
@@ -697,6 +697,41 @@ def test_panel_summary_sorts_ctas_by_selected_peptides():
     by_cta = {row["cta"]: row for row in summary["cta_coverage"]}
     assert by_cta["HIGH"]["estimated_population_coverage"] == pytest.approx(0.51)
     assert by_cta["LOW"]["estimated_population_coverage"] == pytest.approx(0.36)
+
+
+def test_panel_summary_coverage_outranks_peptide_count():
+    selected = pd.DataFrame(
+        {
+            "cta": ["MANY", "MANY", "MANY", "BROAD"],
+            "allele": [
+                "HLA-A*02:01",
+                "HLA-A*02:01",
+                "HLA-A*02:01",
+                "HLA-A*24:02",
+            ],
+            "peptide": ["MANYPEP1", "MANYPEP2", "MANYPEP3", "BROADPEP"],
+            "evidence_tier": [
+                "unrestricted_ms",
+                "unrestricted_ms",
+                "unrestricted_ms",
+                "unrestricted_ms",
+            ],
+        }
+    )
+    summary = panel_summary(
+        selected=selected,
+        cta_list=["MANY", "BROAD"],
+        allele_list=["HLA-A*02:01", "HLA-A*24:02"],
+        allele_frequencies={"HLA-A*02:01": 0.1, "HLA-A*24:02": 0.4},
+    )
+    assert [row["cta"] for row in summary["cta_coverage"]] == ["BROAD", "MANY"]
+    by_cta = {row["cta"]: row for row in summary["cta_coverage"]}
+    assert by_cta["BROAD"]["selected_peptide_count"] == 1
+    assert by_cta["MANY"]["selected_peptide_count"] == 3
+    assert (
+        by_cta["BROAD"]["estimated_population_coverage"]
+        > by_cta["MANY"]["estimated_population_coverage"]
+    )
 
 
 def test_panel_summary_counts_ms_tiers_per_cta():

--- a/tsarina/spanning.py
+++ b/tsarina/spanning.py
@@ -2143,9 +2143,9 @@ def panel_summary(
     cta_rows = sorted(
         cta_rows,
         key=lambda row: (
+            -float(row["estimated_population_coverage"]),
             -int(row["selected_peptide_count"]),
             -int(row["covered_hla_count"]),
-            -float(row["estimated_population_coverage"]),
             str(row["cta"]),
         ),
     )

--- a/tsarina/version.py
+++ b/tsarina/version.py
@@ -10,4 +10,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "1.2.22"
+__version__ = "1.2.23"


### PR DESCRIPTION
## Summary
- The per-CTA table in the panel summary was sorted by `selected_peptide_count` first, so CTAs with high coverage but few peptides (e.g. `PIWIL1` at 98.9% with 2 peptides) ended up far below middling-coverage CTAs with more peptides.
- Reorder the sort key in `panel_summary` to `(-estimated_population_coverage, -selected_peptide_count, -covered_hla_count, cta)` so the table reads top-to-bottom by the column users actually compare.
- Update the existing ordering test name and add a new test where coverage and peptide-count rankings disagree, locking in coverage-first behavior.
- Bump version to 1.2.23.

## Test plan
- [x] `./format.sh`
- [x] `./lint.sh`
- [x] `./test.sh` (308 passed)