### PR TITLE
Add versioned reference-data CLI: tsarina data sources

### DIFF
--- a/scripts/cta_sources.py
+++ b/scripts/cta_sources.py
@@ -12,74 +12,63 @@
 
 """Reproducible source-data fetchers for the CTA curation scripts.
 
-Each curation script (``add_xage2.py``, ``add_cta_gene.py``,
-``backfill_aliases.py``) depends on a large upstream reference file (HPA RNA
-tissue consensus, NCBI ``gene_info``).  These helpers download and cache those
-files on demand so the scripts are self-contained, durable artifacts — re-run
-any of them later and the source is fetched fresh, no manual ``/tmp`` setup.
+Thin wrappers over :mod:`tsarina.reference_data` (the versioned download/cache
+layer also exposed as ``tsarina data sources``), so the curation scripts and the
+CLI share one version-stamped cache.  Each helper accepts an optional explicit
+local path/URL override; otherwise it returns the cached pinned-version copy,
+downloading on demand.
 
-Cache lives at ``<repo>/.cache/`` (gitignored).  Pass an explicit local path to
-any of the scripts' ``--*`` source flags to use a pre-downloaded copy instead.
+Inspect or pre-fetch from the CLI::
+
+    tsarina data sources list
+    tsarina data sources download
 """
 
 from __future__ import annotations
 
-import urllib.request
-import zipfile
 from pathlib import Path
 
-_REPO_ROOT = Path(__file__).resolve().parent.parent
-_CACHE_DIR = _REPO_ROOT / ".cache"
+REPO_ROOT = Path(__file__).resolve().parent.parent
+import sys  # noqa: E402
 
-RNA_TISSUE_CONSENSUS_URL = "https://www.proteinatlas.org/download/tsv/rna_tissue_consensus.tsv.zip"
-NCBI_GENE_INFO_URL = (
-    "https://ftp.ncbi.nlm.nih.gov/gene/DATA/GENE_INFO/Mammalia/Homo_sapiens.gene_info.gz"
-)
+sys.path.insert(0, str(REPO_ROOT))
+
+from tsarina import reference_data  # noqa: E402
 
 
-def _download(url: str, dest: Path) -> None:
-    _CACHE_DIR.mkdir(exist_ok=True)
-    print(f"  downloading {url} -> {dest} ...")
-    with urllib.request.urlopen(url, timeout=300) as response:
-        dest.write_bytes(response.read())
+def _resolve(name: str, source: str | None, version: str | None = None) -> Path:
+    """Return a local path for *name*, honoring an explicit local/URL override."""
+    if source is None:
+        return reference_data.ensure(name, version=version)
+    if not source.startswith(("http://", "https://")):
+        # Explicit local file (e.g. a pre-downloaded .tsv) — use as-is.
+        return Path(source)
+    return _fetch_url(name, source)
+
+
+def _fetch_url(name: str, url: str) -> Path:
+    """Fetch an explicit URL override into a side cache slot (no manifest)."""
+    import urllib.request
+
+    spec = reference_data.REFERENCE_DATASETS[name]
+    dest = reference_data.cache_dir() / name / "override" / spec["filename"]
+    if not dest.exists():
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        raw = urllib.request.urlopen(url, timeout=600).read()
+        reference_data._extract_to(raw, url, dest)
+    return dest
 
 
 def rna_tissue_consensus_path(source: str | None = None) -> Path:
-    """Return a local path to HPA ``rna_tissue_consensus.tsv``.
+    """Local path to HPA ``rna_tissue_consensus.tsv`` (pinned HPA version)."""
+    return _resolve("hpa_rna_consensus", source)
 
-    ``source`` may be a local ``.tsv``/``.zip`` path or a URL (default: HPA).
-    The zip is extracted into the cache; an existing extract is reused.
-    """
-    src = source or RNA_TISSUE_CONSENSUS_URL
-    if src.endswith(".tsv") and not src.startswith(("http://", "https://")):
-        return Path(src)
 
