### PR TITLE
Document CTA evidence tiers + add cta_healthy_tissue_ms_hits helper (#76)

### DIFF
--- a/docs/curation.md
+++ b/docs/curation.md
@@ -202,6 +202,59 @@ the raw export scanner for those files instead of the cached observations index.
 | `RECURRENT_HEALTHY` | Multiple peptides or tissues in healthy somatic MS (genuine off-target) |
 | `NO_MS_DATA` | No MS evidence available for this gene's peptides |
 
+### `restriction_confidence` formula
+
+`tiers.synthesize_restriction` averages a per-source evidence score (protein
+IHC, RNA, MS) and bins it: **≥ 1.2 → HIGH, ≥ 0.8 → MODERATE, else LOW**. So
+`MODERATE` ≈ one solid source, uncorroborated.
+
+### Published CTAs across the axes
+
+The tiers describe evidence **quality**, not target **validity**.  A naive hard
+gate of `restriction ∈ {TESTIS, PLACENTAL}` × `confidence ≥ MODERATE` would
+reject clinically-validated targets that are in the expressed (POSITIVE) set:
+
+| gene | in `CTA_gene_names()` | restriction | confidence | ms_restriction | hard gate |
+|---|:---:|---|---|---|:---:|
+| NY-ESO-1 (CTAG1B) | ✅ | TESTIS | HIGH | CANCER_ONLY | ✅ admit |
+| NUTM1 | ✅ | TESTIS | HIGH | CANCER_ONLY | ✅ admit |
+| HORMAD1 | ✅ | TESTIS | MODERATE | CANCER_ONLY | ✅ admit |
+| PAGE2 | ✅ | TESTIS | MODERATE | CANCER_ONLY | ✅ admit |
+| PAGE5 | ✅ | TESTIS | MODERATE | CANCER_ONLY | ✅ admit |
+| **MAGE-A4** | ✅ | **REPRODUCTIVE** | MODERATE | RECURRENT_HEALTHY | ❌ reject |
+| **PRAME** | ✅ | TESTIS | **LOW** | SINGLETON_HEALTHY | ❌ reject |
+| **XAGE1A** | ✅ | **SOMATIC** | MODERATE | CANCER_ONLY | ❌ reject |
+
+MAGE-A4 (FDA-approved afami-cel/Tecelra), PRAME (e.g. IMA203), and XAGE1A are all
+real targets the gate would drop.  (CTAG2, the third NY-ESO-1 paralog, correctly
+lands in the somatic-leak held-out class — `CTA_excluded_*`.)  **Use the tiers as
+ranking signals, not hard filters.**
+
+### Peptide-level healthy-tissue screening
+
+The gene-level `ms_restriction` collapses detail that matters for safety.
+`cta_healthy_tissue_ms_hits(gene)` surfaces the underlying healthy-*somatic* MS
+hits at peptide × tissue × allele granularity (reproductive/thymic hits, which
+are expected for CTAs, are excluded):
+
+```python
+from tsarina import cta_healthy_tissue_ms_hits
+
+cta_healthy_tissue_ms_hits("PRAME")
+#   peptide tissue       allele provenance      pmid  vital_organ
+# SQLTTLSFY  Blood  HLA class I  unmatched  29557506        False
+# -> cautious gene tier (SINGLETON_HEALTHY), but clean: 1 blood hit, 0 vital organs.
+
+cta_healthy_tissue_ms_hits("MAGEA4")
+# -> 3 heart-eluted peptides (AETSYVKV family, HLA-B*49:01; PMID 33858848,
+#    vital_organ=True) + 1 blood hit. The clinical epitope GVYDGREHTV (A*02:01)
+#    is seen only in cancer, never on heart.
+```
+
+`vital_organ` flags tissues matching a `SAFETY_TISSUE_GROUPS` vital organ
+(brain / heart / lung / liver / pancreas) — the "which organ / which allele /
+which peptide" detail a per-patient screen needs.
+
 The packaged CTA evidence table intentionally does not include MS count columns.
 Use `CTA_detailed_evidence()` or `tsarina panel` to recompute current
 hitlist-derived counts. The runtime `ms_cta_exclusive_*` counts use the stricter

--- a/tests/test_ms_evidence.py
+++ b/tests/test_ms_evidence.py
@@ -97,3 +97,61 @@ def test_aggregate_ms_hits_for_iedb_columns_keeps_legacy_shape():
             "iedb_alleles": "HLA-A*02:01",
         }
     ]
