### PR TITLE
Surface filtered as backward-compat alias of passes_filters

### DIFF
--- a/tests/test_evidence.py
+++ b/tests/test_evidence.py
@@ -1,6 +1,18 @@
 import pandas as pd
 
-from tsarina.evidence import _attach_tcga_prevalence, _compute_ms_restriction
+from tsarina.evidence import CTA_evidence, _attach_tcga_prevalence, _compute_ms_restriction
+
+
+def test_CTA_evidence_exposes_filtered_alias_of_passes_filters():
+    """tsarina#61: legacy ``filtered`` column must travel alongside the
+    canonical ``passes_filters`` so consumers that still schema-check
+    for the old name (e.g. pirlygenes pre-#241) accept the live table
+    instead of falling back to their own snapshot."""
+    df = CTA_evidence()
+    assert "passes_filters" in df.columns
+    assert "filtered" in df.columns
+    # The two columns must agree row-for-row, including dtype.
+    assert df["filtered"].equals(df["passes_filters"])
 
 
 def test_compute_ms_restriction_uses_public_ms_loader(monkeypatch):

--- a/tests/test_gene_sets.py
+++ b/tests/test_gene_sets.py
@@ -86,9 +86,13 @@ def test_evidence_has_expected_columns():
 
 
 def test_evidence_uses_passes_filters_column_name():
+    """``passes_filters`` is the canonical name. ``filtered`` is now
+    surfaced as a backward-compat alias (tsarina#61) — both must be
+    present and identical."""
     df = CTA_evidence()
     assert "passes_filters" in df.columns
-    assert "filtered" not in df.columns
+    assert "filtered" in df.columns
+    assert df["filtered"].equals(df["passes_filters"])
 
 
 def test_xage1b_passes_relaxed_no_protein_threshold():

--- a/tests/test_tiers.py
+++ b/tests/test_tiers.py
@@ -220,8 +220,13 @@ def test_csv_has_all_new_columns():
 
 
 def test_csv_has_no_old_columns():
+    """Guard against pre-rename column names creeping back in.
+
+    ``filtered`` is deliberately retained as a backward-compat alias of
+    ``passes_filters`` (tsarina#61), so it's exempted here even though
+    the rest of the list still represents stale columns."""
     df = CTA_evidence()
-    for col in ["cta_tier", "evidence", "filtered", "ms_safety"]:
+    for col in ["cta_tier", "evidence", "ms_safety"]:
         assert col not in df.columns, f"Stale column present: {col}"
 
 

--- a/tsarina/evidence.py
+++ b/tsarina/evidence.py
@@ -68,6 +68,10 @@ def CTA_evidence() -> pd.DataFrame:
     passes_filters : bool
         Final inclusion flag with tiered RNA thresholds based on protein
         antibody reliability.
+    filtered : bool
+        Backward-compatible alias of ``passes_filters``; identical values.
+        Retained for downstream consumers that still schema-check for the
+        legacy column name (see tsarina#61).
     rna_max_ntpm : float
         Maximum nTPM across all tissues for this gene.
     never_expressed : bool

--- a/tsarina/loader.py
+++ b/tsarina/loader.py
@@ -25,7 +25,14 @@ LEGACY_FILTERED_COLUMN = "filtered"
 @lru_cache(maxsize=1)
 def _load_cta_dataframe() -> pd.DataFrame:
     path = join(_DATA_DIR, "cancer-testis-antigens.csv")
-    return pd.read_csv(path)
+    df = pd.read_csv(path)
+    # Surface the legacy inclusion flag alongside the canonical one so
+    # downstream consumers that still schema-check for ``filtered`` (e.g.
+    # pirlygenes pre-#241) can read the live tsarina table without
+    # falling back to their own bundled snapshot.  See tsarina#61.
+    if PASSES_FILTERS_COLUMN in df.columns and LEGACY_FILTERED_COLUMN not in df.columns:
+        df[LEGACY_FILTERED_COLUMN] = df[PASSES_FILTERS_COLUMN]
+    return df
 
 
 def cta_dataframe() -> pd.DataFrame:

--- a/tsarina/version.py
+++ b/tsarina/version.py
@@ -10,4 +10,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "1.3.4"
+__version__ = "1.3.5"


### PR DESCRIPTION
## Summary
Closes #61. Surfaces the legacy `filtered` column alongside the canonical `passes_filters` so pirlygenes (pre-#241) and any other consumer still schema-checking on the old name accepts the live tsarina table instead of falling back to its own bundled CSV snapshot.

## Why
PR #51 renamed the inclusion column and **simultaneously** relaxed the `Uncertain`/`Missing` protein-tier RNA threshold from 0.99 → 0.98. Pirlygenes' bundled `cancer-testis-antigens.csv` was snapshotted on 2026-04-06, one month before PR #51 merged. Pirlygenes schema-rejects the renamed tsarina table, falls back to its bundled snapshot, and the snapshot's pre-#51 0.99-threshold semantics flip XAGE1B's inclusion to `False` (vs current tsarina's `True`).

This was the one-row drift in #61 (278 bundled vs 279 live). Investigation in [tsarina#61 comment](https://github.com/pirl-unc/tsarina/issues/61#issuecomment-4441265289) and [pirlygenes#241 comment](https://github.com/pirl-unc/pirlygenes/issues/241#issuecomment-4441274879).

## What changed
- `_load_cta_dataframe` now sets `df["filtered"] = df["passes_filters"]` at load time. Identical dtype, identical values, same row order. Both columns travel through every public entry point (`CTA_evidence`, `CTA_detailed_evidence`).
- `CTA_evidence` docstring documents `filtered` as the backward-compat alias.
- The two rename-guard tests that asserted `"filtered" not in df.columns` are updated to assert the new contract (alias present and equal to canonical). New regression test in `test_evidence.py` pins the equivalence.

## Decoupling from pirlygenes timing
This works regardless of whether pirlygenes#241 lands. After this PR ships:
- Pirlygenes pre-#241: schema check on `filtered` succeeds → uses live tsarina table.
- Pirlygenes post-#241: reads `passes_filters` natively, ignores the alias.

Either way, the live-table path is unblocked. The bundled-CSV fallback in pirlygenes is **still** separately stale (frozen at 2026-04-06) — refreshing that is a separate pirlygenes-side fix tracked in pirlygenes#241's comments.

## Version
1.3.4 → 1.3.5.

## Test plan
- [x] `./format.sh`, `./lint.sh` clean
- [x] `./test.sh` — 316 passed in 34.9s (+1 new alias-equivalence test; rewrote two rename-guard tests)
- [ ] CI green across Python 3.9-3.12