### PR TITLE
Surface TCGA pan-cancer RNA prevalence in evidence and panel summary

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,8 @@ name = "tsarina"
 dynamic = ["version"]
 description = "Personalized cancer immunotherapy target selection from curated shared antigen data"
 readme = "README.md"
-license = {file = "LICENSE"}
+license = "Apache-2.0"
+license-files = ["LICENSE"]
 authors = [
     {name = "Alex Rubinsteyn", email = "alex.rubinsteyn@unc.edu"}
 ]
@@ -16,7 +17,6 @@ classifiers = [
     "Environment :: Console",
     "Operating System :: OS Independent",
     "Intended Audience :: Science/Research",
-    "License :: OSI Approved :: Apache Software License",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.9",

--- a/tests/test_cancer_expression.py
+++ b/tests/test_cancer_expression.py
@@ -1,7 +1,10 @@
 import pandas as pd
 import pytest
 
-from tsarina.cancer_expression import cta_cancer_expression_features
+from tsarina.cancer_expression import (
+    cta_cancer_expression_features,
+    cta_tcga_expression_features,
+)
 
 
 def test_cta_cancer_expression_features_count_sample_and_cancer_type_prevalence():
@@ -49,6 +52,60 @@ def test_cta_cancer_expression_features_count_sample_and_cancer_type_prevalence(
         features.loc["CTA1", "tumor_prevalence_panel_score"]
         > features.loc["CTA2", "tumor_prevalence_panel_score"]
     )
+
+
+def test_cta_tcga_expression_features_aggregates_tcga_cohort_only():
+    rna = pd.DataFrame(
+        {
+            "gene_id": ["E1", "E1", "E1", "E2"],
+            "symbol": ["CTA1", "CTA1", "CTA1", "CTA2"],
+            "cancer": [
+                "Cancer A (TCGA)",
+                "Cancer B (TCGA)",
+                "Cancer A (validation)",
+                "Cancer A (TCGA)",
+            ],
+            "cancer_type": ["Cancer A", "Cancer B", "Cancer A", "Cancer A"],
+            "cohort": ["TCGA", "TCGA", "validation", "TCGA"],
+            "samples": [100, 50, 200, 80],
+            "mean_ptpm": [1.0, 1.0, 5.0, 0.5],
+            "max_ptpm": [50.0, 20.0, 200.0, 4.0],
+            "expressed_samples_ptpm_ge_1": [40, 5, 150, 8],
+            "expressed_samples_ptpm_ge_5": [25, 1, 100, 0],
+        }
+    )
+
+    features = cta_tcga_expression_features(rna_prevalence=rna).set_index("symbol")
+
+    # validation cohort row for CTA1 must be excluded (TCGA-only).
+    assert features.loc["CTA1", "tcga_sample_count"] == 150
+    assert features.loc["CTA1", "tcga_cancer_type_count"] == 2
+    assert features.loc["CTA1", "tcga_expressed_samples_tpm_ge_1"] == 45
+    assert features.loc["CTA1", "tcga_expressed_samples_tpm_ge_5"] == 26
+    assert features.loc["CTA1", "tcga_pan_prevalence_tpm_ge_1"] == pytest.approx(45 / 150)
+    assert features.loc["CTA1", "tcga_pan_prevalence_tpm_ge_5"] == pytest.approx(26 / 150)
+    assert features.loc["CTA1", "tcga_max_ptpm"] == pytest.approx(50.0)
+    # Cancer A has 40/100 = 0.40 prevalence at TPM>=1; Cancer B has 5/50 = 0.10.
+    assert features.loc["CTA1", "tcga_top_cancer_type_tpm_ge_1"] == "Cancer A"
+    assert features.loc["CTA1", "tcga_top_cancer_type_prevalence_tpm_ge_1"] == pytest.approx(0.4)
+
+
+def test_cta_tcga_expression_features_returns_empty_without_tcga_rows():
+    rna = pd.DataFrame(
+        {
+            "gene_id": ["E1"],
+            "symbol": ["CTA1"],
+            "cancer_type": ["Cancer A"],
+            "cohort": ["validation"],
+            "samples": [100],
+            "expressed_samples_ptpm_ge_1": [40],
+            "expressed_samples_ptpm_ge_5": [10],
+            "max_ptpm": [50.0],
+        }
+    )
+
+    features = cta_tcga_expression_features(rna_prevalence=rna)
+    assert features.empty
 
 
 def test_cta_cancer_expression_features_requires_requested_threshold():

--- a/tests/test_evidence.py
+++ b/tests/test_evidence.py
@@ -1,6 +1,6 @@
 import pandas as pd
 
-from tsarina.evidence import _compute_ms_restriction
+from tsarina.evidence import _attach_tcga_prevalence, _compute_ms_restriction
 
 
 def test_compute_ms_restriction_uses_public_ms_loader(monkeypatch):
@@ -71,3 +71,49 @@ def test_compute_ms_restriction_uses_public_ms_loader(monkeypatch):
     assert calls["kwargs"]["mhc_class"] == "I"
     assert out.loc[out["Symbol"] == "MAGEA4", "ms_restriction"].iloc[0] == "CANCER_ONLY"
     assert out.loc[out["Symbol"] == "PRAME", "ms_restriction"].iloc[0] == "NO_MS_DATA"
+
+
+def test_attach_tcga_prevalence_joins_on_stripped_ensembl_id(monkeypatch):
+    input_df = pd.DataFrame(
+        {
+            "Symbol": ["MAGEA4", "PRAME", "UNKNOWN"],
+            # Versioned and unversioned Ensembl IDs must both match.
+            "Ensembl_Gene_ID": ["ENSG00000147381.10", "ENSG00000185686", "ENSG99999999999"],
+        }
+    )
+    fake_features = pd.DataFrame(
+        {
+            "gene_id": ["ENSG00000147381", "ENSG00000185686"],
+            "symbol": ["MAGEA4", "PRAME"],
+            "tcga_sample_count": [6918, 6918],
+            "tcga_cancer_type_count": [21, 21],
+            "tcga_max_ptpm": [1602.47, 538.025],
+            "tcga_expressed_samples_tpm_ge_1": [1178, 3036],
+            "tcga_expressed_samples_tpm_ge_5": [912, 2190],
+            "tcga_pan_prevalence_tpm_ge_1": [0.1703, 0.4389],
+            "tcga_pan_prevalence_tpm_ge_5": [0.1318, 0.3166],
+            "tcga_top_cancer_type_tpm_ge_1": [
+                "Lung Squamous Cell Carcinoma",
+                "Skin Cuteneous Melanoma",
+            ],
+            "tcga_top_cancer_type_prevalence_tpm_ge_1": [0.6462, 0.9798],
+        }
+    )
+
+    monkeypatch.setattr(
+        "tsarina.cancer_expression.cta_tcga_expression_features",
+        lambda: fake_features,
+        raising=True,
+    )
+
+    out = _attach_tcga_prevalence(input_df)
+
+    by_symbol = out.set_index("Symbol")
+    assert (
+        by_symbol.loc["MAGEA4", "tcga_top_cancer_type_tpm_ge_1"] == "Lung Squamous Cell Carcinoma"
+    )
+    assert by_symbol.loc["PRAME", "tcga_pan_prevalence_tpm_ge_5"] == 0.3166
+    # Genes without TCGA features get zeros / empty strings, not NaN.
+    assert by_symbol.loc["UNKNOWN", "tcga_sample_count"] == 0
+    assert by_symbol.loc["UNKNOWN", "tcga_pan_prevalence_tpm_ge_1"] == 0.0
+    assert by_symbol.loc["UNKNOWN", "tcga_top_cancer_type_tpm_ge_1"] == ""

--- a/tests/test_spanning.py
+++ b/tests/test_spanning.py
@@ -713,6 +713,72 @@ def test_panel_summary_coverage_outranks_peptide_count():
     )
 
 
