### PR TITLE
test.sh: pick pytest -n from cores and available RAM (1.3.6)

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -1,1 +1,53 @@
-pytest --cov=tsarina/ --cov-report=term-missing tests
+#!/usr/bin/env bash
+# Run the tsarina test suite with a memory-aware pytest-xdist worker
+# count: ``-n auto`` spawns one worker per core, but each worker
+# loads its own DataFrame state and can OOM a 32 GB Mac when other
+# pytest suites are running concurrently. We pick the smaller of
+# (cores, available_RAM / per_worker_gb).
+
+set -e
+
+# Per-worker memory budget. A soft heuristic, not a hard cap.
+readonly PER_WORKER_GB=2.0
+
+# macOS available-RAM heuristic: free + inactive + speculative pages
+# are reclaimable on demand, so they count as headroom.
+macos_available_bytes() {
+    local page_size pages
+    page_size=$(sysctl -n hw.pagesize)
+    pages=$(vm_stat | awk '
+        /Pages free/        { gsub(/\./, "", $3); free     = $3 }
+        /Pages inactive/    { gsub(/\./, "", $3); inactive = $3 }
+        /Pages speculative/ { gsub(/\./, "", $3); spec     = $3 }
+        END                 { print free + inactive + spec }
+    ')
+    echo $(( pages * page_size ))
+}
+
+# Pick a pytest -n value that respects both CPU and available RAM.
+pytest_workers() {
+    local cpus avail_bytes
+    cpus=$(getconf _NPROCESSORS_ONLN 2>/dev/null || sysctl -n hw.logicalcpu)
+    if [[ "$(uname)" == "Darwin" ]]; then
+        avail_bytes=$(macos_available_bytes)
+    else
+        avail_bytes=$(awk '/MemAvailable/ { print $2 * 1024 }' /proc/meminfo)
+    fi
+    awk -v cpus="$cpus" -v bytes="$avail_bytes" -v budget="$PER_WORKER_GB" '
+        BEGIN {
+            by_memory = int(bytes / 1024^3 / budget)
+            n = (cpus < by_memory ? cpus : by_memory)
+            print (n < 1 ? 1 : n)
+        }
+    '
+}
+
+# pytest-xdist is optional — fall back to serial pytest if missing.
+xdist_flag=()
+if python -c "import xdist" 2>/dev/null; then
+    workers=$(pytest_workers)
+    xdist_flag=(-n "$workers")
+    echo "Running pytest with -n ${workers} (per-worker budget ≈ ${PER_WORKER_GB} GB)"
+fi
+
+exec pytest "${xdist_flag[@]}" --cov=tsarina/ --cov-report=term-missing tests "$@"

--- a/tsarina/version.py
+++ b/tsarina/version.py
@@ -10,4 +10,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "1.3.5"
+__version__ = "1.3.6"


### PR DESCRIPTION
## What

Switch ``test.sh`` from a single-process ``pytest`` invocation to pytest-xdist
with a **memory-aware worker count**. Picks ``min(cores, avail_RAM /
per_worker_gb)`` so the suite uses real parallelism on a fresh box but drops
to ``-n 1`` automatically when the machine is already under strain (e.g.
sibling pytest suites in hitlist / trufflepig / vaxrank).

Portable: macOS (``vm_stat``) and Linux (``/proc/meminfo``).
Falls back to serial pytest when ``xdist`` isn't installed (CI).

## Why

Today: 3 sibling pytest suites running concurrently easily pushed a 32 GB
Mac to >50 GB of memory pressure (compressed + swap), thrashing for tens of
minutes. The naive ``-n auto`` ignores memory entirely, and a static cap
(``-n 2`` etc.) is either too conservative for a fresh box or still wrong
when something else is hogging RAM. The cap here is a dynamic snapshot:
free + inactive + speculative pages divided by a per-worker budget.

## Verification

- ``bash -n test.sh`` — syntax OK.
- ``./test.sh --collect-only`` on this box: ``-n 10`` picked, 316 tests
  collected in 0.81s.
- Linux branch simulated: 16-core/24 GB → ``-n 9``; 16-core/1 GB → ``-n 1``.

Version bumped to **1.3.6** per repo policy.