-    tsv_path = _CACHE_DIR / "rna_tissue_consensus.tsv"
-    if tsv_path.exists():
-        return tsv_path
-
-    if src.startswith(("http://", "https://")):
-        zip_path = _CACHE_DIR / "rna_tissue_consensus.tsv.zip"
-        if not zip_path.exists():
-            _download(src, zip_path)
-    else:
-        zip_path = Path(src)
-
-    with zipfile.ZipFile(zip_path) as zf:
-        member = next(n for n in zf.namelist() if n.endswith(".tsv"))
-        _CACHE_DIR.mkdir(exist_ok=True)
-        with zf.open(member) as fsrc:
-            tsv_path.write_bytes(fsrc.read())
-    return tsv_path
+def normal_tissue_path(source: str | None = None) -> Path:
+    """Local path to HPA ``normal_tissue.tsv`` IHC table (pinned HPA version)."""
+    return _resolve("hpa_normal_tissue", source)
 
 
 def ncbi_gene_info_path(source: str | None = None) -> Path:
-    """Return a local path to NCBI human ``gene_info.gz`` (download + cache)."""
-    src = source or NCBI_GENE_INFO_URL
-    if not src.startswith(("http://", "https://")):
-        return Path(src)
-
-    dest = _CACHE_DIR / "Homo_sapiens.gene_info.gz"
-    if not dest.exists():
-        _download(src, dest)
-    return dest
+    """Local path to NCBI human ``gene_info.gz``."""
+    return _resolve("ncbi_gene_info", source)

--- a/tests/test_reference_data.py
+++ b/tests/test_reference_data.py
@@ -1,0 +1,104 @@
+import io
+import json
+import zipfile
+
+import pytest
+
+from tsarina import reference_data
+
+
+@pytest.fixture
+def isolated_cache(tmp_path, monkeypatch):
+    monkeypatch.setenv("TSARINA_DATA_DIR", str(tmp_path))
+    return tmp_path / "sources"
+
+
+def _fake_zip(member_name: str, content: bytes) -> bytes:
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        zf.writestr(member_name, content)
+    return buf.getvalue()
+
+
+class _FakeResponse:
+    def __init__(self, payload):
+        self._payload = payload
+
+    def read(self):
+        return self._payload
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *a):
+        return False
+
+
+def test_resolve_version_defaults_and_errors():
+    # HPA datasets default to the pinned version; NCBI to the rolling sentinel.
+    assert reference_data.resolve_version("hpa_rna_consensus") == reference_data.DEFAULT_HPA_VERSION
+    assert reference_data.resolve_version("ncbi_gene_info") == reference_data.ROLLING
+    with pytest.raises(reference_data.ReferenceDataError):
+        reference_data.resolve_version("hpa_normal_tissue", "v99")
+    with pytest.raises(reference_data.ReferenceDataError):
+        reference_data.resolve_version("does_not_exist")
+
+
+def test_download_extracts_zip_and_records_manifest(isolated_cache, monkeypatch):
+    payload = _fake_zip("rna_tissue_consensus.tsv", b"Gene\tTissue\tnTPM\n")
+    monkeypatch.setattr(
+        reference_data.urllib.request, "urlopen", lambda *a, **k: _FakeResponse(payload)
+    )
+
+    path = reference_data.download("hpa_rna_consensus", version="v23")
+    assert path.exists()
+    assert path.read_bytes() == b"Gene\tTissue\tnTPM\n"
+    assert path == isolated_cache / "hpa_rna_consensus" / "v23" / "rna_tissue_consensus.tsv"
+
+    manifest = json.loads((isolated_cache / "manifest.json").read_text())
+    rec = manifest["hpa_rna_consensus"]
+    assert rec["version"] == "v23"
+    assert rec["bytes"] == path.stat().st_size
+    assert len(rec["sha256"]) == 64
+    assert rec["url"].endswith(".zip")
+
+
+def test_download_reuses_cache_unless_forced(isolated_cache, monkeypatch):
+    calls = {"n": 0}
+
+    def _count(*a, **k):
+        calls["n"] += 1
+        return _FakeResponse(_fake_zip("normal_tissue.tsv", b"x"))
+
+    monkeypatch.setattr(reference_data.urllib.request, "urlopen", _count)
+
+    reference_data.download("hpa_normal_tissue")
+    reference_data.ensure("hpa_normal_tissue")  # cached -> no new fetch
+    assert calls["n"] == 1
+    reference_data.download("hpa_normal_tissue", force=True)
+    assert calls["n"] == 2
+
+
+def test_status_reflects_cache_state(isolated_cache, monkeypatch):
+    monkeypatch.setattr(
+        reference_data.urllib.request,
+        "urlopen",
+        lambda *a, **k: _FakeResponse(_fake_zip("rna_tissue_consensus.tsv", b"y")),
+    )
+    before = {r["name"]: r for r in reference_data.status()}
+    assert before["hpa_rna_consensus"]["cached"] is False
+
+    reference_data.download("hpa_rna_consensus")
+    after = {r["name"]: r for r in reference_data.status()}
+    assert after["hpa_rna_consensus"]["cached"] is True
+    assert after["hpa_rna_consensus"]["cached_version"] == reference_data.DEFAULT_HPA_VERSION
+    assert "v23" in after["hpa_rna_consensus"]["available_versions"]
+
+
+def test_non_zip_payload_written_verbatim(isolated_cache, monkeypatch):
+    monkeypatch.setattr(
+        reference_data.urllib.request, "urlopen", lambda *a, **k: _FakeResponse(b"\x1f\x8bRAWGZ")
+    )
+    path = reference_data.download("ncbi_gene_info")
+    assert path.read_bytes() == b"\x1f\x8bRAWGZ"
+    assert path.name == "Homo_sapiens.gene_info.gz"

