### PR TITLE
Bump hitlist pin to >=1.30.49; re-attach gene columns post-1.30.46

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
 ]
 requires-python = ">=3.9"
 dependencies = [
-    "hitlist>=1.15.1",
+    "hitlist>=1.30.49",
     "mhcgnomes>=3.20.0",
     "pandas",
     "numpy",

--- a/tests/test_cli_hits.py
+++ b/tests/test_cli_hits.py
@@ -338,6 +338,55 @@ def test_cached_path_explicit_lengths_override_class_default(tmp_path):
     assert kwargs.get("length_max") == 10
 
 
+def test_cached_path_reattaches_gene_columns_on_post_1_30_46_parquets(tmp_path):
+    """hitlist 1.30.46 (#238) split gene_names / gene_ids / protein_ids out of
+    observations.parquet — no-projection loads return them only if the caller
+    already had them in columns=.  tsarina's fast path doesn't project, so it
+    must re-attach those columns via peptide_mappings; otherwise per-peptide
+    aggregation drops gene identifiers on freshly-built parquets."""
+    from tsarina import cli_hits
+
+    args = _base_cached_args(tmp_path, lengths=(9,))
+    # Post-1.30.46 shape: no gene_names / gene_ids / protein_ids on the obs frame.
+    hits = pd.DataFrame(
+        {
+            "peptide": ["AAAAAAAAA", "BBBBBBBBB"],
+            "mhc_restriction": ["HLA-A*02:01"] * 2,
+        }
+    )
+    mappings = pd.DataFrame(
+        {
+            "peptide": ["AAAAAAAAA", "AAAAAAAAAA", "BBBBBBBBB"],
+            "gene_name": ["PRAME", "PRAME", "MAGEA4"],
+            "gene_id": ["ENSG_PRAME", "ENSG_PRAME", "ENSG_MAGEA4"],
+            "protein_id": ["ENSP_PRAME_1", "ENSP_PRAME_2", "ENSP_MAGEA4"],
+        }
+    )
+    captured: dict[str, pd.DataFrame] = {}
+
+    def _capture_write(path, df):
+        captured["df"] = df
+
+    with (
+        patch("tsarina.indexing.ensure_index_built"),
+        patch("hitlist.observations.load_observations", return_value=hits),
+        patch("hitlist.mappings.load_peptide_mappings", return_value=mappings) as mappings_loader,
+        patch("tsarina.cli_hits._write", side_effect=_capture_write),
+        patch(
+            "hitlist.aggregate.aggregate_per_pmhc",
+            side_effect=lambda df: df[["peptide", "mhc_restriction"]].copy(),
+        ),
+    ):
+        cli_hits.handle(args)
+
+    mappings_loader.assert_called_once()
+    out = captured["df"]
+    assert "gene_names" in out.columns
+    by_peptide = out.set_index("peptide")["gene_names"].to_dict()
+    assert by_peptide["AAAAAAAAA"] == "PRAME"
+    assert by_peptide["BBBBBBBBB"] == "MAGEA4"
+
+
 def test_enumerate_gene_peptides_caches_proteome_index_across_calls():
     """Second invocation with the same (release, lengths) must reuse the
     cached ~8-15 GB Ensembl ProteomeIndex instead of rebuilding."""

--- a/tests/test_cli_hits.py
+++ b/tests/test_cli_hits.py
@@ -241,6 +241,17 @@ def test_cached_path_non_contiguous_lengths_exact_set_filter(tmp_path):
             "mhc_restriction": ["HLA-A*02:01"] * 3,
         }
     )
+    # Post-1.30.46 the fast path re-attaches gene columns via
+    # ``load_peptide_mappings``; the test focus is length filtering, so
+    # provide an empty-mappings stub to keep the loader real-import-free.
+    empty_mappings = pd.DataFrame(
+        {
+            "peptide": pd.Series(dtype=str),
+            "gene_name": pd.Series(dtype=str),
+            "gene_id": pd.Series(dtype=str),
+            "protein_id": pd.Series(dtype=str),
+        }
+    )
     captured: dict[str, pd.DataFrame] = {}
 
     def _capture_write(path, df):
