### PR TITLE
Exclude non-CTA conserved/multicopy genes from the universe (closes #92)

### DIFF
--- a/docs/curation.md
+++ b/docs/curation.md
@@ -108,19 +108,39 @@ entries**. Each token records membership in a published source:
 
 Provenance is therefore **queryable directly**: a gene in a hand-curated CT
 database vs. one surfaced only by the high-throughput da Silva screen are
-distinguishable by token. Current split: **285** genes are in a curated CT
-database (CTpedia and/or CTexploreR); **75** are screen-only (`daSilva2017`,
+distinguishable by token. Current split: **282** genes are in a curated CT
+database (CTpedia and/or CTexploreR); **72** are screen-only (`daSilva2017`,
 not in a curated CT database). To select by provenance:
 
 ```python
 from tsarina import CTA_evidence
 df = CTA_evidence()
-curated = df[df["source_databases"].str.contains("CTpedia|CTexploreR")]   # 285
-screen_only = df[~df["source_databases"].str.contains("CTpedia|CTexploreR")]  # 75 (daSilva)
+curated = df[df["source_databases"].str.contains("CTpedia|CTexploreR")]   # 282
+screen_only = df[~df["source_databases"].str.contains("CTpedia|CTexploreR")]  # 72 (daSilva)
 ```
 
 (The literature/EWSR1-FLI1 sources listed above confirmed genes already present
 in the curated databases — none entered the panel by literature scan alone.)
+
+### Non-CTA exclusions (conserved/multicopy families)
+
+A few genes enter the CTA universe via a source database but are **not** cancer-
+testis antigens — conserved/multicopy housekeeping families and a placental
+gene. They can even pass the reproductive-restriction filter on a testis-
+enriched copy, yet they make poor targets (ubiquitous/essential proteins) and
+pollute any CTA-keyed sequence/expression analysis. They are dropped from the
+universe at load time via `tsarina.tissues.NON_CTA_EXCLUDED_GENE_IDS`
+(tsarina#92):
+
+| excluded | family | why not a CTA |
+|---|---|---|
+| `H4C6`, `H2BC1`, `H2BC3` | core histones (H4, H2B) | conserved, multicopy nucleosome core |
+| `TUBA3C`, `TUBA3E` | alpha-tubulins | essential cytoskeleton |
+| `CGB8` | chorionic gonadotropin beta | placental, multicopy |
+
+Testis-specific histone *variants* (e.g. `H1-6` / HIST1H1T) are genuine CTAs and
+are **kept** — the exclusion is a curated per-gene deny-list, not a blanket
+family filter.
 
 ## HPA tissue expression annotation
 

--- a/tests/test_gene_sets.py
+++ b/tests/test_gene_sets.py
@@ -17,11 +17,11 @@ from tsarina import (
 
 
 def test_gene_names_nonempty():
-    assert len(CTA_gene_names()) == 263
+    assert len(CTA_gene_names()) == 260
 
 
 def test_gene_ids_nonempty():
-    assert len(CTA_gene_ids()) == 263
+    assert len(CTA_gene_ids()) == 260
 
 
 def test_expressed_is_strict_subset_of_filtered():
@@ -278,3 +278,24 @@ def test_aliases_backfilled_for_most_genes():
     df = CTA_evidence()
     with_aliases = (df["Aliases"].fillna("").astype(str).str.len() > 0).sum()
     assert with_aliases >= 300
+
+
+def test_non_cta_conserved_genes_excluded_from_universe():
+    """Conserved/multicopy non-CTAs (core histones, alpha-tubulins, hCG-beta)
+    are dropped from the CTA universe (tsarina#92); testis-specific histone
+    variants are kept."""
+    from tsarina import CTA_evidence, CTA_unfiltered_gene_names
+
+    universe = CTA_unfiltered_gene_names()
+    evidence_symbols = set(CTA_evidence()["Symbol"])
+    for gene in ("H4C6", "H2BC1", "H2BC3", "CGB8", "TUBA3C", "TUBA3E"):
+        assert gene not in universe, f"{gene} should be excluded from the universe"
+        assert gene not in evidence_symbols, f"{gene} should not be a CTA_evidence row"
+    # The testis-specific linker histone H1t (H1-6) is a legit CTA — kept.
+    assert "H1-6" in universe
+
+
+def test_non_cta_exclusion_preserves_evidence_unfiltered_invariant():
+    from tsarina import CTA_evidence, CTA_unfiltered_gene_names
+
+    assert len(CTA_evidence()) == len(CTA_unfiltered_gene_names())

--- a/tests/test_tiers.py
+++ b/tests/test_tiers.py
@@ -242,11 +242,11 @@ def test_csv_has_no_runtime_ms_count_columns():
 
 
 def test_gene_names_count_unchanged():
-    assert len(CTA_gene_names()) == 263
+    assert len(CTA_gene_names()) == 260
 
 
 def test_filtered_count_unchanged():
-    assert len(CTA_filtered_gene_names()) == 283
+    assert len(CTA_filtered_gene_names()) == 280
 
 
 # ── assign_all_axes runtime consistency ──────────────────────────────────

--- a/tsarina/loader.py
+++ b/tsarina/loader.py
@@ -24,8 +24,16 @@ LEGACY_FILTERED_COLUMN = "filtered"
 
 @lru_cache(maxsize=1)
 def _load_cta_dataframe() -> pd.DataFrame:
+    from .tissues import NON_CTA_EXCLUDED_GENE_IDS
+
     path = join(_DATA_DIR, "cancer-testis-antigens.csv")
     df = pd.read_csv(path)
+    # Drop non-CTA conserved/multicopy genes that entered via a source DB
+    # (core histones, alpha-tubulins, hCG-beta) so they don't pollute the CTA
+    # universe or pass the filter on a testis-enriched copy.  See tsarina#92.
+    if "Ensembl_Gene_ID" in df.columns and NON_CTA_EXCLUDED_GENE_IDS:
+        unversioned = df["Ensembl_Gene_ID"].astype(str).str.split(".").str[0]
+        df = df[~unversioned.isin(NON_CTA_EXCLUDED_GENE_IDS)].reset_index(drop=True)
     # Surface the legacy inclusion flag alongside the canonical one so
     # downstream consumers that still schema-check for ``filtered`` (e.g.
     # pirlygenes pre-#241) can read the live tsarina table without

--- a/tsarina/tissues.py
+++ b/tsarina/tissues.py
@@ -93,6 +93,25 @@ MANUALLY_EXPRESSED_CTA: frozenset[str] = frozenset(
     }
 )
 
+#: Genes that entered the CTA universe via a source database but are NOT cancer-
+#: testis antigens: conserved/multicopy housekeeping families (core histones,
+#: alpha-tubulins) and placental chorionic gonadotropin.  These can pass the
+#: reproductive-restriction filter on a testis-enriched copy, yet they make poor
+#: targets (ubiquitous/essential proteins) and pollute any CTA-keyed sequence or
+#: expression analysis.  Dropped from the universe at load time.  Keyed by
+#: (unversioned) Ensembl gene ID.  See tsarina#92.  Note: testis-specific
+#: histone variants (e.g. H1-6 / HIST1H1T) are deliberately NOT excluded.
+NON_CTA_EXCLUDED_GENE_IDS: frozenset[str] = frozenset(
+    {
+        "ENSG00000274618",  # H4C6   -- core histone H4 (conserved/multicopy)
+        "ENSG00000146047",  # H2BC1  -- core histone H2B
+        "ENSG00000276410",  # H2BC3  -- core histone H2B
+        "ENSG00000213030",  # CGB8   -- chorionic gonadotropin beta (placental)
+        "ENSG00000198033",  # TUBA3C -- alpha-tubulin (conserved/essential)
+        "ENSG00000152086",  # TUBA3E -- alpha-tubulin
+    }
+)
+
 # ── Protein reliability ordering ────────────────────────────────────────────
 
 #: HPA antibody reliability tiers, ordered from strongest to weakest.

--- a/tsarina/version.py
+++ b/tsarina/version.py
@@ -10,4 +10,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "1.5.0"
+__version__ = "1.5.1"


### PR DESCRIPTION
## Overview

Closes #92. Core histones, alpha-tubulins, and hCG-beta entered the CTA universe via source DBs but are **not** cancer-testis antigens — conserved/multicopy/essential proteins. They make poor targets and pollute any CTA-keyed sequence/expression analysis.

Worse than the issue implied: **3 of the 6 were passing the filter** (CGB8, TUBA3C, H2BC1 were in the *expressed* `CTA_gene_names()` set), because they happen to be testis-enriched on one copy — orthogonal to the conserved-family problem.

## Fix

- `tsarina.tissues.NON_CTA_EXCLUDED_GENE_IDS` — curated per-gene deny-list (H4C6, H2BC1, H2BC3, TUBA3C, TUBA3E, CGB8), keyed by Ensembl ID with rationale.
- Applied at the **loader chokepoint** (`_load_cta_dataframe`), so the genes drop from `CTA_evidence` / universe / expressed / partition consistently, and the `evidence == unfiltered` invariant is preserved (both shrink together). Mirrors the `MANUALLY_EXPRESSED_CTA` runtime-curation pattern; raw CSV rows are retained.

## Nuance handled

Not a blanket "exclude histones" filter — **`H1-6` (HIST1H1T, the testis-specific linker histone H1t) is a genuine CTA and is kept.** Only the named conserved/multicopy genes are denied. (Flagging separately: `H1-1`, a somatic core-type histone in the universe, wasn't named in #92 — left in pending your call.)

## Counts / tests

`CTA_gene_names()` 263 → 260; `CTA_filtered_gene_names()` 283 → 280; evidence 360 → 354; provenance split 282 curated / 72 screen-only. New tests assert the 6 are excluded, `H1-6` kept, and the invariant holds. `./format.sh`/`./lint.sh`/`./test.sh` (335 passed). Version 1.5.0 → 1.5.1.

Sibling of #93 (missing paralog copies) — not addressed here.