--- a/tsarina/cli.py
+++ b/tsarina/cli.py
@@ -24,6 +24,11 @@ Usage::
     tsarina data build                          # build the observations index
     tsarina data build --force                  # rebuild from scratch
 
+    tsarina data sources list                    # HPA/NCBI curation data: versions + cache
+    tsarina data sources download                # fetch all (pinned HPA version)
+    tsarina data sources download hpa_normal_tissue --hpa-version v23
+    tsarina data sources path hpa_rna_consensus  # print cached path
+
     tsarina personalize --hla HLA-A*02:01,... --cta PRAME=87.3 -o targets.csv
     tsarina hits --gene PRAME --allele HLA-A*24:02
     tsarina panel -o panel.csv
@@ -122,6 +127,58 @@ def _data_build(args: argparse.Namespace) -> None:
     print(f"Observations index: {path}")
 
 
+def _fmt_bytes(size: int | None) -> str:
+    if not size:
+        return "-"
+    for unit, scale in (("GB", 1e9), ("MB", 1e6), ("KB", 1e3)):
+        if size >= scale:
+            return f"{size / scale:.1f} {unit}"
+    return f"{size} B"
+
+
+def _data_sources(args: argparse.Namespace) -> None:
+    from . import reference_data
+
+    action = getattr(args, "sources_command", None) or "list"
+    if action == "list":
+        rows = reference_data.status()
+        print(f"{'Dataset':<20} {'Cached':<8} {'Version':<10} {'Size':>9}  Description")
+        print("-" * 92)
+        for r in rows:
+            cached = "yes" if r["cached"] else "no"
+            ver = r["cached_version"] or f"({r['default_version']})"
+            print(
+                f"{r['name']:<20} {cached:<8} {ver:<10} {_fmt_bytes(r['bytes']):>9}  "
+                f"{r['description']}"
+            )
+        print(f"\nCache directory: {reference_data.cache_dir()}")
+        print(
+            "Default HPA version: "
+            f"{reference_data.DEFAULT_HPA_VERSION} "
+            "(only release serving both RNA consensus and normal_tissue)"
+        )
+        return
+    if action == "download":
+        names = args.names or list(reference_data.REFERENCE_DATASETS)
+        for name in names:
+            try:
+                path = reference_data.download(name, version=args.hpa_version, force=args.force)
+            except reference_data.ReferenceDataError as e:
+                print(f"Error: {e}", file=sys.stderr)
+                sys.exit(1)
+            print(f"Ready: {name} -> {path}")
+        return
+    if action == "path":
+        from . import reference_data as rd
+
+        try:
+            print(rd.local_path(args.name, version=args.hpa_version))
+        except rd.ReferenceDataError as e:
+            print(f"Error: {e}", file=sys.stderr)
+            sys.exit(1)
+        return
+
+
 def _build_data_parser(sub: argparse._SubParsersAction) -> None:
     data_parser = sub.add_parser("data", help="Manage external datasets")
     data_sub = data_parser.add_subparsers(dest="data_command")
@@ -150,6 +207,20 @@ def _build_data_parser(sub: argparse._SubParsersAction) -> None:
     )
     p_build.add_argument("--force", "-f", action="store_true", help="Rebuild from scratch")
 
