### PR TITLE
Correct gene_name docstring in load_ms_evidence

### DIFF
--- a/tsarina/indexing.py
+++ b/tsarina/indexing.py
@@ -68,10 +68,8 @@ def load_ms_evidence(
     """Load MS evidence rows from the hitlist observations index.
 
     Ensures the index exists (building if needed) and runs a pushdown-filtered
-    parquet read for ``mhc_class``, ``mhc_species``, and the peptide set.
-    ``gene_name`` is forwarded to hitlist's ``load_observations`` and is only
-    honored on builds whose observations parquet carries a ``gene_name``
-    column; prefer passing ``peptides`` when you already have a peptide list.
+    parquet read for ``mhc_class``, ``mhc_species``, ``gene_name``, and the
+    peptide set.
 
     Parameters
     ----------
@@ -83,9 +81,9 @@ def load_ms_evidence(
     mhc_species
         Species filter (default ``"Homo sapiens"``; None disables).
     gene_name
-        Only honored on hitlist builds whose observations parquet carries a
-        ``gene_name`` column.  Prefer ``peptides`` when you already have a
-        peptide list in hand.
+        Filter to rows whose peptide maps to this gene (or list of genes).
+        Resolved through hitlist's ``peptide_mappings`` sidecar, which is
+        built alongside the observations index.
     columns
         Project the parquet read to these columns.
     auto_build

--- a/tsarina/version.py
+++ b/tsarina/version.py
@@ -10,4 +10,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "1.3.2"
+__version__ = "1.3.3"


### PR DESCRIPTION
## Summary
The hedge restored in v1.3.2 was based on a flawed test. Re-verified against hitlist 1.30.0:

| Call | Result |
|---|---|
| `load_observations(gene_name="PRAME")` | 255 rows ✓ |
| `load_observations(gene_id="ENSG00000185686")` | 255 rows ✓ |
| `load_observations(gene_name="PRAME", columns=["peptide","gene_name"])` | `ArrowInvalid` |

The `ArrowInvalid` I attributed to "no gene_name column" was actually triggered by projecting `gene_name` as a returned column. As a *filter*, gene_name resolves through `peptide_mappings.parquet` (hitlist 1.30.0 source: `observations.py:478-503`) — same path as `gene_id` — and the mappings sidecar is built by default.

This PR replaces the inaccurate hedge with a description of the actual mechanism:
- Main description drops the "only honored on builds that carry a `gene_name` column" claim.
- Parameters note for `gene_name` now describes resolution via the `peptide_mappings` sidecar.

Version bump 1.3.2 → 1.3.3.

## Test plan
- [x] `./format.sh` clean
- [x] `./lint.sh` clean
- [x] `./test.sh` — 312 passed in 28.8s
- [ ] CI green across Python 3.9-3.12