### PR TITLE
Audit hygiene: drop dead HPA fraction path; harden tissue derivation (P3)

### DIFF
--- a/tests/test_tissues.py
+++ b/tests/test_tissues.py
@@ -55,6 +55,16 @@ def test_adaptive_thresholds():
     assert adaptive_rna_threshold("no data") == 0.97
 
 
+def test_adaptive_threshold_normalizes_whitespace_and_case():
+    # Non-canonical labels must map to their tier, not silently fall to "Missing".
+    assert adaptive_rna_threshold(" Enhanced ") == 0.80
+    assert adaptive_rna_threshold("enhanced") == 0.80
+    assert adaptive_rna_threshold("SUPPORTED") == 0.90
+    # Genuinely unknown labels still use the strict "Missing" floor.
+    assert adaptive_rna_threshold("bogus") == 0.97
+    assert adaptive_rna_threshold("Missing") == 0.97
+
+
 def test_threshold_order_is_monotonic():
     tiers = ["Enhanced", "Supported", "Approved", "Uncertain"]
     thresholds = [HPA_ADAPTIVE_PROTEIN_RNA_THRESHOLDS[t] for t in tiers]

--- a/tsarina/hpa.py
+++ b/tsarina/hpa.py
@@ -13,9 +13,14 @@
 """Human Protein Atlas tissue expression enrichment for CTA gene evidence.
 
 Ingests raw HPA data files (proteinatlas.tsv, normal_tissue.tsv,
-rna_tissue_consensus.tsv) and computes ~30 tissue restriction columns
-per gene: deflated nTPM fractions, protein support rankings, adaptive
-confidence thresholds, and composite restriction flags.
+rna_tissue_consensus.tsv) and computes tissue restriction columns per
+gene: per-tissue nTPM maps/sets, protein support rankings, and
+core-restriction flags.
+
+The bundled CTA table's filter-driving columns (``rna_deflated_reproductive_frac``,
+``passes_filters``) are produced by the regeneration scripts in ``scripts/``
+(see ``add_cta_gene.py``), not here -- this module only enriches ad-hoc
+evidence frames via :func:`tsarina.evidence.CTA_detailed_evidence`.
 
 Typical usage::
 
@@ -32,13 +37,11 @@ from __future__ import annotations
 
 from pathlib import Path
 
-import numpy as np
 import pandas as pd
 
 from .tissues import (
     CORE_REPRODUCTIVE_TISSUES,
     EXTENDED_REPRODUCTIVE_TISSUES,
-    HPA_ADAPTIVE_PROTEIN_RNA_THRESHOLDS,
     HPA_MARKER_STRICT_MAX_RNA_TISSUES,
     PERMISSIVE_REPRODUCTIVE_TISSUES,
 )
@@ -80,23 +83,6 @@ def parse_ntpm_entries(value) -> dict[str, float]:
     return entries
 
 
-def deflated_ntpm_map(entries: dict[str, float]) -> dict[str, float]:
-    """Apply deflation: max(0, nTPM - 1) per tissue."""
-    return {tissue: max(0.0, val - 1.0) for tissue, val in entries.items()}
-
-
-def reproductive_fraction_weighted(entries: dict[str, float], allowed: frozenset[str]) -> float:
-    """Compute deflated reproductive fraction from nTPM map."""
-    if not entries:
-        return np.nan
-    weighted = deflated_ntpm_map(entries)
-    total = float(sum(weighted.values()))
-    if total <= 0:
-        return 1.0
-    repro_total = float(sum(v for t, v in weighted.items() if t in allowed))
-    return repro_total / total
-
-
 def best_protein_support_label(has_protein: bool, reliability: str) -> str:
     """Return the best HPA protein reliability tier from a semicolon-separated string."""
     if not has_protein:
@@ -119,9 +105,10 @@ def enrich_hpa_evidence(
 ) -> pd.DataFrame:
     """Enrich a gene DataFrame with HPA tissue restriction columns.
 
-    Computes ~30 columns of tissue restriction evidence from Human Protein
-    Atlas data, including deflated nTPM fractions, protein support rankings,
-    adaptive confidence thresholds, and composite restriction flags.
+    Computes per-tissue RNA nTPM maps/sets, protein support rankings, and
+    core-restriction flags from Human Protein Atlas data.  The deflated
+    reproductive-fraction filter that drives the bundled CTA table lives in
+    ``scripts/`` (see module docstring), not here.
 
     Parameters
     ----------