+
+
+def test_cta_healthy_tissue_ms_hits_surfaces_tissue_allele_pmid_vital(monkeypatch):
+    """Per-peptide healthy-somatic MS hits with vital-organ flag (tsarina#76)."""
+    import tsarina.indexing
+
+    rows = pd.DataFrame(
+        {
+            "peptide": ["HEARTPEP", "BLOODPEP", "CANCERPEP", "TESTISPEP"],
+            "mhc_restriction": ["HLA-B*49:01", "HLA-B*44:03", "HLA-A*02:01", "HLA-A*01:01"],
+            "mhc_allele_set": ["HLA-B*49:01", "HLA-B*44:03", "HLA-A*02:01", "HLA-A*01:01"],
+            "mhc_allele_provenance": ["exact", "sample_allele_match", "exact", "exact"],
+            "pmid": ["33858848", "38920720", "111", "222"],
+            "source_tissue": ["Heart", "Blood", "Melanoma", "Testis"],
+            "cell_name": ["", "", "", ""],
+            # only the first two are healthy somatic
+            "src_healthy_tissue": [True, True, False, False],
+        }
+    )
+    monkeypatch.setattr(tsarina.indexing, "load_ms_evidence", lambda **kw: rows, raising=True)
+
+    from tsarina import cta_healthy_tissue_ms_hits
+
+    out = cta_healthy_tissue_ms_hits("MAGEA4")
+    # Only the two healthy-somatic rows survive (cancer/testis dropped).
+    assert list(out["peptide"]) == ["HEARTPEP", "BLOODPEP"]
+    assert list(out["tissue"]) == ["Heart", "Blood"]
+    assert list(out["pmid"]) == ["33858848", "38920720"]
+    # Heart is a vital organ; blood is not.
+    assert list(out["vital_organ"]) == [True, False]
+    assert set(out.columns) == {
+        "peptide",
+        "tissue",
+        "allele",
+        "allele_set",
+        "provenance",
+        "pmid",
+        "vital_organ",
+    }
+
+
+def test_cta_healthy_tissue_ms_hits_empty_when_no_healthy_hits(monkeypatch):
+    import tsarina.indexing
+
+    rows = pd.DataFrame(
+        {
+            "peptide": ["CANCERPEP"],
+            "mhc_restriction": ["HLA-A*02:01"],
+            "source_tissue": ["Melanoma"],
+            "src_healthy_tissue": [False],
+        }
+    )
+    monkeypatch.setattr(tsarina.indexing, "load_ms_evidence", lambda **kw: rows, raising=True)
+
+    from tsarina import cta_healthy_tissue_ms_hits
+
+    out = cta_healthy_tissue_ms_hits("PRAME")
+    assert out.empty

--- a/tsarina/__init__.py
+++ b/tsarina/__init__.py
@@ -42,6 +42,7 @@ from .gene_sets import (
     CTA_unfiltered_gene_names,
     cta_symbol_for_alias,
 )
+from .ms_evidence import cta_healthy_tissue_ms_hits
 from .tiers import (
     CONFIDENCE_VALUES,
     MS_RESTRICTION_VALUES,
@@ -86,6 +87,7 @@ __all__ = [
     "CTA_unfiltered_gene_names",
     "__version__",
     "cta_cancer_expression_features",
+    "cta_healthy_tissue_ms_hits",
     "cta_symbol_for_alias",
     "get_panel",
     "hpa_cancer_ihc_prevalence",

--- a/tsarina/ms_evidence.py
+++ b/tsarina/ms_evidence.py
@@ -144,3 +144,86 @@ def aggregate_ms_hits_for_iedb_columns(hits: pd.DataFrame) -> pd.DataFrame:
             "ms_alleles": "iedb_alleles",
         }
     )[["peptide", "iedb_hit_count", "iedb_alleles"]]