+    p_src = data_sub.add_parser(
+        "sources",
+        help="Manage versioned HPA/NCBI curation reference data (RNA, IHC, gene_info)",
+    )
+    src_sub = p_src.add_subparsers(dest="sources_command")
+    src_sub.add_parser("list", help="Show reference datasets, versions, and cache status")
+    p_src_dl = src_sub.add_parser("download", help="Download reference dataset(s)")
+    p_src_dl.add_argument("names", nargs="*", help="Dataset name(s); default: all")
+    p_src_dl.add_argument("--hpa-version", default=None, help="HPA release (e.g. v23)")
+    p_src_dl.add_argument("--force", "-f", action="store_true", help="Re-download")
+    p_src_path = src_sub.add_parser("path", help="Print the cache path for a dataset")
+    p_src_path.add_argument("name", help="Dataset name")
+    p_src_path.add_argument("--hpa-version", default=None, help="HPA release (e.g. v23)")
+
 
 def _handle_data(args: argparse.Namespace) -> None:
     handlers = {
@@ -160,10 +231,11 @@ def _handle_data(args: argparse.Namespace) -> None:
         "path": _data_path,
         "remove": _data_remove,
         "build": _data_build,
+        "sources": _data_sources,
     }
     if args.data_command is None:
         print(
-            "Usage: tsarina data {list,available,register,fetch,path,remove,build}",
+            "Usage: tsarina data {list,available,register,fetch,path,remove,build,sources}",
             file=sys.stderr,
         )
         sys.exit(1)

