### PR TITLE
Resolve CTA synonyms in the panel selection path (#77)

### DIFF
--- a/tests/test_spanning.py
+++ b/tests/test_spanning.py
@@ -2176,3 +2176,24 @@ def test_xage_family_aliases_backfilled():
     assert "XAGE1E" in str(df.loc["XAGE1B", "Aliases"])
     assert "GAGED2" in str(df.loc["XAGE1A", "Aliases"])
     assert "CT12.2" in str(df.loc["XAGE2", "Aliases"])
+
+
+def test_selection_resolves_synonyms_to_symbols():
+    """CTA selection accepts synonyms / colloquial names, not just HGNC symbols.
+
+    Wires tsarina.gene_sets.cta_symbol_for_alias into the panel selection path
+    (tsarina#77)."""
+    from tsarina.spanning import _normalize_cta_labels
+
+    valid = {"CTAG1A", "CTAG1B", "XAGE2", "MAGEA4", "PRAME"}
+    assert _normalize_cta_labels(["ESO1"], valid) == ["CTAG1A/CTAG1B"]
+    assert _normalize_cta_labels(["CT12.2"], valid) == ["XAGE2"]
+    assert _normalize_cta_labels(["OIP4"], valid) == ["PRAME"]
+    # Mixed synonyms + symbols resolve together, de-duplicated.
+    assert _normalize_cta_labels(["NY-ESO-1", "CT12.2", "MAGEA4"], valid) == [
+        "CTAG1A/CTAG1B",
+        "XAGE2",
+        "MAGEA4",
+    ]
+    # Unknown names are still dropped.
+    assert _normalize_cta_labels(["not-a-gene"], valid) == []

--- a/tsarina/spanning.py
+++ b/tsarina/spanning.py
@@ -1320,6 +1320,8 @@ def _normalize_cta_labels(values: Iterable[str] | None, valid_symbols: set[str])
     if values is None:
         return []
 
+    from .gene_sets import cta_symbol_for_alias
+
     valid_by_compact = {_compact_cta_name(symbol): symbol for symbol in valid_symbols}
     labels: list[str] = []
     seen: set[str] = set()
@@ -1327,6 +1329,12 @@ def _normalize_cta_labels(values: Iterable[str] | None, valid_symbols: set[str])
         compact = _compact_cta_name(value)
         if not compact:
             continue
+        if compact not in _GROUP_ALIAS_TO_LABEL and compact not in valid_by_compact:
+            # Resolve a synonym / alias (NY-ESO-1, ESO1, CT12.2, ...) to its
+            # official symbol, then fall through to group/symbol matching below.
+            resolved = cta_symbol_for_alias(value)
+            if resolved is not None:
+                compact = _compact_cta_name(resolved)
         if compact in _GROUP_ALIAS_TO_LABEL:
             label = _GROUP_ALIAS_TO_LABEL[compact]
         elif compact in valid_by_compact:

--- a/tsarina/version.py
+++ b/tsarina/version.py
@@ -10,4 +10,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "1.4.7"
+__version__ = "1.4.8"


### PR DESCRIPTION
Wires `cta_symbol_for_alias` into `_normalize_cta_labels` (the `--ctas` / selection-allowlist path) as a fallback, so panel selection accepts synonyms and colloquial names — `ESO1`→CTAG1A/CTAG1B, `CT12.2`→XAGE2, `OIP4`→PRAME, `GAGED2`→XAGE1A/XAGE1B — not just HGNC symbols + group aliases. Unknown names still drop. Test added; 331 passed. Version 1.4.7→1.4.8. Refs #77.