### PR TITLE
Export vital-organ vocabulary for downstream consumers (vaxrank#303)

### DIFF
--- a/docs/curation.md
+++ b/docs/curation.md
@@ -335,6 +335,10 @@ cta_healthy_tissue_ms_hits("MAGEA4")
 (brain / heart / lung / liver / pancreas) — the "which organ / which allele /
 which peptide" detail a per-patient screen needs.
 
+The vital-organ vocabulary is exported for downstream consumers (e.g. vaxrank
+safety scoring): `tsarina.SAFETY_TISSUE_GROUPS` (HPA tissue names, grouped) and
+`tsarina.VITAL_TISSUE_MS_NAMES` (the MS source-tissue spellings).
+
 The same screen is available from the CLI:
 
 ```bash

--- a/tests/test_tiers.py
+++ b/tests/test_tiers.py
@@ -378,3 +378,18 @@ def test_ms_empty_inputs():
     assert "ms_restriction" in result.columns
     assert "ms_ebv_lcl_peptide_count" in result.columns
     assert "ms_cta_exclusive_cancer_peptide_count" in result.columns
+
+
+def test_vital_organ_vocabulary_is_publicly_exported():
+    """The vital-organ vocabulary is consumable from the package top level so
+    downstream tools (e.g. vaxrank safety scoring) share it (vaxrank#303)."""
+    import tsarina
+    from tsarina.tiers import VITAL_TISSUE_MS_NAMES
+
+    assert {"brain", "heart", "lung", "liver", "pancreas"} <= set(tsarina.SAFETY_TISSUE_GROUPS)
+    assert "heart" in tsarina.VITAL_TISSUE_MS_NAMES
+    assert tsarina.VITAL_TISSUE_MS_NAMES is VITAL_TISSUE_MS_NAMES
+    # spanning's internal alias points at the same shared vocabulary
+    from tsarina.spanning import _VITAL_TISSUE_MS_NAMES
+
+    assert _VITAL_TISSUE_MS_NAMES is VITAL_TISSUE_MS_NAMES

--- a/tsarina/__init__.py
+++ b/tsarina/__init__.py
@@ -48,6 +48,8 @@ from .tiers import (
     MS_RESTRICTION_VALUES,
     RESTRICTION_VALUES,
     RNA_RESTRICTION_LEVELS,
+    SAFETY_TISSUE_GROUPS,
+    VITAL_TISSUE_MS_NAMES,
 )
 from .tissues import (
     CORE_REPRODUCTIVE_TISSUES,
@@ -68,6 +70,8 @@ __all__ = [
     "PERMISSIVE_REPRODUCTIVE_TISSUES",
     "RESTRICTION_VALUES",
     "RNA_RESTRICTION_LEVELS",
+    "SAFETY_TISSUE_GROUPS",
+    "VITAL_TISSUE_MS_NAMES",
     "CTA_by_axes",
     "CTA_detailed_evidence",
     "CTA_evidence",

--- a/tsarina/spanning.py
+++ b/tsarina/spanning.py
@@ -132,17 +132,9 @@ _VITAL_TISSUE_RNA_COLUMNS: tuple[str, ...] = (
     "rna_liver_max_ntpm",
     "rna_pancreas_max_ntpm",
 )
-_VITAL_TISSUE_MS_NAMES: frozenset[str] = frozenset(
-    {
-        "brain",
-        "central nervous system (cns)",
-        "cerebellum",
-        "heart",
-        "lung",
-        "liver",
-        "pancreas",
-    }
-)
+# Vital-organ MS tissue vocabulary now lives in tiers.py (public, shared with
+# downstream consumers); keep the private alias for internal use here.
+from .tiers import VITAL_TISSUE_MS_NAMES as _VITAL_TISSUE_MS_NAMES  # noqa: E402
 
 _MS_SOURCE_FLAG_DEFAULTS: dict[str, bool] = {
     "src_cancer": False,

--- a/tsarina/tiers.py
+++ b/tsarina/tiers.py
@@ -96,6 +96,23 @@ SAFETY_TISSUE_GROUPS: dict[str, set[str]] = {
 #: Default nTPM threshold for safety flags.
 SAFETY_NTPM_THRESHOLD: float = 5.0
 
+#: Vital-organ tissue names as they appear in MS (immunopeptidome) source-tissue
+#: fields — the MS-side counterpart of :data:`SAFETY_TISSUE_GROUPS` (which uses
+#: HPA tissue names).  A healthy-tissue MS hit in one of these is a vital-organ
+#: off-target signal.  Public so downstream consumers (e.g. vaxrank safety
+#: scoring) can screen against the same vocabulary.  See tsarina#76 / vaxrank#303.
+VITAL_TISSUE_MS_NAMES: frozenset[str] = frozenset(
+    {
+        "brain",
+        "central nervous system (cns)",
+        "cerebellum",
+        "heart",
+        "lung",
+        "liver",
+        "pancreas",
+    }
+)
+
 
 # ── Rank functions ─────────────────────────────────────────────────────────
 

--- a/tsarina/version.py
+++ b/tsarina/version.py
@@ -10,4 +10,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "1.5.3"
+__version__ = "1.5.4"


### PR DESCRIPTION
## Overview

Concrete tsarina-side support for openvax/vaxrank#303, which (per its §3.3 "consume the pirl-unc stack") wants tsarina's **vital-organ vocabulary** for per-peptide safety scoring — but had to reach into internals: `SAFETY_TISSUE_GROUPS` wasn't exported from the top level, and `VITAL_TISSUE_MS_NAMES` was a private symbol (`spanning._VITAL_TISSUE_MS_NAMES`).

## Change (no behavior change)

- Move the MS vital-tissue vocabulary to `tiers.py` as public **`VITAL_TISSUE_MS_NAMES`**, alongside `SAFETY_TISSUE_GROUPS` (the two are the MS-side and HPA-side views of the same vital organs). `spanning.py` keeps a private alias so internal use is untouched.
- Export **`SAFETY_TISSUE_GROUPS`** and **`VITAL_TISSUE_MS_NAMES`** from the `tsarina` top level.

Now `from tsarina import SAFETY_TISSUE_GROUPS, VITAL_TISSUE_MS_NAMES` works — vaxrank can screen against the same vocabulary tsarina curates on.

## Notes
- This is the last concrete tsarina-side dependency in #303; the rest (CTA self-subtraction via `CTA_unfiltered_gene_ids()`, tiers via `CTA_by_axes`/`CTA_evidence`, the per-peptide screen, viral/hotspot sets) was already in place — and #92/#93 cleaned/completed the universe #303 subtracts from.
- Tests assert both names import from the top level and that spanning's alias points at the shared object. `./format.sh`/`./lint.sh`/`./test.sh` (338 passed). Version 1.5.3 → 1.5.4.