### PR TITLE
Document CTA scope (protein-coding only) + source provenance (closes #79)

### DIFF
--- a/docs/curation.md
+++ b/docs/curation.md
@@ -86,6 +86,42 @@ Several additional databases were evaluated but not used as primary sources:
 
 Genes from these sources are cross-referenced in the `source_databases` column (e.g., `daSilva2017` tag indicates the gene appears in the da Silva full 1,103-gene set).
 
+## Scope and provenance (tsarina#79)
+
+**Protein-coding only.** Every CTA in the table is `biotype == protein_coding`;
+the filter rejects non-coding genes outright (see [Filter logic](#filter-logic)).
+So the lncRNA / antisense CT genes in CTexploreR's `CT_genes` list
+(LINC*, *-AS1, *-DT, …) are **deliberately out of scope** — tsarina curates
+protein-coding pMHC targets, not the full CT transcriptome. This is the
+resolution of the lncRNA/antisense scope question in tsarina#79.
+
+**Every gene carries source provenance.** The `source_databases` column is
+populated for all genes — there are **no sourceless or "literature-only"
+entries**. Each token records membership in a published source:
+
+| `source_databases` token | meaning |
+|---|---|
+| `CTpedia` | CTdatabase / CTpedia (curated CT antigen reference) |
+| `CTexploreR_CT` / `CTexploreR_CTP` | CTexploreR testis-specific / testis-preferential |
+| `daSilva2017` | da Silva 2017 full 1,103-gene RNA-seq screen |
+| `daSilva2017_protein` | da Silva 2017 tumor-MS protein-level subset |
+
+Provenance is therefore **queryable directly**: a gene in a hand-curated CT
+database vs. one surfaced only by the high-throughput da Silva screen are
+distinguishable by token. Current split: **285** genes are in a curated CT
+database (CTpedia and/or CTexploreR); **75** are screen-only (`daSilva2017`,
+not in a curated CT database). To select by provenance:
+
+```python
+from tsarina import CTA_evidence
+df = CTA_evidence()
+curated = df[df["source_databases"].str.contains("CTpedia|CTexploreR")]   # 285
+screen_only = df[~df["source_databases"].str.contains("CTpedia|CTexploreR")]  # 75 (daSilva)
+```
+
+(The literature/EWSR1-FLI1 sources listed above confirmed genes already present
+in the curated databases — none entered the panel by literature scan alone.)
+
 ## HPA tissue expression annotation
 
 Every gene is scored against [Human Protein Atlas](https://www.proteinatlas.org/) v23 using two data modalities:

--- a/tsarina/version.py
+++ b/tsarina/version.py
@@ -10,4 +10,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "1.4.8"
+__version__ = "1.4.9"


### PR DESCRIPTION
Resolves the two remaining #79 items — both already decided by existing tsarina design, now made explicit:

- **lncRNA/antisense scope:** tsarina is protein-coding only (the biotype filter rejects non-coding genes), so CTexploreR's lncRNA/antisense CT genes are deliberately out of scope.
- **Provenance:** `source_databases` is populated for **every** gene — verified 0 sourceless / literature-only entries (the #79 '143' figure came from a stale pirlygenes snapshot). Curated CT database (CTpedia/CTexploreR, **285**) vs screen-only (daSilva2017, **75**) is queryable directly; documented with token semantics + a filtering recipe.

Docs-only + version bump 1.4.8 → 1.4.9. Closes #79.