### PR TITLE
Cache ProteomeIndex; drop dead legacy parquet fallback

### DIFF
--- a/tests/test_cli_hits.py
+++ b/tests/test_cli_hits.py
@@ -336,3 +336,26 @@ def test_cached_path_explicit_lengths_override_class_default(tmp_path):
     kwargs = ms_only.call_args.kwargs
     assert kwargs.get("length_min") == 9
     assert kwargs.get("length_max") == 10
+
+
+def test_enumerate_gene_peptides_caches_proteome_index_across_calls():
+    """Building the Ensembl ProteomeIndex is the dominant cost on the niche
+    enumeration path (~8-15 GB peak). Second invocation with the same
+    (release, lengths) must hit the lru_cache, not rebuild."""
+    from tsarina import cli_hits
+
+    class _StubProteomeIndex:
+        proteins = {"P1": "MAGEAPEPTIDESEQX"}
+        protein_meta = {"P1": {"gene_name": "TARGET", "gene_id": "ENSG"}}
+
+    cli_hits._cached_proteome_index.cache_clear()
+    try:
+        with patch(
+            "hitlist.proteome.ProteomeIndex.from_ensembl",
+            return_value=_StubProteomeIndex(),
+        ) as from_ensembl:
+            cli_hits._enumerate_gene_peptides("TARGET", 112, (9,))
+            cli_hits._enumerate_gene_peptides("TARGET", 112, (9,))
+        from_ensembl.assert_called_once()
+    finally:
+        cli_hits._cached_proteome_index.cache_clear()

--- a/tests/test_cli_hits.py
+++ b/tests/test_cli_hits.py
@@ -339,9 +339,8 @@ def test_cached_path_explicit_lengths_override_class_default(tmp_path):
 
 
 def test_enumerate_gene_peptides_caches_proteome_index_across_calls():
-    """Building the Ensembl ProteomeIndex is the dominant cost on the niche
-    enumeration path (~8-15 GB peak). Second invocation with the same
-    (release, lengths) must hit the lru_cache, not rebuild."""
+    """Second invocation with the same (release, lengths) must reuse the
+    cached ~8-15 GB Ensembl ProteomeIndex instead of rebuilding."""
     from tsarina import cli_hits
 
     class _StubProteomeIndex:
@@ -354,8 +353,9 @@ def test_enumerate_gene_peptides_caches_proteome_index_across_calls():
             "hitlist.proteome.ProteomeIndex.from_ensembl",
             return_value=_StubProteomeIndex(),
         ) as from_ensembl:
-            cli_hits._enumerate_gene_peptides("TARGET", 112, (9,))
+            df = cli_hits._enumerate_gene_peptides("TARGET", 112, (9,))
             cli_hits._enumerate_gene_peptides("TARGET", 112, (9,))
         from_ensembl.assert_called_once()
+        assert "peptide" in df.columns
     finally:
         cli_hits._cached_proteome_index.cache_clear()

--- a/tests/test_indexing.py
+++ b/tests/test_indexing.py
@@ -81,29 +81,6 @@ def test_load_ms_evidence_pushes_peptide_filter_to_loader():
     assert out["peptide"].tolist() == ["AAA"]
 
 
