### PR TITLE
Harden vital-organ MS safety screen against false matches

### DIFF
--- a/tests/test_ms_evidence.py
+++ b/tests/test_ms_evidence.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 
 import pandas as pd
+import pytest
 
 from tsarina.ms_evidence import (
     aggregate_ms_hits_by_peptide,
@@ -155,3 +156,113 @@ def test_cta_healthy_tissue_ms_hits_empty_when_no_healthy_hits(monkeypatch):
 
     out = cta_healthy_tissue_ms_hits("PRAME")
     assert out.empty
+
+
+# ── Vital-organ matcher (_is_vital_organ_tissue) ──────────────────────────────
+
+
+def test_vital_organ_matcher_covers_safety_source_of_truth():
+    """The MS screen must flag every tissue in the RNA-side vital vocabulary.
+
+    Guards against drift: if a tissue is added to SAFETY_TISSUE_GROUPS or
+    VITAL_TISSUE_MS_NAMES, this fails until the MS screen covers it too.
+    """
+    from tsarina.ms_evidence import _is_vital_organ_tissue
+    from tsarina.tiers import SAFETY_TISSUE_GROUPS, VITAL_TISSUE_MS_NAMES
+
+    source_of_truth = set().union(*SAFETY_TISSUE_GROUPS.values()) | set(VITAL_TISSUE_MS_NAMES)
+    missed = sorted(name for name in source_of_truth if not _is_vital_organ_tissue(name))
+    assert missed == []
+
+
+@pytest.mark.parametrize(
+    "tissue",
+    [
+        # heart
+        "Heart",
+        "heart muscle",
+        "Cardiac muscle",
+        "myocardium",
+        "left ventricle myocardium",
+        # lung
+        "Lung",
+        "pulmonary",
+        # liver
+        "Liver",
+        "livers",
+        "hepatic tissue",
+        "hepatocyte",
+        # pancreas
+        "Pancreas",
+        "pancreatic islets",
+        "islets of Langerhans",
+        # brain / CNS (incl. cortex spellings and subregions)
+        "Brain",
+        "midbrain",
+        "brainstem",
+        "Cerebellum",
+        "cerebellar cortex",
+        "Cerebral cortex",
+        "frontal cortex",
+        "visual cortex",
+        "Central nervous system (CNS)",
+        "CNS",
+        "spinal cord",
+        "Hippocampus",
+        "hippocampal formation",
+        "amygdala",
+        "thalamus",
+        "hypothalamus",
+        "pons",
+        "basal ganglia",
+        "choroid plexus",
+        "medulla oblongata",
+        "white matter",
+        "retina",
+    ],
+)
+def test_vital_organ_matcher_true(tissue):
+    from tsarina.ms_evidence import _is_vital_organ_tissue
+
+    assert _is_vital_organ_tissue(tissue) is True
+
+
+@pytest.mark.parametrize(
+    "tissue",
+    [
+        "",
+        "Blood",
+        "Bone Marrow",
+        "Skin",
+        "Breast",
+        "Colon",
+        "Kidney",
+        "Stomach",
+        "Lymph Node",
+        # non-CNS cortices must NOT masquerade as brain
+        "adrenal cortex",
+        "renal cortex",
+        "kidney cortex",
+        "ovarian cortex",
+        "lymph node cortex",
+        "thymic cortex",
+        # bare "medulla" names adrenal/renal medulla, not brain
+        "adrenal medulla",
+        "renal medulla",
+        # expected-tissue / unrelated
+        "thymus",
+        "testis",
+        "ovary",
+        "placenta",
+        # substring traps
+        "delivery",
+        "striated muscle",
+        "skeletal muscle",
+        "gastric cardia",
+        "melanoma",
+    ],
+)
+def test_vital_organ_matcher_false(tissue):
+    from tsarina.ms_evidence import _is_vital_organ_tissue
+
+    assert _is_vital_organ_tissue(tissue) is False

--- a/tsarina/ms_evidence.py
+++ b/tsarina/ms_evidence.py
@@ -14,9 +14,12 @@
 
 from __future__ import annotations
 
+import re
 from pathlib import Path
 
 import pandas as pd
+
+from .tiers import SAFETY_TISSUE_GROUPS, VITAL_TISSUE_MS_NAMES
 
 SOURCE_FLAG_OUTPUTS: dict[str, str] = {
     "src_cancer": "ms_cancer",
@@ -146,13 +149,102 @@ def aggregate_ms_hits_for_iedb_columns(hits: pd.DataFrame) -> pd.DataFrame:
     )[["peptide", "iedb_hit_count", "iedb_alleles"]]
 
 
-#: Substrings flagging an MS source tissue as a vital organ (per
-#: ``tiers.SAFETY_TISSUE_GROUPS`` — brain/heart/lung/liver/pancreas — plus the
-#: CNS spellings MS datasets use).  Matched case-insensitively against the row's
-#: source tissue.
-_VITAL_ORGAN_KEYWORDS: frozenset[str] = frozenset(
-    {"brain", "cerebell", "cns", "cortex", "heart", "lung", "liver", "pancrea"}
+#: Exact vital-organ tissue names, taken verbatim from the RNA-side safety
+#: vocabulary so this MS screen can never drift from it: every brain subregion
+#: in :data:`tiers.SAFETY_TISSUE_GROUPS` (plus heart/lung/liver/pancreas) and the
+#: MS-specific spellings in :data:`tiers.VITAL_TISSUE_MS_NAMES` (e.g.
+#: ``"central nervous system (cns)"``).  Any one of these is a vital organ.
+_VITAL_ORGAN_EXACT_NAMES: frozenset[str] = frozenset().union(*SAFETY_TISSUE_GROUPS.values()) | {
+    name.lower() for name in VITAL_TISSUE_MS_NAMES
+}
+
+#: Stems flagging an MS source tissue / cell name as a vital organ
+#: (brain/CNS, heart, lung, liver, pancreas) -- the MS-side counterpart of
+#: :data:`tiers.SAFETY_TISSUE_GROUPS`.  Stems (not whole words) so spelling
+#: variants and inflections are caught: ``hepat`` -> hepatic/hepatocyte,
+#: ``cerebr`` -> cerebral/cerebrum, ``thalam`` -> thalamus/hypothalamus,
+#: ``myocard`` -> myocardium/myocardial, ``pulmonar`` -> pulmonary.  Matched as
+#: plain substrings so compound names match too (``brain`` -> midbrain/
+#: brainstem; ``medulla oblongata`` avoids bare ``medulla``, which also names
+#: the non-vital adrenal/renal medulla).  Brain/CNS gets the widest net because
+#: a missed vital-organ hit (false negative) is worse for a safety screen than
+#: an over-flag.
+_VITAL_ORGAN_SUBSTRINGS: tuple[str, ...] = (
+    # brain / CNS
+    "brain",
+    "cerebr",
+    "cerebell",
+    "central nervous system",
+    "spinal cord",
+    "hippocamp",
+    "amygdala",
+    "thalam",
+    "basal ganglia",
+    "choroid plexus",
+    "medulla oblongata",
+    "white matter",
+    "retina",
+    # heart
+    "heart",
+    "cardiac",
+    "myocard",
+    # lung
+    "lung",
+    "pulmonar",
+    # liver
+    "hepat",
+    # pancreas
+    "pancrea",
+    "islet",
 )
+
+#: Short/ambiguous vital-organ stems matched at a word boundary so they cannot
+#: appear spuriously inside an unrelated tissue: ``\bliver`` does not match
+#: ``deliver``; ``cns``/``pons`` stay whole words.
+_VITAL_ORGAN_WORD_BOUNDED: tuple[str, ...] = ("cns", "liver", "pons")
+
+_VITAL_ORGAN_REGEX = re.compile(
+    "|".join(
+        [
+            *(re.escape(stem) for stem in _VITAL_ORGAN_SUBSTRINGS),
+            *(rf"\b{re.escape(stem)}" for stem in _VITAL_ORGAN_WORD_BOUNDED),
+        ]
+    )
+)
+
+#: Organ qualifiers that make a ``"... cortex"`` non-CNS, and therefore NOT a
+#: vital organ.  ``"renal"`` also covers ``"adrenal"`` (substring), but both are
+#: listed for clarity; ``"ovar"`` covers ovary/ovarian, ``"thym"`` thymic/thymus,
+#: ``"lymph"``/``"nodal"`` lymph-node cortex.  Everything else containing
+#: ``"cortex"`` (cerebral, frontal, temporal, motor, visual, ...) is treated as
+#: brain -- an inclusive bias appropriate for a safety screen.
+_NON_CNS_CORTEX_QUALIFIERS: tuple[str, ...] = (
+    "adrenal",
+    "renal",
+    "kidney",
+    "ovar",
+    "thym",
+    "lymph",
+    "nodal",
+)
+
+
+def _is_vital_organ_tissue(tissue: str) -> bool:
+    """Whether an MS source-tissue / cell name denotes a vital organ.
+
+    Vital organs are brain/CNS, heart, lung, liver, and pancreas -- the
+    MS-side counterpart of :data:`tiers.SAFETY_TISSUE_GROUPS`.  Matching is
+    case-insensitive and whitespace-normalized.
+    """
+    text = " ".join(str(tissue).lower().split())
+    if not text:
+        return False
+    if text in _VITAL_ORGAN_EXACT_NAMES:
+        return True
+    if "cortex" in text and not any(q in text for q in _NON_CNS_CORTEX_QUALIFIERS):
+        return True
+    return _VITAL_ORGAN_REGEX.search(text) is not None
+
 
 CTA_HEALTHY_TISSUE_MS_COLUMNS: list[str] = [
     "peptide",
@@ -212,8 +304,7 @@ def cta_healthy_tissue_ms_hits(
     if "cell_name" in hits.columns:
         cell = hits["cell_name"].fillna("").astype(str)
         tissue = tissue.where(tissue.str.strip() != "", cell)
-    low = tissue.str.lower()
-    vital = low.map(lambda t: any(keyword in t for keyword in _VITAL_ORGAN_KEYWORDS))
+    vital = tissue.map(_is_vital_organ_tissue)
 
     out = pd.DataFrame(
         {

--- a/tsarina/version.py
+++ b/tsarina/version.py
@@ -10,4 +10,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "1.5.4"
+__version__ = "1.5.5"


### PR DESCRIPTION
## What

Hardens the vital-organ matcher behind \`cta_healthy_tissue_ms_hits()\` (the \`tsarina hits --healthy-tissue\` safety screen). Follow-up to the bug/typo review of the recent CTA-curation work.

## Why

The screen flagged vital-organ off-targets with a bare substring keyword set: \`{brain, cerebell, cns, cortex, heart, lung, liver, pancrea}\`, matched via \`keyword in tissue\`. Two robustness gaps:

- **\`"cortex"\` false positives** — bare \`cortex\` also matches the non-CNS **adrenal cortex / renal cortex / ovarian cortex / lymph-node cortex**, mislabeling them as brain (\`vital_organ=True\`).
- **fragile substring matching** — \`"liver"\` is a substring of \`"deliver"\`; a bare \`"medulla"\` stem would have matched the non-vital **adrenal/renal medulla**.

## How

Replace the flat keyword set with a layered, exhaustive, drift-proof matcher (\`_is_vital_organ_tissue\`):

1. **Exact-name set** derived directly from \`tiers.SAFETY_TISSUE_GROUPS\` + \`tiers.VITAL_TISSUE_MS_NAMES\` — the MS screen can no longer drift from the RNA-side safety vocabulary (fixes a latent maintenance hazard flagged in review).
2. **Exhaustive stem set** matched as substrings so spelling variants/inflections and compound names are caught: all brain subregions, \`heart/cardiac/myocard\`, \`lung/pulmonar\`, \`hepat\`, \`pancrea/islet\`. \`medulla oblongata\` is used (never bare \`medulla\`).
3. **Word-boundary anchoring** for short/ambiguous stems (\`cns\`, \`liver\`, \`pons\`) so they can't appear spuriously inside an unrelated tissue (\`\bliver\` ≠ \`deliver\`).
4. **\`cortex\` inclusive-with-exclusions**: treated as CNS unless qualified by a non-CNS organ (\`adrenal/renal/kidney/ovarian/thymic/lymph-node\`). Inclusive bias is correct for a safety screen — a missed vital-organ hit (false negative) is worse than an over-flag, and this now catches \`frontal/temporal/visual/... cortex\` too.

## Tests

- **Drift guard**: asserts every \`SAFETY_TISSUE_GROUPS\` / \`VITAL_TISSUE_MS_NAMES\` entry is matched.
- Parametrized **true** cases (spelling variants across all 5 organ systems + brain subregions) and **false** cases (the non-CNS cortices, adrenal/renal medulla, and substring traps \`delivery\`/\`striated muscle\`/\`gastric cardia\`).

All 401 tests pass; \`format.sh\`/\`lint.sh\` clean. Patch bump 1.5.4 → 1.5.5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)