@@ -249,6 +260,7 @@ def test_cached_path_non_contiguous_lengths_exact_set_filter(tmp_path):
     with (
         patch("tsarina.indexing.ensure_index_built"),
         patch("hitlist.observations.load_observations", return_value=hits) as ms_only,
+        patch("hitlist.mappings.load_peptide_mappings", return_value=empty_mappings),
         patch("tsarina.cli_hits._write", side_effect=_capture_write),
         patch(
             "hitlist.aggregate.aggregate_per_pmhc",
@@ -385,6 +397,54 @@ def test_cached_path_reattaches_gene_columns_on_post_1_30_46_parquets(tmp_path):
     by_peptide = out.set_index("peptide")["gene_names"].to_dict()
     assert by_peptide["AAAAAAAAA"] == "PRAME"
     assert by_peptide["BBBBBBBBB"] == "MAGEA4"
+
+
+def test_cached_path_reattaches_gene_columns_on_load_all_evidence_path(tmp_path):
+    """Parity with ``test_cached_path_reattaches_gene_columns_on_post_1_30_46_parquets``
+    for the ``include_binding_assays=True`` branch — both branches share
+    the re-attach guard, so the binding-assays + observations union path
+    must also pick up gene columns from peptide_mappings on freshly-built
+    parquets."""
+    from tsarina import cli_hits
+
+    args = _base_cached_args(tmp_path, lengths=(9,), include_binding_assays=True)
+    hits = pd.DataFrame(
+        {
+            "peptide": ["AAAAAAAAA"],
+            "mhc_restriction": ["HLA-A*02:01"],
+            "evidence_kind": ["ms"],
+        }
+    )
+    mappings = pd.DataFrame(
+        {
+            "peptide": ["AAAAAAAAA"],
+            "gene_name": ["PRAME"],
+            "gene_id": ["ENSG_PRAME"],
+            "protein_id": ["ENSP_PRAME"],
+        }
+    )
+    captured: dict[str, pd.DataFrame] = {}
+
+    def _capture_write(path, df):
+        captured["df"] = df
+
+    with (
+        patch("tsarina.indexing.ensure_index_built"),
+        patch("hitlist.observations.load_all_evidence", return_value=hits) as all_ev,
+        patch("hitlist.mappings.load_peptide_mappings", return_value=mappings) as mappings_loader,
+        patch("tsarina.cli_hits._write", side_effect=_capture_write),
+        patch(
+            "hitlist.aggregate.aggregate_per_pmhc",
+            side_effect=lambda df: df[["peptide", "mhc_restriction"]].copy(),
+        ),
+    ):
+        cli_hits.handle(args)
+
+    all_ev.assert_called_once()
+    mappings_loader.assert_called_once()
+    out = captured["df"]
+    assert "gene_names" in out.columns
+    assert out.set_index("peptide")["gene_names"]["AAAAAAAAA"] == "PRAME"
 
 
 def test_enumerate_gene_peptides_caches_proteome_index_across_calls():

--- a/tests/test_cli_hits_refs.py
+++ b/tests/test_cli_hits_refs.py
@@ -137,11 +137,11 @@ def test_refs_handler_merges_gene_ident_cols_from_cached_path(tmp_path):
     assert all(out["gene_names"] == "PRAME")
 
 
-def test_refs_handler_passes_through_when_no_gene_ident_cols(tmp_path):
-    """When the scan result lacks gene_names / gene_ids / protein_ids
-    (e.g. raw-scan override path without the enumeration frame), the
-    refs branch should still produce the aggregator output rather than
-    erroring or dropping rows."""
+def test_refs_handler_emits_empty_gene_idents_when_mappings_sidecar_is_empty(tmp_path):
+    """When peptide_mappings yields no rows for the loaded peptides (e.g.
+    a sidecar that hasn't indexed this gene yet), the refs handler must
+    still produce the aggregator output and pass empty-string gene
+    identifiers through rather than erroring or dropping rows."""
     import argparse
     from unittest.mock import patch
 
@@ -160,6 +160,14 @@ def test_refs_handler_passes_through_when_no_gene_ident_cols(tmp_path):
             "src_cancer": [True],
             "src_healthy_tissue": [False],
             "is_monoallelic": [False],
+        }
+    )
+    empty_mappings = pd.DataFrame(
+        {
+            "peptide": pd.Series(dtype=str),
+            "gene_name": pd.Series(dtype=str),
+            "gene_id": pd.Series(dtype=str),
+            "protein_id": pd.Series(dtype=str),
         }
     )
 
