### PR TITLE
Stub MHCflurry predictor in pytest conftest to prevent ~55 GB OOM

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ env/
 
 .pytest_cache/
 .coverage
+.coverage.*
 htmlcov/
 coverage.xml
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,53 +12,54 @@
 
 """Shared pytest fixtures.
 
-The autouse fixture in this file installs a tiny in-memory stand-in for
-``mhcflurry.Class1PresentationPredictor`` into the cached singleton at
-``tsarina.scoring._MHCFLURRY_PRESENTATION_PREDICTOR``. This prevents the
-real predictor — which loads ~140 Keras models and consumes 3-6 GB per
-process — from ever being instantiated during the test suite.
+The autouse fixture in this file installs a sentinel object into the
+cached predictor singleton at
+``tsarina.scoring._MHCFLURRY_PRESENTATION_PREDICTOR``. The sentinel
+prevents the real ``Class1PresentationPredictor`` — which loads ~140
+Keras models and consumes 3-6 GB per process — from ever being
+instantiated during the test suite, and refuses to fabricate
+predictions if a test path reaches it.
 
 See issue #68: without this stub, any test path that reaches
 ``score_presentation(..., predictor="mhcflurry")`` without per-test
-monkeypatching can trigger an OOM (~55 GB observed) when multiplied
-across pytest-cov subprocesses.
+monkeypatching loaded real MHCflurry. Multiplied across pytest-xdist
+workers this produced an OOM (~55 GB observed) on developer machines.
 
-Tests that need to exercise the real loader path (e.g. asserting the
-ImportError raised when mhcflurry isn't installed) reset the singleton
-to ``None`` themselves; the loader function is unchanged and will
-attempt the real import when the singleton is cleared.
+Per-test stubs of ``tsarina.scoring.score_presentation`` or
+``tsarina.scoring._load_mhcflurry_presentation_predictor`` continue to
+override this sentinel at the call site, so tests with their own scoring
+fakes are unaffected. Tests that need to exercise the real loader path
+(e.g. asserting the ImportError raised when mhcflurry isn't installed)
+reset the singleton to ``None`` themselves.
 """
 
 from __future__ import annotations
 
-import pandas as pd
 import pytest
 
 
-class _StubMHCflurryPresentationPredictor:
-    """Deterministic stand-in for ``Class1PresentationPredictor``.
+class _UnstubbedMHCflurryPredictor:
+    """Sentinel ``Class1PresentationPredictor`` that refuses to predict.
 