--- a/tsarina/reference_data.py
+++ b/tsarina/reference_data.py
@@ -1,0 +1,243 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Versioned download + cache for the upstream curation reference data.
+
+The bundled CTA table (``cancer-testis-antigens.csv``) is derived from large
+upstream reference files -- HPA RNA consensus, HPA IHC ``normal_tissue``, and
+NCBI ``gene_info``.  This module downloads and caches those files **with an
+explicit version stamp**, so the regeneration of the bundled table is
+reproducible and can't silently mix HPA releases (the ``www`` "latest" mirror,
+for example, serves the RNA consensus but not ``normal_tissue`` -- only the
+pinned ``v23`` archive carries both, so the two must be fetched as a matched
+pair).
+
+Surfaced on the CLI as ``tsarina data sources {list,download,path}`` -- the
+HPA/NCBI counterpart of the hitlist-backed ``tsarina data`` (IEDB/CEDAR/viral).
+
+Cache layout (one subdir per dataset+version, plus a JSON manifest)::
+
+    <cache>/sources/<name>/<version>/<filename>
+    <cache>/sources/manifest.json
+
+The cache dir is ``$TSARINA_DATA_DIR`` if set, else ``<repo>/.cache`` when run
+from a source checkout, else ``~/.cache/tsarina``.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import io
+import json
+import os
+import urllib.request
+import zipfile
+from datetime import datetime, timezone
+from pathlib import Path
+
+#: Default HPA release.  ``v23`` is the most recent HPA version whose download
+#: mirror serves *both* ``rna_tissue_consensus`` and ``normal_tissue`` as a
+#: matched pair; newer ``www``/``vNN`` mirrors drop ``normal_tissue``, which
+#: would force a release-mismatched (RNA-new / protein-old) table.
+DEFAULT_HPA_VERSION = "v23"
+
+#: Sentinel "version" for continuously-updated, unversioned upstreams (NCBI).
+ROLLING = "latest"
+
+#: Registry of reference datasets.  ``urls`` maps a version label to a download
+#: URL; ``.zip`` URLs are transparently extracted to ``filename``.
+REFERENCE_DATASETS: dict[str, dict] = {
+    "hpa_rna_consensus": {
+        "description": "HPA RNA consensus tissue nTPM (per-tissue expression)",
+        "filename": "rna_tissue_consensus.tsv",
+        "kind": "hpa",
+        "urls": {
+            "v23": "https://v23.proteinatlas.org/download/rna_tissue_consensus.tsv.zip",
+            "latest": "https://www.proteinatlas.org/download/tsv/rna_tissue_consensus.tsv.zip",
+        },
+    },
+    "hpa_normal_tissue": {
+        "description": "HPA IHC protein expression (normal_tissue, per tissue/cell type)",
+        "filename": "normal_tissue.tsv",
+        "kind": "hpa",
+        "urls": {
+            "v23": "https://v23.proteinatlas.org/download/normal_tissue.tsv.zip",
+        },
+    },
+    "ncbi_gene_info": {
+        "description": "NCBI human gene_info (official symbols + synonyms)",
+        "filename": "Homo_sapiens.gene_info.gz",
+        "kind": "ncbi",
+        "urls": {
+            "latest": (
+                "https://ftp.ncbi.nlm.nih.gov/gene/DATA/GENE_INFO/"
+                "Mammalia/Homo_sapiens.gene_info.gz"
+            ),
+        },
+    },
+}
+
+
+class ReferenceDataError(RuntimeError):
+    """Raised for unknown datasets/versions or download failures."""
+
+
+# ── Cache location ───────────────────────────────────────────────────────────
+
+
+def cache_dir() -> Path:
+    """Return the reference-data cache directory (created on demand)."""
+    env = os.environ.get("TSARINA_DATA_DIR")
+    if env:
+        base = Path(env).expanduser()
+    else:
+        repo_cache = Path(__file__).resolve().parent.parent / ".cache"
+        # Use the repo's .cache only from a source checkout (where scripts/ lives).
+        if (repo_cache.parent / "scripts").is_dir():
+            base = repo_cache
+        else:
+            base = Path.home() / ".cache" / "tsarina"
+    sources = base / "sources"
+    sources.mkdir(parents=True, exist_ok=True)
+    return sources
+
+
+def _manifest_path() -> Path:
+    return cache_dir() / "manifest.json"
+
+
+def _read_manifest() -> dict:
+    path = _manifest_path()
+    if not path.exists():
+        return {}
+    try:
+        return json.loads(path.read_text())
+    except (json.JSONDecodeError, OSError):
+        return {}
+
+
+def _write_manifest(manifest: dict) -> None:
+    _manifest_path().write_text(json.dumps(manifest, indent=2, sort_keys=True))
+
+
+# ── Dataset / version resolution ─────────────────────────────────────────────
+
+
+def _dataset(name: str) -> dict:
+    try:
+        return REFERENCE_DATASETS[name]
+    except KeyError:
+        known = ", ".join(sorted(REFERENCE_DATASETS))
+        raise ReferenceDataError(f"unknown dataset {name!r}; known: {known}") from None
+
+
+def resolve_version(name: str, version: str | None = None) -> str:
+    """Return the concrete version for *name*, applying per-kind defaults."""
+    spec = _dataset(name)
+    if version is None:
+        version = DEFAULT_HPA_VERSION if spec["kind"] == "hpa" else ROLLING
+    if version not in spec["urls"]:
+        avail = ", ".join(sorted(spec["urls"]))
+        raise ReferenceDataError(f"{name!r} has no version {version!r}; available: {avail}")
+    return version
+
+
+def local_path(name: str, version: str | None = None) -> Path:
+    """Return the expected cache path for *name*/*version* (may not exist yet)."""
+    version = resolve_version(name, version)
+    spec = _dataset(name)
+    return cache_dir() / name / version / spec["filename"]
+
+
+def is_cached(name: str, version: str | None = None) -> bool:
+    return local_path(name, version).exists()
+
+
+# ── Download ─────────────────────────────────────────────────────────────────
+
+
+def _extract_to(raw: bytes, url: str, dest: Path) -> None:
+    """Write *raw* (a .zip or plain payload) to *dest*, unzipping if needed."""
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    if url.endswith(".zip"):
+        with zipfile.ZipFile(io.BytesIO(raw)) as zf:
+            member = next(n for n in zf.namelist() if n.endswith(dest.suffix))
+            dest.write_bytes(zf.read(member))
+    else:
+        dest.write_bytes(raw)
+
+
+def download(name: str, version: str | None = None, *, force: bool = False) -> Path:
+    """Download *name*/*version* into the cache and record it in the manifest.
+
+    Returns the local path.  A cached copy is reused unless ``force=True``.
+    """
+    version = resolve_version(name, version)
+    spec = _dataset(name)
+    dest = local_path(name, version)
+    url = spec["urls"][version]
+
+    if dest.exists() and not force:
+        return dest
+
+    try:
+        with urllib.request.urlopen(url, timeout=600) as response:
+            raw = response.read()
+    except Exception as e:  # surface any network/HTTP failure uniformly
+        raise ReferenceDataError(f"failed to download {name} ({url}): {e}") from e
+
+    _extract_to(raw, url, dest)
+
+    manifest = _read_manifest()
+    manifest[name] = {
+        "version": version,
+        "url": url,
+        "path": str(dest),
+        "bytes": dest.stat().st_size,
+        "sha256": hashlib.sha256(dest.read_bytes()).hexdigest(),
+        "downloaded_at": datetime.now(timezone.utc).isoformat(timespec="seconds"),
+    }
+    _write_manifest(manifest)
+    return dest
+
+
+def ensure(name: str, version: str | None = None) -> Path:
+    """Return a local path to *name*/*version*, downloading if absent."""
+    path = local_path(name, version)
+    return path if path.exists() else download(name, version)
+
+
+# ── Status (for the CLI) ─────────────────────────────────────────────────────
+
+
+def status() -> list[dict]:
+    """Return one status row per dataset for ``tsarina data sources list``."""
+    manifest = _read_manifest()
+    rows = []
+    for name, spec in sorted(REFERENCE_DATASETS.items()):
+        default_v = DEFAULT_HPA_VERSION if spec["kind"] == "hpa" else ROLLING
+        path = cache_dir() / name / default_v / spec["filename"]
+        record = manifest.get(name, {})
+        rows.append(
+            {
+                "name": name,
+                "description": spec["description"],
+                "default_version": default_v,
+                "available_versions": sorted(spec["urls"]),
+                "cached": path.exists(),
+                "cached_version": record.get("version") if record else None,
+                "bytes": record.get("bytes") if path.exists() else None,
+                "downloaded_at": record.get("downloaded_at") if path.exists() else None,
+                "path": str(path),
+            }
+        )
+    return rows

