### PR TITLE
Bump hitlist pin to >=1.30.57; develop against sibling hitlist checkout

### DIFF
--- a/develop.sh
+++ b/develop.sh
@@ -16,7 +16,18 @@ source "$VENV_DIR/bin/activate"
 if command -v uv &> /dev/null; then
     echo "Using uv to install package with development dependencies..."
     uv pip install -e ".[dev]"
+    PIP_INSTALL=(uv pip install)
 else
     echo "uv not found, falling back to regular pip..."
     pip install -e ".[dev]"
+    PIP_INSTALL=(pip install)
+fi
+
+# Develop against the sibling hitlist checkout when present, so tsarina always
+# tracks the latest hitlist code (its MS-evidence schema changes frequently).
+# Falls back silently to the PyPI-pinned hitlist if the sibling is absent.
+HITLIST_DIR="${HITLIST_DIR:-../hitlist}"
+if [ -d "$HITLIST_DIR" ]; then
+    echo "Installing sibling hitlist editable from $HITLIST_DIR ..."
+    "${PIP_INSTALL[@]}" -e "$HITLIST_DIR"
 fi

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,10 @@ classifiers = [
 ]
 requires-python = ">=3.9"
 dependencies = [
-    "hitlist>=1.30.49",
+    # 1.30.57: cell_name split into cell_line_name + cell_type (handled via
+    # the cell-column fallbacks in spanning.py / ms_evidence.py).  1.30.49+
+    # already required for the post-1.30.46 gene-column sidecar re-attach.
+    "hitlist>=1.30.57",
     "mhcgnomes>=3.20.0",
     "pandas",
     "numpy",

--- a/tsarina/version.py
+++ b/tsarina/version.py
@@ -10,4 +10,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "1.4.0"
+__version__ = "1.4.1"


### PR DESCRIPTION
## Overview

Keeps tsarina current with the latest `hitlist` (its MS-evidence schema changes frequently).

- **Bump `hitlist>=1.30.49` → `>=1.30.57`** (latest).
- **`develop.sh` installs the sibling `../hitlist` editable when present** (override via `HITLIST_DIR`), so local dev always tracks the latest hitlist code instead of a stale PyPI build. Falls back to the pinned hitlist if the sibling is absent.
- Version 1.4.0 → 1.4.1.

## Verified against 1.30.57 (real, non-mocked)

The dev env had drifted to hitlist 1.30.0 (below the old pin). After installing 1.30.57 editable from the sibling:

- `./test.sh` → 321 passed.
- `tsarina hits --gene MAGEA4 --mhc-class I --format pmhc` → correct: gene-column re-attach (singular `gene_name` → plural `gene_names`), paralogy preserved, per-pMHC aggregation with refs.
- `tsarina panel --ctas MAGEA4 --alleles HLA-A*02:01` → correct: MS-safety tiers (`sample_allele_ms=3`), sample-narrowed provenance, `ms_samples` populated, TCGA prevalence, coverage.

The 1.30.57 `cell_name → cell_line_name + cell_type` split is already absorbed by the existing cell-column fallbacks (`spanning.py:1787`, `ms_evidence.py:123`).

## Note

CI mocks all ~46 hitlist call sites, so it would **not** have caught a real schema break — this PR's verification was manual. Filing a separate issue to add a real (non-mocked) hitlist smoke test to CI.