-def test_load_ms_evidence_falls_back_when_peptide_kwarg_unsupported():
-    fake = pd.DataFrame(
-        {
-            "peptide": ["AAA", "BBB"],
-            "mhc_restriction": ["HLA-A*02:01"] * 2,
-            "is_binding_assay": [False, False],
-        }
-    )
-
-    def _load(**kwargs):
-        if "peptide" in kwargs:
-            raise TypeError("unexpected kwarg peptide (simulating hitlist < 1.6.0)")
-        return fake
-
-    with (
-        patch("hitlist.observations.is_built", return_value=True),
-        patch("hitlist.observations.load_observations", side_effect=_load),
-    ):
-        out = load_ms_evidence(peptides={"AAA"})
-    # Fallback path still produces the right answer via in-memory isin.
-    assert out["peptide"].tolist() == ["AAA"]
-
-
 def test_load_ms_evidence_can_skip_binding_assay_drop():
     fake = pd.DataFrame(
         {

--- a/tsarina/cli_hits.py
+++ b/tsarina/cli_hits.py
@@ -26,6 +26,7 @@ override that bypasses the index).
 from __future__ import annotations
 
 import argparse
+import functools
 import sys
 
 import pandas as pd
@@ -210,15 +211,24 @@ def build_parser(sub: argparse._SubParsersAction) -> argparse.ArgumentParser:
     return p
 
 
+@functools.lru_cache(maxsize=1)
+def _cached_proteome_index(ensembl_release: int, lengths: tuple[int, ...]):
+    # Holds the full Ensembl proteome index (~8-15 GB peak during build) for
+    # the lifetime of the process. Cache size 1 because the index is keyed
+    # only on (release, lengths) and a second key would double resident
+    # memory; back-to-back queries with different inputs evict the prior one.
+    from hitlist.proteome import ProteomeIndex
+
+    return ProteomeIndex.from_ensembl(release=ensembl_release, lengths=lengths, verbose=False)
+
+
 def _enumerate_gene_peptides(
     gene: str,
     ensembl_release: int,
     lengths: tuple[int, ...],
 ) -> pd.DataFrame:
     """Build a DataFrame of (peptide, protein_id, gene_name, gene_id, position, n_flank, c_flank)."""
-    from hitlist.proteome import ProteomeIndex
-
-    idx = ProteomeIndex.from_ensembl(release=ensembl_release, lengths=lengths, verbose=False)
+    idx = _cached_proteome_index(ensembl_release, lengths)
 
     target_ids = [pid for pid, meta in idx.protein_meta.items() if meta.get("gene_name") == gene]
     if not target_ids:

--- a/tsarina/cli_hits.py
+++ b/tsarina/cli_hits.py
@@ -213,10 +213,9 @@ def build_parser(sub: argparse._SubParsersAction) -> argparse.ArgumentParser:
 
 @functools.lru_cache(maxsize=1)
 def _cached_proteome_index(ensembl_release: int, lengths: tuple[int, ...]):
-    # Holds the full Ensembl proteome index (~8-15 GB peak during build) for
-    # the lifetime of the process. Cache size 1 because the index is keyed
-    # only on (release, lengths) and a second key would double resident
-    # memory; back-to-back queries with different inputs evict the prior one.
+    # Only one (release, lengths) is used per process. The index is
+    # ~8-15 GB resident, so caching more than one entry would double
+    # memory without improving hit rate.
     from hitlist.proteome import ProteomeIndex
 
     return ProteomeIndex.from_ensembl(release=ensembl_release, lengths=lengths, verbose=False)

--- a/tsarina/indexing.py
+++ b/tsarina/indexing.py
@@ -67,10 +67,9 @@ def load_ms_evidence(
 ) -> pd.DataFrame:
     """Load MS evidence rows from the hitlist observations index.
 
-    Ensures the index exists (building if needed), then runs a pushdown-filtered
-    parquet read for ``mhc_class`` / ``mhc_species`` (and ``gene_name`` if a
-    flanking-built index is present), and finally filters to the supplied
-    peptide set in memory.
+    Ensures the index exists (building if needed) and runs a pushdown-filtered
+    parquet read for ``mhc_class``, ``mhc_species``, ``gene_name``, and the
+    peptide set.
 
     Parameters
     ----------

--- a/tsarina/indexing.py
+++ b/tsarina/indexing.py
@@ -101,30 +101,18 @@ def load_ms_evidence(
     if auto_build and not is_built():
         ensure_index_built()
 
-    # Push peptide set down to the parquet reader when possible — hitlist
-    # 1.6.0+ accepts a ``peptide=`` filter.  Fall back to in-memory isin
-    # for older installs.
     load_kwargs: dict = {
         "mhc_class": mhc_class,
         "species": mhc_species,
         "gene_name": gene_name,
         "columns": columns,
     }
-    peptide_list: list[str] | None = None
     if peptides is not None:
-        peptide_list = (
+        load_kwargs["peptide"] = (
             sorted(peptides) if isinstance(peptides, (set, frozenset)) else list(peptides)
         )
-        load_kwargs["peptide"] = peptide_list
 
-    try:
-        df = load_observations(**load_kwargs)
-    except TypeError:
-        # Older hitlist without ``peptide=`` pushdown.
-        load_kwargs.pop("peptide", None)
-        df = load_observations(**load_kwargs)
-        if peptide_list is not None:
-            df = df[df["peptide"].isin(set(peptide_list))]
+    df = load_observations(**load_kwargs)
 
     if drop_binding_assays and "is_binding_assay" in df.columns:
         df = df[~df["is_binding_assay"]]

--- a/tsarina/indexing.py
+++ b/tsarina/indexing.py
@@ -68,8 +68,10 @@ def load_ms_evidence(
     """Load MS evidence rows from the hitlist observations index.
 
     Ensures the index exists (building if needed) and runs a pushdown-filtered
-    parquet read for ``mhc_class``, ``mhc_species``, ``gene_name``, and the
-    peptide set.
+    parquet read for ``mhc_class``, ``mhc_species``, and the peptide set.
+    ``gene_name`` is forwarded to hitlist's ``load_observations`` and is only
+    honored on builds whose observations parquet carries a ``gene_name``
+    column; prefer passing ``peptides`` when you already have a peptide list.
 
     Parameters
     ----------
@@ -81,8 +83,9 @@ def load_ms_evidence(
     mhc_species
         Species filter (default ``"Homo sapiens"``; None disables).
     gene_name
-        Only supported on flanking-built indices.  Use ``peptides`` instead
-        when you already have a peptide list in hand.
+        Only honored on hitlist builds whose observations parquet carries a
+        ``gene_name`` column.  Prefer ``peptides`` when you already have a
+        peptide list in hand.
     columns
         Project the parquet read to these columns.
     auto_build

--- a/tsarina/version.py
+++ b/tsarina/version.py
@@ -10,4 +10,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "1.3.1"
+__version__ = "1.3.2"


### PR DESCRIPTION
## Summary
- Removes the `TypeError` fallback in `tsarina.indexing.load_ms_evidence` (hitlist < 1.6.0 path). The fallback was unreachable under the `hitlist>=1.15.1` pin in `pyproject.toml` — `peptide=` pushdown has been available since 1.6.0. Drops the matching regression test.
- Wraps the `ProteomeIndex.from_ensembl` call in `tsarina.cli_hits._enumerate_gene_peptides` with `functools.lru_cache(maxsize=1)` keyed by `(release, lengths)`. Back-to-back gene queries on the niche `--skip-ms-evidence` / `--iedb` / `--cedar` paths now reuse the ~8-15 GB proteome index instead of rebuilding it every call. Cache size 1 prevents accidental doubling of resident memory.
- Bumps version 1.3.1 → 1.3.2.

## Scope vs. #69
This PR addresses two of the three items called out in #69:
- ✅ Dead legacy parquet fallback
- ✅ Per-call `ProteomeIndex` rebuild
- ⏭️ Cross-process disk cache for `proteome_kmer_set` — out of scope; already cached process-wide by hitlist itself, and persistent caching is a meaningfully larger feature.

## Test plan
- [x] `./format.sh` clean
- [x] `./lint.sh` clean
- [x] `./test.sh` — 312 passed in 27.2s (-1 removed fallback test, +1 new cache test → net zero)
- New `test_enumerate_gene_peptides_caches_proteome_index_across_calls` pins `from_ensembl.assert_called_once()` across two `_enumerate_gene_peptides` invocations
- [ ] CI green across Python 3.9-3.12

Refs #69.