### PR TITLE
Add tsarina hits --healthy-tissue per-peptide safety screen

### DIFF
--- a/docs/curation.md
+++ b/docs/curation.md
@@ -291,6 +291,14 @@ cta_healthy_tissue_ms_hits("MAGEA4")
 (brain / heart / lung / liver / pancreas) — the "which organ / which allele /
 which peptide" detail a per-patient screen needs.
 
+The same screen is available from the CLI:
+
+```bash
+tsarina hits --gene MAGEA4 --mhc-class I --healthy-tissue
+# peptide,tissue,allele,allele_set,provenance,pmid,vital_organ
+# AETSYVKV,Heart,HLA-B*49:01,...,33858848,True
+```
+
 The packaged CTA evidence table intentionally does not include MS count columns.
 Use `CTA_detailed_evidence()` or `tsarina panel` to recompute current
 hitlist-derived counts. The runtime `ms_cta_exclusive_*` counts use the stricter

--- a/tests/test_cli_hits.py
+++ b/tests/test_cli_hits.py
@@ -101,6 +101,7 @@ def test_include_binding_assays_routes_to_load_all_evidence(tmp_path):
         iedb_path=None,
         cedar_path=None,
         skip_ms_evidence=False,
+        healthy_tissue=False,
         output=str(tmp_path / "out.csv"),
     )
     empty = pd.DataFrame(
@@ -143,6 +144,7 @@ def test_default_cached_path_uses_load_observations_not_union(tmp_path):
         iedb_path=None,
         cedar_path=None,
         skip_ms_evidence=False,
+        healthy_tissue=False,
         output=str(tmp_path / "out.csv"),
     )
     empty = pd.DataFrame({"peptide": pd.Series(dtype=str), "mhc_restriction": pd.Series(dtype=str)})
@@ -175,6 +177,7 @@ def _base_cached_args(tmp_path, lengths, *, include_binding_assays=False, mhc_cl
         iedb_path=None,
         cedar_path=None,
         skip_ms_evidence=False,
+        healthy_tissue=False,
         output=str(tmp_path / "out.csv"),
     )
 
@@ -468,3 +471,45 @@ def test_enumerate_gene_peptides_caches_proteome_index_across_calls():
         assert "peptide" in df.columns
     finally:
         cli_hits._cached_proteome_index.cache_clear()
+
+
+def test_healthy_tissue_flag_outputs_safety_screen(tmp_path):
+    """`--healthy-tissue` short-circuits to the per-peptide healthy-somatic MS
+    safety view (tsarina#76 helper surfaced in the CLI)."""
+    from tsarina import cli_hits
+
+    args = _base_cached_args(tmp_path, lengths=None)
+    args.healthy_tissue = True
+    screen = pd.DataFrame(
+        {
+            "peptide": ["AETSYVKV", "KEVDPASNTY"],
+            "tissue": ["Heart", "Blood"],
+            "allele": ["HLA-B*49:01", "HLA-B*44:03"],
+            "allele_set": ["HLA-B*49:01", "HLA-B*44:03"],
+            "provenance": ["exact", "sample_allele_match"],
+            "pmid": ["33858848", "38920720"],
+            "vital_organ": [True, False],
+        }
+    )
+    with patch("tsarina.ms_evidence.cta_healthy_tissue_ms_hits", return_value=screen) as helper:
+        cli_hits.handle(args)
+
+    # Called for the resolved gene; output is the safety screen, not the
+    # cancer-MS aggregation.
+    assert helper.call_args.args[0] == "PRAME"
+    out = pd.read_csv(tmp_path / "out.csv")
+    assert list(out["peptide"]) == ["AETSYVKV", "KEVDPASNTY"]
+    assert list(out["vital_organ"]) == [True, False]
+    assert "tissue" in out.columns and "pmid" in out.columns
+
+
+def test_healthy_tissue_flag_handles_no_hits(tmp_path):
+    from tsarina import cli_hits
+
+    args = _base_cached_args(tmp_path, lengths=None)
+    args.healthy_tissue = True
+    from tsarina.ms_evidence import CTA_HEALTHY_TISSUE_MS_COLUMNS
+
+    empty = pd.DataFrame(columns=CTA_HEALTHY_TISSUE_MS_COLUMNS)
+    with patch("tsarina.ms_evidence.cta_healthy_tissue_ms_hits", return_value=empty):
+        cli_hits.handle(args)  # must not raise