@@ -187,12 +195,16 @@ def test_refs_handler_passes_through_when_no_gene_ident_cols(tmp_path):
     with (
         patch("tsarina.indexing.ensure_index_built"),
         patch("hitlist.observations.load_observations", return_value=hits_frame),
+        patch("hitlist.mappings.load_peptide_mappings", return_value=empty_mappings),
     ):
         cli_hits.handle(args)
 
-    out = pd.read_csv(output_csv)
-    # Output has the aggregator columns but no gene_ident_cols since
-    # the input didn't provide them.
+    # Empty cells round-trip through CSV as NaN by default; read with
+    # keep_default_na=False so the empty-string contract from
+    # annotate_observations_with_genes is preserved.
+    out = pd.read_csv(output_csv, keep_default_na=False)
     assert "ms_pmhc_hit_count" in out.columns
-    assert "gene_names" not in out.columns
     assert list(out["peptide"]) == ["QYIAQFTSQF"]
+    assert out["gene_names"].tolist() == [""]
+    assert out["gene_ids"].tolist() == [""]
+    assert out["protein_ids"].tolist() == [""]

--- a/tests/test_indexing.py
+++ b/tests/test_indexing.py
@@ -11,6 +11,7 @@ def test_ensure_index_built_skips_when_already_built(tmp_path: Path, capsys):
     fake_path.write_text("dummy")
     with (
         patch("hitlist.observations.is_built", return_value=True),
+        patch("hitlist.mappings.is_mappings_built", return_value=True),
         patch("hitlist.observations.observations_path", return_value=fake_path),
         patch("hitlist.builder.build_observations") as build,
     ):
@@ -25,6 +26,25 @@ def test_ensure_index_built_triggers_build_when_missing(tmp_path: Path, capsys):
     fake_path = tmp_path / "obs.parquet"
     with (
         patch("hitlist.observations.is_built", return_value=False),
+        patch("hitlist.mappings.is_mappings_built", return_value=False),
+        patch("hitlist.observations.observations_path", return_value=fake_path),
+        patch("hitlist.builder.build_observations") as build,
+    ):
+        ensure_index_built()
+    build.assert_called_once()
+    assert "Building hitlist observations index" in capsys.readouterr().err
+
+
+def test_ensure_index_built_rebuilds_when_only_sidecar_is_missing(tmp_path: Path, capsys):
+    """Observations parquet present but peptide_mappings.parquet missing
+    (e.g. partial build via ``build_mappings=False``, or sidecar deleted)
+    must trigger a rebuild — otherwise downstream gene-attach paths
+    raise ``FileNotFoundError`` mid-query."""
+    fake_path = tmp_path / "obs.parquet"
+    fake_path.write_text("dummy")
+    with (
+        patch("hitlist.observations.is_built", return_value=True),
+        patch("hitlist.mappings.is_mappings_built", return_value=False),
         patch("hitlist.observations.observations_path", return_value=fake_path),
         patch("hitlist.builder.build_observations") as build,
     ):
@@ -38,6 +58,7 @@ def test_ensure_index_built_force_triggers_rebuild(tmp_path: Path):
     fake_path.write_text("dummy")
     with (
         patch("hitlist.observations.is_built", return_value=True),
+        patch("hitlist.mappings.is_mappings_built", return_value=True),
         patch("hitlist.observations.observations_path", return_value=fake_path),
         patch("hitlist.builder.build_observations") as build,
     ):

--- a/tsarina/cli_hits.py
+++ b/tsarina/cli_hits.py
@@ -460,6 +460,20 @@ def handle(args: argparse.Namespace) -> None:
                 length_min=length_min,
                 length_max=length_max,
             )