+def test_panel_summary_attaches_tcga_prevalence_when_features_provided():
+    selected = pd.DataFrame(
+        {
+            "cta": ["PRAME", "MERGED"],
+            "allele": ["HLA-A*02:01", "HLA-A*02:01"],
+            "peptide": ["P1", "P2"],
+            "evidence_tier": ["unrestricted_ms", "unrestricted_ms"],
+            "cta_members": ["PRAME", "ALPHA/BETA"],
+        }
+    )
+    tcga_features = pd.DataFrame(
+        {
+            "gene_id": ["E1", "E2", "E3"],
+            "symbol": ["PRAME", "ALPHA", "BETA"],
+            "tcga_sample_count": [6918, 6918, 6918],
+            "tcga_cancer_type_count": [21, 21, 21],
+            "tcga_max_ptpm": [538.0, 100.0, 200.0],
+            "tcga_expressed_samples_tpm_ge_1": [3036, 100, 500],
+            "tcga_expressed_samples_tpm_ge_5": [2190, 20, 200],
+            "tcga_pan_prevalence_tpm_ge_1": [0.44, 0.01, 0.07],
+            "tcga_pan_prevalence_tpm_ge_5": [0.32, 0.003, 0.03],
+            "tcga_top_cancer_type_tpm_ge_1": [
+                "Skin Cuteneous Melanoma",
+                "Stomach Adenocarcinoma",
+                "Lung Adenocarcinoma",
+            ],
+            "tcga_top_cancer_type_prevalence_tpm_ge_1": [0.98, 0.10, 0.25],
+        }
+    )
+    summary = panel_summary(
+        selected=selected,
+        cta_list=["PRAME", "MERGED"],
+        allele_list=["HLA-A*02:01"],
+        allele_frequencies={"HLA-A*02:01": 0.25},
+        tcga_features=tcga_features,
+    )
+    by_cta = {row["cta"]: row for row in summary["cta_coverage"]}
+    assert by_cta["PRAME"]["tcga_pan_prevalence_tpm_ge_1"] == pytest.approx(0.44)
+    assert by_cta["PRAME"]["tcga_top_cancer_type"] == "Skin Cuteneous Melanoma"
+    # Merged label keeps the BETA member's top cancer type (BETA has higher
+    # pan-cancer prevalence at TPM>=1 than ALPHA).
+    assert by_cta["MERGED"]["tcga_pan_prevalence_tpm_ge_1"] == pytest.approx(0.07)
+    assert by_cta["MERGED"]["tcga_top_cancer_type"] == "Lung Adenocarcinoma"
+
+
+def test_panel_summary_omits_tcga_values_without_features():
+    selected = pd.DataFrame(
+        {
+            "cta": ["PRAME"],
+            "allele": ["HLA-A*02:01"],
+            "peptide": ["P1"],
+            "evidence_tier": ["unrestricted_ms"],
+        }
+    )
+    summary = panel_summary(
+        selected=selected,
+        cta_list=["PRAME"],
+        allele_list=["HLA-A*02:01"],
+        allele_frequencies={"HLA-A*02:01": 0.25},
+    )
+    row = summary["cta_coverage"][0]
+    assert row["tcga_pan_prevalence_tpm_ge_1"] == 0.0
+    assert row["tcga_pan_prevalence_tpm_ge_5"] == 0.0
+    assert row["tcga_top_cancer_type"] == ""
+
+
 def test_panel_summary_counts_ms_tiers_per_cta():
     selected = pd.DataFrame(
         {

--- a/tsarina/cancer_expression.py
+++ b/tsarina/cancer_expression.py
@@ -18,6 +18,8 @@ _RNA_PREVALENCE_CSV = join(_DATA_DIR, "hpa-cancer-rna-prevalence.csv")
 _IHC_PREVALENCE_CSV = join(_DATA_DIR, "hpa-cancer-ihc-prevalence.csv")
 _DEFAULT_RNA_THRESHOLD = 2.0
 _DEFAULT_CANCER_TYPE_PREVALENCE_FLOOR = 0.05
+_TCGA_COHORT = "TCGA"
+_TCGA_DEFAULT_THRESHOLDS = (1.0, 5.0)
 
 
 def _threshold_label(value: float) -> str:
@@ -224,3 +226,115 @@ def _ihc_features(
             "cancer_ihc_medium_high_sample_prevalence": 0.0,
         }
     )
+
+
+def cta_tcga_expression_features(
+    *,
+    thresholds: tuple[float, ...] = _TCGA_DEFAULT_THRESHOLDS,
+    rna_prevalence: pd.DataFrame | None = None,
+) -> pd.DataFrame:
+    """Per-gene TCGA pan-cancer RNA prevalence summary.
+
+    Aggregates the TCGA-cohort rows of the bundled HPA cancer RNA prevalence
+    table into one row per ``(gene_id, symbol)`` with prevalence at each
+    requested pTPM threshold (defaults: ``1.0`` and ``5.0``), the originating
+    TCGA cancer type that maximizes prevalence at the lowest threshold, and
+    counts of distinct TCGA cancer types contributing samples.
+
+    The underlying TCGA expression measurements are the cohort=``TCGA`` rows
+    of HPA v23's ``cancer RNA-Seq`` tab, which republishes harmonized TCGA
+    Pan-Cancer pTPM values. Sample counts and 21 distinct TCGA project codes
+    (BRCA, LUAD, ...) are preserved.
+    """
+    rna = hpa_cancer_rna_prevalence() if rna_prevalence is None else rna_prevalence
+    if rna.empty or "cohort" not in rna.columns:
+        return pd.DataFrame(columns=["gene_id", "symbol"])
+
+    tcga = rna[rna["cohort"] == _TCGA_COHORT].copy()
+    if tcga.empty:
+        return pd.DataFrame(columns=["gene_id", "symbol"])
+
+    if not thresholds:
+        raise ValueError("cta_tcga_expression_features requires at least one threshold")
+    sorted_thresholds = tuple(sorted(thresholds))
+    threshold_labels = {t: _threshold_label(t) for t in sorted_thresholds}
+
+    required = {"gene_id", "symbol", "cancer_type", "samples"}
+    missing = required - set(tcga.columns)
+    if missing:
+        raise ValueError(
+            f"Bundled HPA cancer RNA prevalence table missing TCGA column(s): {sorted(missing)}"
+        )
+    tcga["samples"] = pd.to_numeric(tcga["samples"], errors="coerce").fillna(0)
+    for threshold, label in threshold_labels.items():
+        count_col = f"expressed_samples_ptpm_ge_{label}"
+        if count_col not in tcga.columns:
+            raise ValueError(
+                f"Bundled HPA cancer RNA prevalence table missing column {count_col!r} "
+                f"required for TCGA threshold {threshold:g} pTPM"
+            )
+        tcga[count_col] = pd.to_numeric(tcga[count_col], errors="coerce").fillna(0)
+
+    per_type = tcga.groupby(["gene_id", "symbol", "cancer_type"], as_index=False, sort=False).agg(
+        samples=("samples", "sum"),
+        **{
+            f"expressed_samples_ptpm_ge_{label}": (f"expressed_samples_ptpm_ge_{label}", "sum")
+            for label in threshold_labels.values()
+        },
+        max_ptpm=("max_ptpm", "max"),
+    )
+    for label in threshold_labels.values():
+        count_col = f"expressed_samples_ptpm_ge_{label}"
+        prev_col = f"cancer_type_prevalence_tpm_ge_{label}"
+        per_type[prev_col] = per_type[count_col] / per_type["samples"].where(
+            per_type["samples"] != 0, pd.NA
+        )
+
+    primary_label = threshold_labels[sorted_thresholds[0]]
+    primary_prev_col = f"cancer_type_prevalence_tpm_ge_{primary_label}"
+    top_type_col = f"tcga_top_cancer_type_tpm_ge_{primary_label}"
+    top_prev_col = f"tcga_top_cancer_type_prevalence_tpm_ge_{primary_label}"
+
+    ranked = per_type.sort_values(
+        ["gene_id", "symbol", primary_prev_col],
+        ascending=[True, True, False],
+        na_position="last",
+    )
+    tops = (
+        ranked.drop_duplicates(["gene_id", "symbol"], keep="first")[
+            ["gene_id", "symbol", "cancer_type", primary_prev_col]
+        ]
+        .rename(
+            columns={
+                "cancer_type": top_type_col,
+                primary_prev_col: top_prev_col,
+            }
+        )
+        .reset_index(drop=True)
+    )
+    tops[top_type_col] = tops[top_type_col].astype(str).fillna("")
+    tops[top_prev_col] = pd.to_numeric(tops[top_prev_col], errors="coerce").fillna(0.0)
+
+    base_aggs: dict[str, tuple[str, str]] = {
+        "tcga_sample_count": ("samples", "sum"),
+        "tcga_cancer_type_count": ("cancer_type", "nunique"),
+        "tcga_max_ptpm": ("max_ptpm", "max"),
+    }
+    for label in threshold_labels.values():
+        base_aggs[f"tcga_expressed_samples_tpm_ge_{label}"] = (
+            f"expressed_samples_ptpm_ge_{label}",
+            "sum",
+        )
+
+    summary = per_type.groupby(["gene_id", "symbol"], as_index=False, sort=False).agg(**base_aggs)
+    for label in threshold_labels.values():
+        prev_col = f"tcga_pan_prevalence_tpm_ge_{label}"
+        summary[prev_col] = summary[f"tcga_expressed_samples_tpm_ge_{label}"] / summary[
+            "tcga_sample_count"
+        ].where(summary["tcga_sample_count"] != 0, pd.NA)
+        summary[prev_col] = summary[prev_col].fillna(0.0)
+
+    summary = summary.merge(tops, on=["gene_id", "symbol"], how="left")
+    summary[top_type_col] = summary[top_type_col].fillna("")
+    summary[top_prev_col] = summary[top_prev_col].fillna(0.0)
+    return summary

--- a/tsarina/cli_spanning.py
+++ b/tsarina/cli_spanning.py
@@ -456,6 +456,42 @@ def _format_percent(value: object) -> str:
         return "n/a"
 
 
+# HPA-style TCGA cancer-type display name → TCGA project code. Used to keep
+# the panel summary table narrow.
+_TCGA_PROJECT_CODE = {
+    "Bladder Urothelial Carcinoma": "BLCA",
+    "Breast Invasive Carcinoma": "BRCA",
+    "Cervical Squamous Cell Carcinoma and Endocervical Adenocarcinoma": "CESC",
+    "Colon Adenocarcinoma": "COAD",
+    "Glioblastoma Multiforme": "GBM",
+    "Head and Neck Squamous Cell Carcinoma": "HNSC",
+    "Kidney Chromophobe": "KICH",
+    "Kidney Renal Clear Cell Carcinoma": "KIRC",
+    "Kidney Renal Papillary Cell Carcinoma": "KIRP",
+    "Liver Hepatocellular Carcinoma": "LIHC",
+    "Lung Adenocarcinoma": "LUAD",
+    "Lung Squamous Cell Carcinoma": "LUSC",
+    "Ovary Serous Cystadenocarcinoma": "OV",
+    "Pancreatic Adenocarcinoma": "PAAD",
+    "Prostate Adenocarcinoma": "PRAD",
+    "Rectum Adenocarcinoma": "READ",
+    "Skin Cuteneous Melanoma": "SKCM",
+    "Stomach Adenocarcinoma": "STAD",
+    "Testicular Germ Cell Tumor": "TGCT",
+    "Thyroid Carcinoma": "THCA",
+    "Uterine Corpus Endometrial Carcinoma": "UCEC",
+}
+
+
+def _abbreviate_tcga_cancer_type(value: object) -> str:
+    if value is None:
+        return ""
+    text = str(value).strip()
+    if not text:
+        return ""
+    return _TCGA_PROJECT_CODE.get(text, text[:12])
+
+
 def _format_rank_value(value: object) -> str:
     try:
         number = float(value)
@@ -618,6 +654,9 @@ def format_panel_summary(df) -> str:
             str(row.get("sample_allele_ms_pmhc_count", 0)),
             str(row.get("unrestricted_ms_pmhc_count", 0)),
             _format_percent(row["estimated_population_coverage"]),
+            _format_percent(row.get("tcga_pan_prevalence_tpm_ge_1", 0.0)),
+            _format_percent(row.get("tcga_pan_prevalence_tpm_ge_5", 0.0)),
+            _abbreviate_tcga_cancer_type(row.get("tcga_top_cancer_type", "")),
         ]
         for row in summary["cta_coverage"]
     ]