--- a/tests/test_cli_hits_refs.py
+++ b/tests/test_cli_hits_refs.py
@@ -118,6 +118,7 @@ def test_refs_handler_merges_gene_ident_cols_from_cached_path(tmp_path):
         iedb_path=None,
         cedar_path=None,
         skip_ms_evidence=False,
+        healthy_tissue=False,
         output=str(output_csv),
     )
     with (
@@ -190,6 +191,7 @@ def test_refs_handler_emits_empty_gene_idents_when_mappings_sidecar_is_empty(tmp
         iedb_path=None,
         cedar_path=None,
         skip_ms_evidence=False,
+        healthy_tissue=False,
         output=str(output_csv),
     )
     with (

--- a/tsarina/cli_hits.py
+++ b/tsarina/cli_hits.py
@@ -203,6 +203,16 @@ def build_parser(sub: argparse._SubParsersAction) -> argparse.ArgumentParser:
         help="Skip IEDB/CEDAR; output the proteome-enumerated peptides only.",
     )
     p.add_argument(
+        "--healthy-tissue",
+        action="store_true",
+        help=(
+            "Safety screen: output this gene's per-peptide healthy-SOMATIC-tissue "
+            "MS hits (tissue, allele, allele_set, provenance, pmid, vital_organ "
+            "flag) instead of the cancer-MS aggregation. Reproductive/thymic hits "
+            "(expected for CTAs) are excluded. See cta_healthy_tissue_ms_hits()."
+        ),
+    )
+    p.add_argument(
         "-o",
         "--output",
         default=None,
@@ -366,6 +376,18 @@ def handle(args: argparse.Namespace) -> None:
         print(f"UniProt {args.uniprot} → gene {gene}", file=sys.stderr)
 
     mhc_species = None if args.species.lower() == "any" else args.species
+
+    # ── 1b. Healthy-tissue safety screen ───────────────────────────────
+    # Short-circuit: peptide x tissue x allele healthy-somatic MS hits for
+    # the gene, with a vital-organ flag — the per-patient safety view.
+    if args.healthy_tissue:
+        from .ms_evidence import cta_healthy_tissue_ms_hits
+
+        hits = cta_healthy_tissue_ms_hits(gene, mhc_class=args.mhc_class, mhc_species=mhc_species)
+        if hits.empty:
+            print(f"No healthy-somatic-tissue MS hits for {gene}.", file=sys.stderr)
+        _write(args.output, hits)
+        return
 
     # ── 2. Proteome-enumeration fallbacks ──────────────────────────────
     # --skip-ms-evidence outputs the theoretical peptide menu.

--- a/tsarina/version.py
+++ b/tsarina/version.py
@@ -10,4 +10,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "1.4.9"
+__version__ = "1.5.0"


### PR DESCRIPTION
## Overview

Surfaces the #76 `cta_healthy_tissue_ms_hits` helper in the CLI — it was Python-API-only. Completes the per-peptide vital-organ safety screen that #76's motivating consumer (openvax/vaxrank#303) needs.

## What

`tsarina hits --gene X --healthy-tissue` short-circuits to the gene's per-peptide **healthy-somatic-tissue** MS hits — `peptide, tissue, allele, allele_set, provenance, pmid, vital_organ` — instead of the cancer-MS aggregation. Reproductive/thymic hits (expected for CTAs) are excluded; `vital_organ` flags brain/heart/lung/liver/pancreas (`SAFETY_TISSUE_GROUPS`).

Reproduces #76's deep-dive from the CLI (verified against the live index):
```
tsarina hits --gene MAGEA4 --healthy-tissue  → 3 heart-eluted peptides (HLA-B*49:01, PMID 33858848, vital_organ=True) + 1 blood
tsarina hits --gene PRAME  --healthy-tissue  → 1 clean blood hit (vital_organ=False)
```

## Notes
- Clean short-circuit right after gene resolution (before the heavy MS-aggregation path); honors `--mhc-class` / `--species`.
- Added the `healthy_tissue` field to the existing `handle()` `Namespace` test builders (new arg).
- Tests: the flag's output + the no-hits case. Docs updated. `./format.sh`/`./lint.sh`/`./test.sh` (333 passed). Version 1.4.9 → 1.5.0.