+        # hitlist 1.30.46 split gene_names / gene_ids / protein_ids out of
+        # observations.parquet (#238) — they're now derived on demand from
+        # the peptide_mappings sidecar.  No-projection loads don't get them
+        # back automatically, so re-attach here using hitlist's own
+        # aggregator so downstream gene_ident_cols logic keeps working on
+        # both pre- and post-1.30.46 parquets.
+        if not hits.empty and "gene_names" not in hits.columns:
+            from hitlist.mappings import annotate_observations_with_genes, load_peptide_mappings
+
+            mappings = load_peptide_mappings(
+                peptide=hits["peptide"].unique().tolist(),
+                columns=["peptide", "gene_name", "gene_id", "protein_id"],
+            )
+            hits = annotate_observations_with_genes(hits, mappings)
         if resolved_lengths and not hits.empty:
             hits = hits[hits["peptide"].str.len().isin(resolved_lengths)].copy()
         hits = _apply_min_resolution(hits, args.min_resolution)

--- a/tsarina/cli_hits.py
+++ b/tsarina/cli_hits.py
@@ -466,6 +466,12 @@ def handle(args: argparse.Namespace) -> None:
         # back automatically, so re-attach here using hitlist's own
         # aggregator so downstream gene_ident_cols logic keeps working on
         # both pre- and post-1.30.46 parquets.
+        #
+        # Test note: any test that mocks ``hitlist.observations.load_observations``
+        # (or ``load_all_evidence``) with a non-empty frame lacking
+        # ``gene_names`` must also mock ``hitlist.mappings.load_peptide_mappings``
+        # — otherwise the real loader raises ``FileNotFoundError`` against
+        # a CI environment without a built sidecar.
         if not hits.empty and "gene_names" not in hits.columns:
             from hitlist.mappings import annotate_observations_with_genes, load_peptide_mappings
 

--- a/tsarina/indexing.py
+++ b/tsarina/indexing.py
@@ -28,7 +28,16 @@ import pandas as pd
 
 
 def ensure_index_built(force: bool = False, verbose: bool = True) -> Path:
-    """Ensure the hitlist observations parquet exists; build if not.
+    """Ensure both the hitlist observations parquet and its peptide_mappings
+    sidecar exist; build if either is missing.
+
+    tsarina depends on the sidecar for gene-identifier resolution
+    (``annotate_observations_with_genes`` in the cached fast path,
+    ``gene_name=`` filter pushdown in ``load_ms_evidence``). hitlist's
+    default ``build_observations`` produces both in one pass, so a
+    missing sidecar means either a partial manual build
+    (``build_mappings=False``) or sidecar deletion — either way, rebuild
+    so callers downstream don't trip a ``FileNotFoundError`` mid-query.
 
     Parameters
     ----------
@@ -44,9 +53,10 @@ def ensure_index_built(force: bool = False, verbose: bool = True) -> Path:
         Path to ``observations.parquet``.
     """
     from hitlist.builder import build_observations
+    from hitlist.mappings import is_mappings_built
     from hitlist.observations import is_built, observations_path
 
-    if force or not is_built():
+    if force or not is_built() or not is_mappings_built():
         if verbose:
             print(
                 "Building hitlist observations index (one-time ~2-5 min; cached afterwards)...",

--- a/tsarina/version.py
+++ b/tsarina/version.py
@@ -10,4 +10,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "1.3.3"
+__version__ = "1.3.4"

--- a/tsarina/viral.py
+++ b/tsarina/viral.py
@@ -275,10 +275,11 @@ def human_exclusive_viral_peptides(
     -----
     The human k-mer set is computed once per
     ``(ensembl_release, lengths)`` via
-    :func:`hitlist.proteome.proteome_kmer_set` and cached process-wide.
-    First call pays the Ensembl walk once; subsequent calls with the
-    same inputs return immediately.  The cache is shared across any
-    sibling pirl-unc package that calls the same primitive.
+    :func:`hitlist.proteome.proteome_kmer_set` and cached both in-process
+    and on disk (hitlist 1.30.49+ persists the ``ProteomeIndex`` to
+    ``~/.hitlist/proteome_index_cache/`` so repeat invocations across
+    fresh processes — e.g. per-patient cluster jobs — skip the cold
+    Ensembl build entirely).
     """
     from hitlist.proteome import proteome_kmer_set
 