@@ -141,7 +128,7 @@ def enrich_hpa_evidence(
     Returns
     -------
     pd.DataFrame
-        Input DataFrame with ~30 additional HPA evidence columns.
+        Input DataFrame with additional HPA evidence columns.
     """
     df = gene_df.copy()
 
@@ -225,60 +212,11 @@ def enrich_hpa_evidence(
         lambda ts: ";".join(sorted(ts - EXTENDED_REPRODUCTIVE_TISSUES))
     )
 
-    # Deflated reproductive fractions
-    df["rna_reproductive_fraction_weighted__core"] = df["rna_tissue_ntpm_map"].map(
-        lambda m: reproductive_fraction_weighted(m, CORE_REPRODUCTIVE_TISSUES)
-    )
-    df["rna_reproductive_fraction_weighted__extended"] = df["rna_tissue_ntpm_map"].map(
-        lambda m: reproductive_fraction_weighted(m, EXTENDED_REPRODUCTIVE_TISSUES)
-    )
-
-    # Threshold flags
-    core_frac = df["rna_reproductive_fraction_weighted__core"].fillna(-1)
-    ext_frac = df["rna_reproductive_fraction_weighted__extended"].fillna(-1)
-    df["rna_repro_frac_ge_0_80__extended"] = ext_frac.ge(0.80)
-    df["rna_repro_frac_ge_0_90__core"] = core_frac.ge(0.90)
-    df["rna_repro_frac_ge_0_90__extended"] = ext_frac.ge(0.90)
-    df["rna_repro_frac_ge_0_95__extended"] = ext_frac.ge(0.95)
-    df["rna_repro_frac_ge_0_98__extended"] = ext_frac.ge(0.98)
-    df["rna_repro_frac_ge_0_99__extended"] = ext_frac.ge(0.99)
-
-    # Adaptive confidence: protein tier → required RNA fraction
-    df["protein_confidence_tier"] = df["hpa_best_protein_support"]
-    df["adaptive_rna_fraction_required"] = df["protein_confidence_tier"].map(
-        HPA_ADAPTIVE_PROTEIN_RNA_THRESHOLDS
-    )
-
-    # Has evidence flags
-    if "protein_reproductive" not in df.columns:
-        df["protein_reproductive"] = df["protein_core_restricted"]
-    df["protein_reproductive_or_missing"] = df["protein_reproductive"].fillna(False) | (
-        df["hpa_best_protein_support"] == "Missing"
-    )
-
-    has_rna = df["rna_tissue_set"].map(lambda ts: len(ts) > 0)
-
-    # Composite restriction flags
-    df["hpa_adaptive_confidence_restricted"] = (
-        df["protein_reproductive_or_missing"]
-        & has_rna
-        & ext_frac.ge(
-            df["adaptive_rna_fraction_required"].fillna(
-                HPA_ADAPTIVE_PROTEIN_RNA_THRESHOLDS["Missing"]
-            )
-        )
-    )
-
+    # Composite restriction flag: protein-reliable, core-restricted, few RNA tissues.
     df["hpa_marker_strict_restricted"] = (
         df["protein_core_restricted"]
         & df["hpa_protein_reliability_enhanced"]
         & df["rna_detected_tissues_le_7"]
-    )
-
-    df["hpa_marker_extended_rna80_restricted"] = (
-        df["protein_core_restricted"]
-        & df["hpa_protein_reliability_enhanced"]
-        & df["rna_repro_frac_ge_0_80__extended"]
     )
 
     return df

--- a/tsarina/tiers.py
+++ b/tsarina/tiers.py
@@ -71,6 +71,17 @@ _NON_SOMATIC: frozenset[str] = PERMISSIVE_REPRODUCTIVE_TISSUES | frozenset({"thy
 
 #: Safety-critical tissue groups with nTPM threshold.
 #: Genes with max nTPM >= threshold in any tissue in the group get flagged.
+#:
+#: The ``brain`` group spans two HPA vocabularies on purpose.  Ten names are
+#: present in the bulk ``rna_tissue_consensus`` and so drive the RNA safety flag
+#: (``rna_brain_max_ntpm``): amygdala, basal ganglia, cerebellum, cerebral
+#: cortex, choroid plexus, hippocampal formation, hypothalamus, midbrain,
+#: retina, spinal cord.  Four names (medulla oblongata, pons, thalamus, white
+#: matter) come from HPA's finer brain-specific dataset; they are absent from
+#: the consensus -- inert for the RNA flag (``.get(t, 0.0)``) -- but are kept
+#: because the MS vital-organ screen
+#: (:data:`tsarina.ms_evidence._VITAL_ORGAN_EXACT_NAMES`) derives its vocabulary
+#: from this group and immunopeptidome ``source_tissue`` fields do use them.
 SAFETY_TISSUE_GROUPS: dict[str, set[str]] = {
     "brain": {
         "amygdala",
@@ -84,6 +95,7 @@ SAFETY_TISSUE_GROUPS: dict[str, set[str]] = {
         "midbrain",
         "pons",
         "retina",
+        "spinal cord",
         "thalamus",
         "white matter",
     },

--- a/tsarina/tissues.py
+++ b/tsarina/tissues.py
@@ -181,9 +181,10 @@ def adaptive_rna_threshold(protein_reliability: str) -> float:
         Minimum deflated reproductive fraction required to pass the
         adaptive confidence filter.
     """
-    key = (
-        protein_reliability
-        if protein_reliability in HPA_ADAPTIVE_PROTEIN_RNA_THRESHOLDS
-        else "Missing"
-    )
+    # Normalize whitespace/case so a non-canonical label (e.g. " enhanced ")
+    # maps to its tier instead of silently falling back to the strict "Missing"
+    # threshold.  Unknown labels (incl. "no data") use the "Missing" floor.
+    normalized = str(protein_reliability).strip().casefold()
+    by_casefold = {k.casefold(): k for k in HPA_ADAPTIVE_PROTEIN_RNA_THRESHOLDS}
+    key = by_casefold.get(normalized, "Missing")
     return HPA_ADAPTIVE_PROTEIN_RNA_THRESHOLDS[key]

--- a/tsarina/version.py
+++ b/tsarina/version.py
@@ -10,4 +10,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "1.5.5"
+__version__ = "1.5.6"


### PR DESCRIPTION
Follow-up to the full tissue-derivation audit. The three P3 (low-risk hygiene) items the audit surfaced. No change to the bundled gene sets.

## hpa.py — remove dead, divergent deflated-fraction implementation
`enrich_hpa_evidence` computed a parallel deflated reproductive-fraction filter (`reproductive_fraction_weighted`, `deflated_ntpm_map`, `rna_reproductive_fraction_weighted__core/__extended`, `rna_repro_frac_ge_*`, `adaptive_rna_fraction_required`, `hpa_adaptive_confidence_restricted`, `hpa_marker_extended_rna80_restricted`).

- **Zero consumers / tests** — `evidence.py` only uses `rna_tissue_ntpm_map` from this function; nothing reads the fraction columns and no test references them (verified).
- **Divergent** — it used `EXTENDED` reproductive while the live filter (`scripts/add_cta_gene.py`) uses `CORE`, a latent maintainer trap.

Removed it (and now-orphaned `numpy`/`HPA_ADAPTIVE_PROTEIN_RNA_THRESHOLDS` imports), kept the fraction-independent `hpa_marker_strict_restricted`, and updated docstrings to point at `scripts/` as the source of `passes_filters`.

## tiers.py — close brain-group gap + document dual vocabulary
- Added `spinal cord` to `SAFETY_TISSUE_GROUPS["brain"]` — it's a consensus tissue that was in **no** safety group, so a spinal-cord-only CNS gene escaped the RNA safety flag.
- Documented that the brain group spans two HPA vocabularies: 10 names live in the consensus and drive `rna_brain_max_ntpm`; `medulla oblongata/pons/thalamus/white matter` are consensus-absent (inert for the RNA flag) but feed the MS vital-organ screen, which derives its vocabulary from this group.

## tissues.py — harden `adaptive_rna_threshold`
Strip + casefold the tier label so a non-canonical string (`" Enhanced "`, `"enhanced"`) maps to its tier instead of silently falling to the strict 0.97 `Missing` floor. Unknown labels still use `Missing`.

## Safety of the change
The bundled CSV's stored columns are unchanged, so **no gene-set membership shifts**. The spinal-cord addition affects only future regeneration and the MS screen (already covered by the drift-guard test). New test for the threshold normalization. 402 tests pass; lint/format clean. Patch bump 1.5.5 → 1.5.6.

> Note: the larger P1 item from the audit (mixed HPA provenance in the bundled table — ~7 genes would flip membership under current HPA) is being handled separately via a full-regeneration script + delta review, per decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)