@@ -634,6 +673,9 @@ def format_panel_summary(df) -> str:
                     "Sample MS",
                     "Unres MS",
                     "Est. coverage",
+                    "TCGA >1 TPM",
+                    "TCGA >5 TPM",
+                    "TCGA top type",
                 ],
                 cta_rows,
             ),

--- a/tsarina/evidence.py
+++ b/tsarina/evidence.py
@@ -137,12 +137,21 @@ def CTA_detailed_evidence(
         Gene symbols to compute MS restriction for.  If None, uses all
         CTA genes (slower — enumerates peptides for all 358 genes).
 
+    TCGA tumor RNA prevalence columns (always added):
+    ``tcga_sample_count``, ``tcga_cancer_type_count``, ``tcga_max_ptpm``,
+    ``tcga_expressed_samples_tpm_ge_1``, ``tcga_expressed_samples_tpm_ge_5``,
+    ``tcga_pan_prevalence_tpm_ge_1``, ``tcga_pan_prevalence_tpm_ge_5``,
+    ``tcga_top_cancer_type_tpm_ge_1``,
+    ``tcga_top_cancer_type_prevalence_tpm_ge_1``. Sourced from the
+    cohort=TCGA rows of the bundled HPA cancer RNA-seq prevalence table.
+
     Returns
     -------
     pd.DataFrame
         CTA evidence DataFrame with additional detail columns.
     """
     df = cta_dataframe().copy()
+    df = _attach_tcga_prevalence(df)
 
     if hpa_bulk_path is not None:
         from .hpa import enrich_hpa_evidence, extract_per_tissue_detail, parse_ntpm_entries
@@ -173,6 +182,51 @@ def CTA_detailed_evidence(
         df = _compute_ms_restriction(df, iedb_path, cedar_path, genes=genes)
 
     return df
+
+
+_TCGA_PREVALENCE_NUMERIC_DEFAULTS = {
+    "tcga_sample_count": 0,
+    "tcga_cancer_type_count": 0,
+    "tcga_max_ptpm": 0.0,
+    "tcga_expressed_samples_tpm_ge_1": 0,
+    "tcga_expressed_samples_tpm_ge_5": 0,
+    "tcga_pan_prevalence_tpm_ge_1": 0.0,
+    "tcga_pan_prevalence_tpm_ge_5": 0.0,
+    "tcga_top_cancer_type_prevalence_tpm_ge_1": 0.0,
+}
+_TCGA_PREVALENCE_STRING_DEFAULTS = {"tcga_top_cancer_type_tpm_ge_1": ""}
+
+
+def _attach_tcga_prevalence(df: pd.DataFrame) -> pd.DataFrame:
+    """Left-merge TCGA pan-cancer prevalence features onto the CTA evidence table.
+
+    Joins on the stripped Ensembl gene id so transcript-versioned ids in the
+    evidence frame still match. Genes without TCGA expression measurements get
+    zero/empty defaults rather than NaN, so downstream filters and table
+    rendering stay stable.
+    """
+    if "Ensembl_Gene_ID" not in df.columns:
+        return df
+
+    from .cancer_expression import cta_tcga_expression_features
+
+    features = cta_tcga_expression_features()
+    if features.empty:
+        for column, default in _TCGA_PREVALENCE_NUMERIC_DEFAULTS.items():
+            df[column] = default
+        for column, default in _TCGA_PREVALENCE_STRING_DEFAULTS.items():
+            df[column] = default
+        return df
+
+    join_key = "_tcga_gene_id"
+    df[join_key] = df["Ensembl_Gene_ID"].astype(str).str.split(".").str[0]
+    features = features.rename(columns={"gene_id": join_key}).drop(columns=["symbol"])
+    merged = df.merge(features, on=join_key, how="left").drop(columns=[join_key])
+    for column, default in _TCGA_PREVALENCE_NUMERIC_DEFAULTS.items():
+        merged[column] = pd.to_numeric(merged[column], errors="coerce").fillna(default)
+    for column, default in _TCGA_PREVALENCE_STRING_DEFAULTS.items():
+        merged[column] = merged[column].fillna(default).astype(str)
+    return merged
 
 
 def _compute_ms_restriction(

--- a/tsarina/spanning.py
+++ b/tsarina/spanning.py
@@ -576,6 +576,7 @@ def spanning_pmhc_set(
         allele_list=allele_list,
         allele_frequencies=allele_frequencies,
         allele_frequency_sources=allele_frequency_sources,
+        tcga_features=_load_tcga_features_safely(),
     )
     summary["candidate_cta_count"] = len(cta_candidates)
     summary["cta_rank_by"] = cta_rank_by
@@ -2080,12 +2081,91 @@ def _selected_tier_row_counts(selected: pd.DataFrame) -> dict[str, int]:
     return counts
 
 
+_TCGA_PANEL_FIELDS = (
+    "tcga_pan_prevalence_tpm_ge_1",
+    "tcga_pan_prevalence_tpm_ge_5",
+    "tcga_max_ptpm",
+    "tcga_top_cancer_type",
+)
+
+
+def _load_tcga_features_safely() -> pd.DataFrame | None:
+    """Best-effort load of bundled TCGA prevalence; ``None`` if unavailable.
+
+    Wrapped so a malformed or missing bundled CSV cannot break panel
+    construction — callers should still get a populated summary, just
+    without the TCGA columns.
+    """
+    try:
+        from .cancer_expression import cta_tcga_expression_features
+
+        return cta_tcga_expression_features()
+    except (FileNotFoundError, ValueError):
+        return None
+
+
+def _empty_tcga_panel_summary() -> dict[str, object]:
+    return {
+        "tcga_pan_prevalence_tpm_ge_1": 0.0,
+        "tcga_pan_prevalence_tpm_ge_5": 0.0,
+        "tcga_max_ptpm": 0.0,
+        "tcga_top_cancer_type": "",
+    }
+
+
+def _tcga_features_by_symbol(
+    tcga_features: pd.DataFrame | None,
+) -> dict[str, dict[str, object]]:
+    if tcga_features is None or tcga_features.empty or "symbol" not in tcga_features.columns:
+        return {}
+    return {
+        str(row["symbol"]): {
+            "tcga_pan_prevalence_tpm_ge_1": float(
+                row.get("tcga_pan_prevalence_tpm_ge_1", 0.0) or 0.0
+            ),
+            "tcga_pan_prevalence_tpm_ge_5": float(
+                row.get("tcga_pan_prevalence_tpm_ge_5", 0.0) or 0.0
+            ),
+            "tcga_max_ptpm": float(row.get("tcga_max_ptpm", 0.0) or 0.0),
+            "tcga_top_cancer_type": str(row.get("tcga_top_cancer_type_tpm_ge_1", "") or ""),
+        }
+        for _, row in tcga_features.iterrows()
+    }
+
+
+def _tcga_summary_for_cta(
+    cta_members: str,
+    tcga_lookup: dict[str, dict[str, object]],
+) -> dict[str, object]:
+    """Aggregate TCGA prevalence across the (possibly merged) CTA members.
+
+    For each slash-joined member symbol we pull its TCGA summary and keep the
+    member with the highest ``tcga_pan_prevalence_tpm_ge_1`` so the top
+    cancer-type string corresponds to a real underlying gene rather than a
+    cross-member mash-up.
+    """
+    if not tcga_lookup or not cta_members:
+        return _empty_tcga_panel_summary()
+    members = [m for m in str(cta_members).split("/") if m]
+    rows = [tcga_lookup[m] for m in members if m in tcga_lookup]
+    if not rows:
+        return _empty_tcga_panel_summary()
+    best = max(rows, key=lambda r: float(r["tcga_pan_prevalence_tpm_ge_1"]))
+    return {
+        "tcga_pan_prevalence_tpm_ge_1": max(float(r["tcga_pan_prevalence_tpm_ge_1"]) for r in rows),
+        "tcga_pan_prevalence_tpm_ge_5": max(float(r["tcga_pan_prevalence_tpm_ge_5"]) for r in rows),
+        "tcga_max_ptpm": max(float(r["tcga_max_ptpm"]) for r in rows),
+        "tcga_top_cancer_type": str(best["tcga_top_cancer_type"]),
+    }
+
+
 def panel_summary(
     selected: pd.DataFrame,
     cta_list: list[str],
     allele_list: list[str],
     allele_frequencies: dict[str, float] | None = None,
     allele_frequency_sources: dict[str, str] | None = None,
+    tcga_features: pd.DataFrame | None = None,
 ) -> dict[str, object]:
     """Summarize a selected panel table.
 
@@ -2094,9 +2174,16 @@ def panel_summary(
     sum to a carrier probability, then combine loci. The values are intended
     for ranking and sanity-checking panel breadth, not for clinical-grade
     population-genetics inference.
+
+    ``tcga_features`` is the optional output of
+    :func:`tsarina.cancer_expression.cta_tcga_expression_features`. When
+    supplied, the per-CTA coverage rows gain ``tcga_pan_prevalence_tpm_ge_1``,
+    ``tcga_pan_prevalence_tpm_ge_5``, ``tcga_max_ptpm`` and
+    ``tcga_top_cancer_type`` columns (max across slash-joined CTA members).
     """
     allele_frequencies = allele_frequencies or dict.fromkeys(allele_list, 0.0)
     allele_frequency_sources = allele_frequency_sources or dict.fromkeys(allele_list, "missing")
+    tcga_lookup = _tcga_features_by_symbol(tcga_features)
     possible_cell_count = len(cta_list) * len(allele_list)
 
     if selected.empty:
@@ -2125,6 +2212,7 @@ def panel_summary(
         coverage = _combined_carrier_probability(
             {allele: allele_frequencies.get(allele, 0.0) for allele in covered_alleles}
         )
+        tcga_summary = _tcga_summary_for_cta(cta_members, tcga_lookup)
         cta_rows.append(
             {
                 "cta": cta,
@@ -2138,6 +2226,7 @@ def panel_summary(
                 "unrestricted_ms_pmhc_count": tier_row_counts.get("unrestricted_ms", 0),
                 "predicted_only_pmhc_count": tier_row_counts.get("predicted_only", 0),
                 "estimated_population_coverage": coverage,
+                **tcga_summary,
             }
         )
     cta_rows = sorted(
@@ -2262,6 +2351,7 @@ def _empty_output(
         allele_list=allele_list,
         allele_frequencies=allele_frequencies,
         allele_frequency_sources=allele_frequency_sources,
+        tcga_features=_load_tcga_features_safely(),
     )
     input_cta_list = input_cta_list or cta_list
     empty_ctas = empty_ctas or []

--- a/tsarina/version.py
+++ b/tsarina/version.py
@@ -10,4 +10,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "1.2.23"
+__version__ = "1.3.0"


### PR DESCRIPTION
Closes #55. Also addresses #49 (pyproject license metadata).

## What this changes

The bundled `hpa-cancer-rna-prevalence.csv` already contains TCGA-cohort rows for 21 TCGA project equivalents, but those values previously only reached the `tumor_prevalence_panel_score` ranker. `CTA_detailed_evidence()` and the per-CTA panel summary table never showed them, so users couldn't see which CTAs were broadly tumor-expressed (e.g. PRAME in melanoma) versus which were testis-restricted with very low tumor RNA (e.g. PIWIL1).

### `cta_tcga_expression_features()`
New aggregator in `tsarina.cancer_expression`. One row per CTA with:
- `tcga_sample_count`, `tcga_cancer_type_count`, `tcga_max_ptpm`
- `tcga_expressed_samples_tpm_ge_1`, `tcga_expressed_samples_tpm_ge_5`
- `tcga_pan_prevalence_tpm_ge_1`, `tcga_pan_prevalence_tpm_ge_5`
- `tcga_top_cancer_type_tpm_ge_1`, `tcga_top_cancer_type_prevalence_tpm_ge_1`

### `CTA_detailed_evidence()`
Always attaches the nine TCGA columns by stripped-Ensembl-id join. Genes without TCGA measurements get zeros / empty strings, not NaN, so downstream filters and table rendering stay stable.

### `panel_summary()` and CLI rendering
`panel_summary()` accepts an optional `tcga_features` dataframe and adds `tcga_pan_prevalence_tpm_ge_1` / `tcga_pan_prevalence_tpm_ge_5` / `tcga_max_ptpm` / `tcga_top_cancer_type` to each per-CTA row (max across slash-joined CTA members; top cancer type comes from the member with the highest TPM>1 prevalence). `spanning_pmhc_set()` best-effort loads the bundled TCGA features so the CLI picks the new columns up automatically. `format_panel_summary()` renders three new table columns ("TCGA >1 TPM", "TCGA >5 TPM", "TCGA top type") with cancer types abbreviated to TCGA project codes (SKCM, LUAD, ...) to keep the table narrow.

### Spot-check (matches published biology)
| CTA | TPM≥1 | TPM≥5 | Top TCGA type |
| --- | --- | --- | --- |
| PRAME | 43.9% | 31.7% | SKCM (97.9%) |
| MAGEA4 | 17.0% | 13.2% | LUSC (64.6%) |
| XAGE1A | 17.3% | 12.9% | LUAD (82.5%) |
| PIWIL1 | 2.8% | 0.3% | STAD (18.2%) |

### `pyproject.toml` (#49)
- `project.license = "Apache-2.0"` SPDX string + `project.license-files = ["LICENSE"]` replacing the deprecated `{file = "LICENSE"}` table form.
- Drops the deprecated `License :: OSI Approved :: Apache Software License` classifier.
- Verified locally: `python -m build --wheel` no longer emits the setuptools deprecation warning.

## Test plan
- [x] `./format.sh`
- [x] `./lint.sh`
- [x] `./test.sh` — 312 passed (+5 new: TCGA aggregator cohort filter, empty-cohort fallback, `_attach_tcga_prevalence` Ensembl-version join, `panel_summary` with/without TCGA features)