@@ -326,11 +327,11 @@ def cancer_specific_viral_peptides(
     Notes
     -----
     Both the CTA and non-CTA k-mer sets are computed via
-    :func:`hitlist.proteome.proteome_kmer_set` and cached process-wide,
-    shared with :func:`cta_exclusive_peptides` /
-    :func:`human_exclusive_viral_peptides` where their gene filters
-    overlap.  First call pays the Ensembl walk; subsequent calls with
-    the same ``(release, lengths)`` return in sub-millisecond time.
+    :func:`hitlist.proteome.proteome_kmer_set` and cached both
+    in-process and on disk (hitlist 1.30.49+).  The on-disk
+    ``ProteomeIndex`` cache amortizes the Ensembl build across fresh
+    processes — relevant for per-patient cluster jobs that re-invoke
+    this entry point in a shell loop.
     """
     from hitlist.proteome import proteome_kmer_set
 


### PR DESCRIPTION
## Summary

Three correlated changes, all driven by auditing hitlist 1.15.1 → 1.30.50 for tsarina-visible drift.

### 1. `hitlist>=1.30.49` pin
Floor was 1.15.1 but tsarina actively reads symbols that landed later:
- `mhc_allele_set` / `mhc_allele_provenance` columns (read by `spanning.py`) — added in hitlist v1.23.0
- `peptide_attribution` provenance — required in v1.30.39 (commit 28fe1c5 noted this)
- `ProteomeIndex.from_ensembl` on-disk cache — **v1.30.49** (the one we've been waiting for; closes the third bullet of #69)

Bumping to `>=1.30.49` aligns the declared floor with the actual runtime requirement, and per-patient `tsarina personalize` shell loops now skip the cold ~10-60 s Ensembl walk on every invocation after the first.

### 2. Gene-column re-attach fix (latent bug)
hitlist v1.30.46 (#238) split `gene_names` / `gene_ids` / `protein_ids` / `n_source_proteins` out of `observations.parquet`. They're now auto-derived only when the caller explicitly lists them in `columns=`. tsarina's fast path in `cli_hits._handle_cached_path` calls `load_observations` / `load_all_evidence` with **no** `columns=` projection, so:
- On post-1.30.46 parquets, the returned frame is missing those columns.
- The downstream `gene_ident_cols = [c for c in (...) if c in hits.columns]` resolves to `[]`.
- `peptides` / `pmhc` / `refs` output formats **silently lose gene identifier columns**.

Tests didn't catch this because they mocked those columns into the input frame. Fix re-attaches via hitlist's own `annotate_observations_with_genes` against the peptide_mappings sidecar; works on both pre- and post-1.30.46 parquets (skips the join when columns are already present).

New regression test `test_cached_path_reattaches_gene_columns_on_post_1_30_46_parquets`. The old `test_refs_handler_passes_through_when_no_gene_ident_cols` was asserting an invariant the fix deliberately removes (the fast path now always produces gene columns); rewrote it as `test_refs_handler_emits_empty_gene_idents_when_mappings_sidecar_is_empty` to pin the empty-mappings contract.

### 3. Viral docstring touchup
Updated `human_exclusive_viral_peptides` / `cancer_specific_viral_peptides` `Notes` sections to mention that hitlist 1.30.49+ persists the `ProteomeIndex` to `~/.hitlist/proteome_index_cache/`, so the cache amortizes across fresh processes (the workflow that motivated #69's third bullet).

## What the audit found and ruled out

| hitlist change | Tsarina impact |
|---|---|
| v1.30.46 gene-column split | **Latent bug, fixed in this PR** |
| v1.30.37 `exclude_non_peptide_ligand=True` default | Silent correctness improvement — peptide-column joins no longer match CD1/MR1/MIC chemical-name rows |
| v1.30.39-44 categorical compression | No-op — `peptide` is not categorical; tsarina's only `.str.X` op is `.str.len()` on `peptide` |
| v1.30.10 PTM-aware peptide columns | Silent fix — pre-1.30.10 `peptide` could leak `"LQPFPQPQLPY + DEAM(Q8)"` strings into length filters |
| v1.30.0 load-time allele normalization | Idempotent — tsarina re-normalizes via mhcgnomes anyway |
| `explode_mappings → map_source_proteins` rename | N/A — tsarina doesn't import either |

## Test plan
- [x] `./format.sh`, `./lint.sh` clean
- [x] `./test.sh` — 313 passed in 28.1s (+1 new cache-fix test; rewrote one stale test)
- [ ] CI green across Python 3.9-3.12

Refs #69. Closes the disk-cache portion; #69 closes once this ships.