-    Mirrors the keyword-only ``predict`` surface that
-    ``tsarina.scoring._score_mhcflurry`` invokes and returns a DataFrame
-    with the columns the downstream code reads.
+    Installed into ``tsarina.scoring._MHCFLURRY_PRESENTATION_PREDICTOR`` by
+    the autouse fixture below so that no test path can accidentally load
+    real MHCflurry. If a test reaches this object's ``predict`` method,
+    that's a bug in the test (it forgot to stub
+    ``tsarina.scoring.score_presentation`` or
+    ``tsarina.scoring._load_mhcflurry_presentation_predictor``) — fail
+    loudly rather than return dummy values that could be silently
+    asserted on.
     """
 
     def predict(self, *, peptides, alleles, include_affinity_percentile, verbose):
-        rows = []
-        for sample_name, sample_alleles in alleles.items():
-            assert sample_alleles == [sample_name]
-            for peptide in peptides:
-                rows.append(
-                    {
-                        "peptide": peptide,
-                        "sample_name": sample_name,
-                        "best_allele": sample_name,
-                        "affinity": 50.0,
-                        "presentation_score": 0.95,
-                        "presentation_percentile": 0.5,
-                    }
-                )
-        return pd.DataFrame(rows)
+        raise AssertionError(
+            "Real MHCflurry predictor was reached during the test suite. "
+            "Stub `tsarina.scoring.score_presentation` (preferred) or "
+            "`tsarina.scoring._load_mhcflurry_presentation_predictor` in "
+            "the test that triggered this call. To exercise the real "
+            "loader path, reset the singleton to None first: "
+            "`monkeypatch.setattr(scoring, '_MHCFLURRY_PRESENTATION_PREDICTOR', None)`."
+        )
 
 
 @pytest.fixture(autouse=True)
@@ -68,6 +69,6 @@ def _stub_mhcflurry_predictor(monkeypatch):
     monkeypatch.setattr(
         scoring,
         "_MHCFLURRY_PRESENTATION_PREDICTOR",
-        _StubMHCflurryPresentationPredictor(),
+        _UnstubbedMHCflurryPredictor(),
         raising=True,
     )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,73 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Shared pytest fixtures.
+
+The autouse fixture in this file installs a tiny in-memory stand-in for
+``mhcflurry.Class1PresentationPredictor`` into the cached singleton at
+``tsarina.scoring._MHCFLURRY_PRESENTATION_PREDICTOR``. This prevents the
+real predictor — which loads ~140 Keras models and consumes 3-6 GB per
+process — from ever being instantiated during the test suite.
+
+See issue #68: without this stub, any test path that reaches
+``score_presentation(..., predictor="mhcflurry")`` without per-test
+monkeypatching can trigger an OOM (~55 GB observed) when multiplied
+across pytest-cov subprocesses.
+
+Tests that need to exercise the real loader path (e.g. asserting the
+ImportError raised when mhcflurry isn't installed) reset the singleton
+to ``None`` themselves; the loader function is unchanged and will
+attempt the real import when the singleton is cleared.
+"""
+
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+
+class _StubMHCflurryPresentationPredictor:
+    """Deterministic stand-in for ``Class1PresentationPredictor``.
+
+    Mirrors the keyword-only ``predict`` surface that
+    ``tsarina.scoring._score_mhcflurry`` invokes and returns a DataFrame
+    with the columns the downstream code reads.
+    """
+
+    def predict(self, *, peptides, alleles, include_affinity_percentile, verbose):
+        rows = []
+        for sample_name, sample_alleles in alleles.items():
+            assert sample_alleles == [sample_name]
+            for peptide in peptides:
+                rows.append(
+                    {
+                        "peptide": peptide,
+                        "sample_name": sample_name,
+                        "best_allele": sample_name,
+                        "affinity": 50.0,
+                        "presentation_score": 0.95,
+                        "presentation_percentile": 0.5,
+                    }
+                )
+        return pd.DataFrame(rows)
+
+
+@pytest.fixture(autouse=True)
+def _stub_mhcflurry_predictor(monkeypatch):
+    import tsarina.scoring as scoring
+
+    monkeypatch.setattr(
+        scoring,
+        "_MHCFLURRY_PRESENTATION_PREDICTOR",
+        _StubMHCflurryPresentationPredictor(),
+        raising=True,
+    )

--- a/tsarina/version.py
+++ b/tsarina/version.py
@@ -10,4 +10,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "1.3.0"
+__version__ = "1.3.1"


### PR DESCRIPTION
## Summary
- Adds `tests/conftest.py` with an autouse fixture that installs a deterministic stub into `tsarina.scoring._MHCFLURRY_PRESENTATION_PREDICTOR`, preventing the real ~140-model Keras presentation predictor (3-6 GB resident per process) from being instantiated during tests.
- Extends `.gitignore` to cover `.coverage.*` parallel-mode files (32 stray ones were left in the repo root after the OOM-killed test run that prompted this fix).
- Bumps version 1.3.0 → 1.3.1.

## Why
Without a shared guard, any test path reaching `score_presentation(..., predictor="mhcflurry")` without per-test monkeypatching can load real MHCflurry. Combined with `--cov=tsarina/` (which we deliberately keep) and pytest-cov's subprocess collection, this manifested as a ~55 GB resident-memory blow-up that triggered an OS OOM kill on a developer machine. Diagnosis and root-cause writeup in #68.

## How the stub stays safe
- Existing per-test monkeypatches on `tsarina.scoring.score_presentation` and `tsarina.scoring._load_mhcflurry_presentation_predictor` continue to override the conftest stub at the call site.
- `test_mhcflurry_import_error` resets the singleton to `None` itself before blocking the `mhcflurry` import, so the real loader path is still exercised end-to-end.
- `--cov=tsarina/` is preserved in `./test.sh`; the fix is orthogonal to coverage collection.

## Out of scope (tracked separately)
- Per-CLI-subprocess `ProteomeIndex` / proteome k-mer rebuilds and the `indexing.py` legacy parquet fallback (#69).

## Test plan
- [x] `./format.sh` clean
- [x] `./lint.sh` clean (`ruff check` + `ruff format --check`)
- [x] `./test.sh` — 312 passed in 27.48s, including `test_mhcflurry_import_error` and `test_mhcflurry_direct_path_batches_and_skips_affinity_percentiles` which exercise the real loader path
- [ ] CI green across Python 3.9–3.12

Closes #68.