+
+
+#: Substrings flagging an MS source tissue as a vital organ (per
+#: ``tiers.SAFETY_TISSUE_GROUPS`` — brain/heart/lung/liver/pancreas — plus the
+#: CNS spellings MS datasets use).  Matched case-insensitively against the row's
+#: source tissue.
+_VITAL_ORGAN_KEYWORDS: frozenset[str] = frozenset(
+    {"brain", "cerebell", "cns", "cortex", "heart", "lung", "liver", "pancrea"}
+)
+
+CTA_HEALTHY_TISSUE_MS_COLUMNS: list[str] = [
+    "peptide",
+    "tissue",
+    "allele",
+    "allele_set",
+    "provenance",
+    "pmid",
+    "vital_organ",
+]
+
+
+def cta_healthy_tissue_ms_hits(
+    gene: str,
+    *,
+    mhc_class: str | None = "I",
+    mhc_species: str | None = "Homo sapiens",
+) -> pd.DataFrame:
+    """Per-peptide healthy *somatic*-tissue MS hits for a CTA gene.
+
+    The gene-level ``ms_restriction`` tier collapses detail that matters for
+    safety; this surfaces the underlying immunopeptidome hits at
+    peptide x tissue x allele granularity so consumers can do allele-aware,
+    peptide-level screening (tsarina#76).
+
+    Reproductive and thymic hits (expected for CTAs) are excluded — only
+    ``src_healthy_tissue`` (non-reproductive, non-thymus) rows are returned.
+
+    Parameters
+    ----------
+    gene
+        Gene symbol (or alias — resolved via the hitlist peptide mappings).
+    mhc_class, mhc_species
+        Passed through to :func:`tsarina.indexing.load_ms_evidence`.
+
+    Returns
+    -------
+    pd.DataFrame
+        One row per healthy-somatic MS observation, columns:
+        ``peptide``, ``tissue``, ``allele`` (recorded ``mhc_restriction``),
+        ``allele_set`` (candidate set for multiallelic samples),
+        ``provenance``, ``pmid``, and ``vital_organ`` (bool — tissue matches a
+        ``SAFETY_TISSUE_GROUPS`` vital organ).  Empty if the gene has no
+        healthy-somatic MS hits.
+    """
+    from .indexing import load_ms_evidence
+
+    df = load_ms_evidence(gene_name=gene, mhc_class=mhc_class, mhc_species=mhc_species)
+    if df.empty or "src_healthy_tissue" not in df.columns:
+        return pd.DataFrame(columns=CTA_HEALTHY_TISSUE_MS_COLUMNS)
+
+    hits = df[df["src_healthy_tissue"].astype(bool)].copy()
+    if hits.empty:
+        return pd.DataFrame(columns=CTA_HEALTHY_TISSUE_MS_COLUMNS)
+
+    tissue = hits.get("source_tissue", pd.Series("", index=hits.index)).fillna("").astype(str)
+    if "cell_name" in hits.columns:
+        cell = hits["cell_name"].fillna("").astype(str)
+        tissue = tissue.where(tissue.str.strip() != "", cell)
+    low = tissue.str.lower()
+    vital = low.map(lambda t: any(keyword in t for keyword in _VITAL_ORGAN_KEYWORDS))
+
+    out = pd.DataFrame(
+        {
+            "peptide": hits["peptide"].astype(str).values,
+            "tissue": tissue.values,
+            "allele": hits.get("mhc_restriction", pd.Series("", index=hits.index)).values,
+            "allele_set": hits.get("mhc_allele_set", pd.Series("", index=hits.index)).values,
+            "provenance": hits.get("mhc_allele_provenance", pd.Series("", index=hits.index)).values,
+            "pmid": hits.get("pmid", pd.Series("", index=hits.index)).values,
+            "vital_organ": vital.values,
+        }
+    )
+    return out.reset_index(drop=True)

--- a/tsarina/version.py
+++ b/tsarina/version.py
@@ -10,4 +10,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "1.4.6"
+__version__ = "1.4.7"


### PR DESCRIPTION
## Overview

Closes the two gaps in #76 (spun out of openvax/vaxrank#303): make the tier semantics concrete, and surface healthy-tissue MS detail at the granularity a per-patient safety screen needs.

## (1) Docs — published CTAs across the evidence axes

`docs/curation.md` now includes:
- A **reference table** placing the commonly-published CTAs on each axis (NY-ESO-1, NUTM1, HORMAD1, PAGE2/5, MAGE-A4, PRAME, XAGE1A — values generated from `CTA_evidence()`, matching the issue).
- The **`restriction_confidence` formula**: per-source averaged score → ≥1.2 HIGH, ≥0.8 MODERATE, else LOW.
- The teaching point stated explicitly: **tiers describe evidence *quality*, not target *validity***. A hard `{TESTIS,PLACENTAL}`×`≥MODERATE` gate would reject MAGE-A4 (FDA-approved afami-cel/Tecelra), PRAME (IMA203), and XAGE1A — all in the POSITIVE set. Use tiers as ranking signals, not hard filters.

## (2) API — `cta_healthy_tissue_ms_hits(gene)`

Surfaces healthy-**somatic**-tissue MS hits at **peptide × tissue × allele** granularity (reproductive/thymic hits excluded — expected for CTAs). Columns: `peptide, tissue, allele, allele_set, provenance, pmid, vital_organ` (vital = matches a `SAFETY_TISSUE_GROUPS` organ). Built on `load_ms_evidence(gene_name=…)`.

Reproduces the issue's deep-dive **exactly** against real data:
- **PRAME** → 1 hit, `SQLTTLSFY` in Blood, `vital_organ=False` (cautious gene tier, but clean presentation).
- **MAGE-A4** → 3 heart-eluted peptides (`AETSYVKV` family, HLA-B*49:01, PMID 33858848, `vital_organ=True`) + 1 blood hit.

## Verification

- Helper exported from the package top level; mocked unit tests (tissue/allele/PMID extraction + vital-organ flag + empty case).
- `./format.sh`, `./lint.sh`, `./test.sh` (330 passed). Version 1.4.6 → 1.4.7.

Closes #76.