--- a/tsarina/version.py
+++ b/tsarina/version.py
@@ -10,4 +10,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "1.5.6"
+__version__ = "1.6.0"


### PR DESCRIPTION
Answers "is there a data/download command that caches these files and shows what's available/cached and its versions?" (cf. pyensembl `install`/`list`). Also the foundation for a clean, reproducible CTA-table regeneration.

## Problem

The HPA/NCBI **curation source files** — RNA consensus, IHC `normal_tissue`, NCBI `gene_info` — were fetched ad-hoc by `scripts/cta_sources.py` into `<repo>/.cache` with **no version tracking and no CLI**. The existing `tsarina data` command only covers hitlist's MS/viral datasets.

Worse, the upstream mirrors are **release-inconsistent**: the `latest` (`www`) HPA mirror serves the RNA consensus but **not** `normal_tissue`; only the pinned **v23** archive carries both as a matched pair (v24/v25 dropped the IHC TSV). Regenerating the bundled table from mismatched releases is exactly how its mixed-provenance drift crept in (per the tissue-derivation audit).

## What

**`tsarina/reference_data.py`** — a versioned download/cache layer:
- registry of the 3 reference datasets, each with version→URL maps;
- pinned `DEFAULT_HPA_VERSION = "v23"` (the only release with both HPA files);
- per-`dataset/version` cache layout + a JSON **manifest** recording `version`, `url`, `sha256`, `bytes`, `downloaded_at`;
- cache dir = `$TSARINA_DATA_DIR` → repo `.cache` (source checkout) → `~/.cache/tsarina`.

**CLI** — `tsarina data sources {list,download,path}`:
```
$ tsarina data sources list
Dataset              Cached   Version         Size  Description
--------------------------------------------------------------------------------------------
hpa_normal_tissue    yes      v23          82.9 MB  HPA IHC protein expression (normal_tissue, ...)
hpa_rna_consensus    yes      v23          37.9 MB  HPA RNA consensus tissue nTPM (per-tissue ...)
ncbi_gene_info       yes      latest        5.2 MB  NCBI human gene_info (official symbols + synonyms)

Cache directory: .../.cache/sources
Default HPA version: v23 (only release serving both RNA consensus and normal_tissue)
```

`scripts/cta_sources.py` now **delegates** to it (one shared version-stamped cache; adds `normal_tissue_path`), so the curation scripts and the CLI can't diverge.

## Tests
Network-free (`urlopen` monkeypatched): zip extraction, manifest recording, cache reuse vs `--force`, version defaulting/validation, and `status()` reporting. 407 tests pass; lint/format clean. Minor bump 1.5.6 → 1.6.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)