### PR TITLE
Consolidate CLI: shared args, unified flags, deprecation aliases

### DIFF
--- a/docs/curation.md
+++ b/docs/curation.md
@@ -174,7 +174,7 @@ Every gene is scored against [Human Protein Atlas](https://www.proteinatlas.org/
 > **v23** — the most recent HPA version whose download mirror serves *both*
 > `rna_tissue_consensus` (RNA) and `normal_tissue` (IHC) as a matched pair, so
 > the whole table is derived from one release. Fetch and inspect the sources
-> with `tsarina data sources {list,download}`; regenerate every RNA/protein
+> with `tsarina data sources {list,fetch}`; regenerate every RNA/protein
 > column for the bundled table with `python scripts/regenerate_table.py`
 > (`--apply` to write). A small curated `_CROSS_REACTIVE_IHC` override in that
 > script forces the IHC to "no data" for sequence-near-identical paralog

--- a/scripts/cta_sources.py
+++ b/scripts/cta_sources.py
@@ -21,7 +21,7 @@ downloading on demand.
 Inspect or pre-fetch from the CLI::
 
     tsarina data sources list
-    tsarina data sources download
+    tsarina data sources fetch
 """
 
 from __future__ import annotations

--- a/tests/test_cli_common.py
+++ b/tests/test_cli_common.py
@@ -1,0 +1,42 @@
+import argparse
+
+import pytest
+
+from tsarina import cli_common
+
+
+def test_split_csv_trims_and_drops_empty():
+    assert cli_common.split_csv(" A , ,B,, C ") == ["A", "B", "C"]
+    assert cli_common.split_csv("") == []
+
+
+def test_parse_lengths_ok_and_error():
+    assert cli_common.parse_lengths("8,9, 10") == (8, 9, 10)
+    with pytest.raises(argparse.ArgumentTypeError):
+        cli_common.parse_lengths("8,x")
+
+
+def test_iedb_cedar_aliases_share_dest():
+    p = argparse.ArgumentParser()
+    cli_common.add_iedb_cedar_args(p)
+    assert p.parse_args(["--iedb", "a"]).iedb_path == "a"
+    assert p.parse_args(["--iedb-path", "b"]).iedb_path == "b"
+    assert p.parse_args(["--cedar", "c"]).cedar_path == "c"
+    assert p.parse_args(["--cedar-path", "d"]).cedar_path == "d"
+
+
+def test_add_predictor_arg_choices_and_default():
+    p = argparse.ArgumentParser()
+    cli_common.add_predictor_arg(p, context="testing")
+    assert p.parse_args([]).predictor == "mhcflurry"
+    with pytest.raises(SystemExit):
+        p.parse_args(["--predictor", "nope"])
+
+
+def test_warn_ignored_flags(capsys):
+    cli_common.warn_ignored_flags("--healthy-tissue", ["--allele", "--format"])
+    err = capsys.readouterr().err
+    assert "--healthy-tissue" in err and "--allele" in err and "--format" in err
+    # No output when nothing is ignored.
+    cli_common.warn_ignored_flags("--healthy-tissue", [])
+    assert capsys.readouterr().err == ""

--- a/tests/test_cli_spanning.py
+++ b/tests/test_cli_spanning.py
@@ -25,7 +25,6 @@ HEADLINE_FLAGS = (
     "--cta-count",
     "--ctas",
     "--panel",
-    "--max-percentile",
     "--format",
 )
 
@@ -43,9 +42,16 @@ PANEL_ONLY_FLAGS = (
     "--allow-non-magea4-mage-family",
     "--show-empty-ctas",
     "--no-summary",
+    "--progress",
+    "--predictor",
+)
+
+#: Deprecated flags hidden from --help but still parsed for back-compat.
+DEPRECATED_HIDDEN_FLAGS = (
+    "--max-percentile",
     "--no-progress",
     "--progress-bars",
-    "--predictor",
+    "--no-progress-bars",
 )
 
 
@@ -63,6 +69,51 @@ def test_panel_help_exits_zero():
     assert r.returncode == 0
     for flag in (*HEADLINE_FLAGS, *PANEL_ONLY_FLAGS):
         assert flag in r.stdout, f"missing help text for {flag}"
+
+
+def test_panel_deprecated_flags_hidden_from_help():
+    r = _run_cli("panel", "--help")
+    for flag in DEPRECATED_HIDDEN_FLAGS:
+        assert flag not in r.stdout, f"{flag} should be hidden from --help"
+
+
+def test_panel_deprecated_flags_still_parse():
+    """Hidden deprecated flags must keep working (back-compat aliases)."""
+    import argparse
+
+    from tsarina import cli_spanning
+
+    p = argparse.ArgumentParser()
+    cli_spanning._configure_parser(p)
+    args = p.parse_args(
+        [
+            "--max-percentile",
+            "1.0",
+            "--no-progress",
+            "--progress-bars",
+            "--iedb-path",
+            "x.csv",
+            "--cedar-path",
+            "y.csv",
+            "--ctas",
+            "MAGEA4",
+        ]
+    )
+    assert args.max_percentile == 1.0
+    assert args.progress == "off"
+    assert args.progress_bars is True
+    assert args.iedb_path == "x.csv"
+    assert args.cedar_path == "y.csv"
+
+
+def test_panel_iedb_alias_matches_iedb_path():
+    import argparse
+
+    from tsarina import cli_spanning
+
+    p = argparse.ArgumentParser()
+    cli_spanning._configure_parser(p)
+    assert p.parse_args(["--iedb", "z.csv"]).iedb_path == "z.csv"
 
 
 def test_panel_unknown_panel_rejected():

--- a/tsarina/cli.py
+++ b/tsarina/cli.py
@@ -25,8 +25,8 @@ Usage::
     tsarina data build --force                  # rebuild from scratch
 
     tsarina data sources list                    # HPA/NCBI curation data: versions + cache
-    tsarina data sources download                # fetch all (pinned HPA version)
-    tsarina data sources download hpa_normal_tissue --hpa-version v23
+    tsarina data sources fetch                    # fetch all (pinned HPA version)
+    tsarina data sources fetch hpa_normal_tissue --hpa-version v23
     tsarina data sources path hpa_rna_consensus  # print cached path
 
     tsarina personalize --hla HLA-A*02:01,... --cta PRAME=87.3 -o targets.csv
@@ -53,6 +53,9 @@ from .downloads import (
 
 
 def _data_list(args: argparse.Namespace) -> None:
+    if getattr(args, "all", False):
+        _data_available(args)
+        return
     datasets = list_datasets()
     if not datasets:
         print("No datasets registered.")
@@ -76,6 +79,8 @@ def _data_list(args: argparse.Namespace) -> None:
         desc = info.get("description", "")
         print(f"{name:<12} {size_str:>12}  {source_label:<14} {desc}")
     print(f"\nData directory: {data_dir()}")
+    print("(`tsarina data list --all` shows the full catalog; HPA/NCBI curation")
+    print(" reference data is separate: `tsarina data sources list`.)")
 
 
 def _data_available(args: argparse.Namespace) -> None:
@@ -158,7 +163,13 @@ def _data_sources(args: argparse.Namespace) -> None:
             "(only release serving both RNA consensus and normal_tissue)"
         )
         return
-    if action == "download":
+    if action in ("fetch", "download"):
+        if action == "download":
+            print(
+                "Note: 'data sources download' is now 'data sources fetch' "
+                "(verb unified with 'data fetch').",
+                file=sys.stderr,
+            )
         names = args.names or list(reference_data.REFERENCE_DATASETS)
         for name in names:
             try:
@@ -183,8 +194,11 @@ def _build_data_parser(sub: argparse._SubParsersAction) -> None:
     data_parser = sub.add_parser("data", help="Manage external datasets")
     data_sub = data_parser.add_subparsers(dest="data_command")
 
-    data_sub.add_parser("list", help="Show registered datasets")
-    data_sub.add_parser("available", help="Show all known datasets")
+    p_list = data_sub.add_parser("list", help="Show registered datasets (--all for full catalog)")
+    p_list.add_argument(
+        "--all", action="store_true", help="Show the full catalog, not just installed datasets."
+    )
+    data_sub.add_parser("available", help="Alias for `list --all` (full catalog)")
 
     p_reg = data_sub.add_parser("register", help="Register a local file")
     p_reg.add_argument("name", help="Dataset name (e.g. iedb, cedar)")
@@ -213,10 +227,15 @@ def _build_data_parser(sub: argparse._SubParsersAction) -> None:
     )
     src_sub = p_src.add_subparsers(dest="sources_command")
     src_sub.add_parser("list", help="Show reference datasets, versions, and cache status")
-    p_src_dl = src_sub.add_parser("download", help="Download reference dataset(s)")
-    p_src_dl.add_argument("names", nargs="*", help="Dataset name(s); default: all")
-    p_src_dl.add_argument("--hpa-version", default=None, help="HPA release (e.g. v23)")
-    p_src_dl.add_argument("--force", "-f", action="store_true", help="Re-download")
+    # Primary verb is 'fetch' (matches 'tsarina data fetch'); 'download' kept as alias.
+    for verb, verb_help in (
+        ("fetch", "Fetch reference dataset(s)"),
+        ("download", "Deprecated alias of `fetch`"),
+    ):
+        p_src_dl = src_sub.add_parser(verb, help=verb_help)
+        p_src_dl.add_argument("names", nargs="*", help="Dataset name(s); default: all")
+        p_src_dl.add_argument("--hpa-version", default=None, help="HPA release (e.g. v23)")
+        p_src_dl.add_argument("--force", "-f", action="store_true", help="Re-download")
     p_src_path = src_sub.add_parser("path", help="Print the cache path for a dataset")
     p_src_path.add_argument("name", help="Dataset name")
     p_src_path.add_argument("--hpa-version", default=None, help="HPA release (e.g. v23)")

--- a/tsarina/cli_common.py
+++ b/tsarina/cli_common.py
@@ -1,0 +1,79 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Shared CLI argument helpers, so the ``hits``/``personalize``/``panel``
+subcommands spell common options identically (one source of truth instead of
+three drifting copies)."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+
+#: mhctools predictors accepted by every scoring-capable subcommand.
+SUPPORTED_PREDICTORS = ("mhcflurry", "netmhcpan", "netmhcpan_el")
+
+
+def split_csv(value: str) -> list[str]:
+    """Parse a comma-separated argument into a trimmed, non-empty list."""
+    return [s.strip() for s in value.split(",") if s.strip()]
+
+
+def parse_lengths(value: str) -> tuple[int, ...]:
+    """argparse type for ``--lengths`` (comma-separated integers)."""
+    try:
+        return tuple(int(x) for x in split_csv(value))
+    except ValueError as e:
+        raise argparse.ArgumentTypeError(f"--lengths must be integers: {value!r}") from e
+
+
+def add_iedb_cedar_args(parser: argparse.ArgumentParser) -> None:
+    """Add IEDB/CEDAR path overrides with a consistent spelling everywhere.
+
+    Both ``--iedb``/``--cedar`` and ``--iedb-path``/``--cedar-path`` are
+    accepted (the latter are kept so the historical ``panel`` spelling keeps
+    working); all map to ``iedb_path`` / ``cedar_path``.
+    """
+    parser.add_argument(
+        "--iedb",
+        "--iedb-path",
+        dest="iedb_path",
+        default=None,
+        help="Explicit IEDB ligand CSV path (default: hitlist data registry).",
+    )
+    parser.add_argument(
+        "--cedar",
+        "--cedar-path",
+        dest="cedar_path",
+        default=None,
+        help="Explicit CEDAR ligand CSV path (default: hitlist data registry).",
+    )
+
+
+def add_predictor_arg(parser: argparse.ArgumentParser, *, context: str) -> None:
+    """Add the ``--predictor`` choice with a context-specific help string."""
+    parser.add_argument(
+        "--predictor",
+        choices=SUPPORTED_PREDICTORS,
+        default="mhcflurry",
+        help=f"mhctools predictor for {context} (default mhcflurry).",
+    )
+
+
+def warn_ignored_flags(mode_flag: str, ignored: list[str]) -> None:
+    """Print a stderr warning that *mode_flag* makes *ignored* flags no-ops."""
+    if ignored:
+        joined = ", ".join(sorted(ignored))
+        print(
+            f"Warning: {mode_flag} is a mode switch; these flags are ignored: {joined}",
+            file=sys.stderr,
+        )

--- a/tsarina/cli_hits.py
+++ b/tsarina/cli_hits.py
@@ -31,20 +31,22 @@ import sys
 
 import pandas as pd
 
+from .cli_common import (
+    add_iedb_cedar_args,
+    add_predictor_arg,
+)
+from .cli_common import (
+    parse_lengths as _parse_lengths,
+)
+from .cli_common import (
+    split_csv as _split_csv,
+)
+from .cli_common import (
+    warn_ignored_flags as _warn_ignored_flags,
+)
+
 _SUPPORTED_FORMATS = ("peptides", "pmhc", "refs", "raw")
-_SUPPORTED_PREDICTORS = ("mhcflurry", "netmhcpan", "netmhcpan_el")
 _SUPPORTED_RESOLUTIONS = ("four_digit", "two_digit", "serological", "class_only")
-
-
-def _split_csv(value: str) -> list[str]:
-    return [s.strip() for s in value.split(",") if s.strip()]
-
-
-def _parse_lengths(value: str) -> tuple[int, ...]:
-    try:
-        return tuple(int(x) for x in _split_csv(value))
-    except ValueError as e:
-        raise argparse.ArgumentTypeError(f"--lengths must be integers: {value!r}") from e
 
 
 # Class-default peptide length windows used when --lengths is omitted.
@@ -179,37 +181,27 @@ def build_parser(sub: argparse._SubParsersAction) -> argparse.ArgumentParser:
         action="store_true",
         help="Also score observed (peptide, allele) pairs via topiary.",
     )
-    p.add_argument(
-        "--predictor",
-        choices=_SUPPORTED_PREDICTORS,
-        default="mhcflurry",
-        help="mhctools predictor for --predict (default mhcflurry).",
-    )
-    p.add_argument(
-        "--iedb",
-        dest="iedb_path",
-        default=None,
-        help="Override IEDB path (default: hitlist registry).",
-    )
-    p.add_argument(
-        "--cedar",
-        dest="cedar_path",
-        default=None,
-        help="Override CEDAR path (default: hitlist registry).",
-    )
+    add_predictor_arg(p, context="--predict")
+    add_iedb_cedar_args(p)
     p.add_argument(
         "--skip-ms-evidence",
         action="store_true",
-        help="Skip IEDB/CEDAR; output the proteome-enumerated peptides only.",
+        help=(
+            "Mode switch: skip IEDB/CEDAR and output only the proteome-enumerated "
+            "peptide menu. Filtering/aggregation flags (--allele, --serotype, "
+            "--format, --predict, …) are ignored."
+        ),
     )
     p.add_argument(
         "--healthy-tissue",
         action="store_true",
         help=(
-            "Safety screen: output this gene's per-peptide healthy-SOMATIC-tissue "
+            "Mode switch: output this gene's per-peptide healthy-SOMATIC-tissue "
             "MS hits (tissue, allele, allele_set, provenance, pmid, vital_organ "
             "flag) instead of the cancer-MS aggregation. Reproductive/thymic hits "
-            "(expected for CTAs) are excluded. See cta_healthy_tissue_ms_hits()."
+            "(expected for CTAs) are excluded. Only --gene/--uniprot, --mhc-class, "
+            "--species, --output apply; other flags are ignored. See "
+            "cta_healthy_tissue_ms_hits()."
         ),
     )
     p.add_argument(
@@ -377,10 +369,40 @@ def handle(args: argparse.Namespace) -> None:
 
     mhc_species = None if args.species.lower() == "any" else args.species
 
+    # Flags that only apply to the default cancer-MS aggregation path; warn if
+    # the user combines them with a mode switch that ignores them.
+    def _set_aggregation_flags() -> list[str]:
+        flags = []
+        if args.allele:
+            flags.append("--allele")
+        if args.serotype:
+            flags.append("--serotype")
+        if args.min_resolution is not None:
+            flags.append("--min-resolution")
+        if args.include_binding_assays:
+            flags.append("--include-binding-assays")
+        if args.mono_allelic_only:
+            flags.append("--mono-allelic-only")
+        if args.predict:
+            flags.append("--predict")
+        if args.format != "pmhc":
+            flags.append("--format")
+        return flags
+
     # ── 1b. Healthy-tissue safety screen ───────────────────────────────
     # Short-circuit: peptide x tissue x allele healthy-somatic MS hits for
     # the gene, with a vital-organ flag — the per-patient safety view.
     if args.healthy_tissue:
+        ignored = _set_aggregation_flags()
+        if args.lengths is not None:
+            ignored.append("--lengths")
+        if args.skip_ms_evidence:
+            ignored.append("--skip-ms-evidence")
+        if args.iedb_path is not None:
+            ignored.append("--iedb")
+        if args.cedar_path is not None:
+            ignored.append("--cedar")
+        _warn_ignored_flags("--healthy-tissue", ignored)
         from .ms_evidence import cta_healthy_tissue_ms_hits
 
         hits = cta_healthy_tissue_ms_hits(gene, mhc_class=args.mhc_class, mhc_species=mhc_species)
@@ -410,6 +432,7 @@ def handle(args: argparse.Namespace) -> None:
             sys.exit(1)
 
     if args.skip_ms_evidence:
+        _warn_ignored_flags("--skip-ms-evidence", _set_aggregation_flags())
         _write(args.output, pep_df)
         return
 

--- a/tsarina/cli_personalize.py
+++ b/tsarina/cli_personalize.py
@@ -21,11 +21,9 @@ from __future__ import annotations
 import argparse
 import sys
 
-_SUPPORTED_PREDICTORS = ("mhcflurry", "netmhcpan", "netmhcpan_el")
-
-
-def _split_csv(value: str) -> list[str]:
-    return [s.strip() for s in value.split(",") if s.strip()]
+from .cli_common import add_iedb_cedar_args, add_predictor_arg
+from .cli_common import parse_lengths as _parse_lengths
+from .cli_common import split_csv as _split_csv
 
 
 def _parse_cta(value: str) -> dict[str, float]:
@@ -41,13 +39,6 @@ def _parse_cta(value: str) -> dict[str, float]:
         except ValueError as e:
             raise argparse.ArgumentTypeError(f"--cta TPM '{tpm_s}' is not a number") from e
     return out
-
-
-def _parse_lengths(value: str) -> tuple[int, ...]:
-    try:
-        return tuple(int(x) for x in _split_csv(value))
-    except ValueError as e:
-        raise argparse.ArgumentTypeError(f"--lengths must be integers: {value!r}") from e
 
 
 def build_parser(sub: argparse._SubParsersAction) -> argparse.ArgumentParser:
@@ -118,6 +109,7 @@ def build_parser(sub: argparse._SubParsersAction) -> argparse.ArgumentParser:
         ),
     )
     p.add_argument(
+        "--mtec-matrix-path",
         "--mtec-matrix",
         dest="mtec_matrix_path",
         default=None,
@@ -152,24 +144,8 @@ def build_parser(sub: argparse._SubParsersAction) -> argparse.ArgumentParser:
         action="store_true",
         help="Disable MHC presentation scoring (skip topiary).",
     )
-    p.add_argument(
-        "--predictor",
-        choices=_SUPPORTED_PREDICTORS,
-        default="mhcflurry",
-        help="mhctools predictor used for presentation scoring (default mhcflurry).",
-    )
-    p.add_argument(
-        "--iedb",
-        dest="iedb_path",
-        default=None,
-        help="Override IEDB path (default: hitlist registry).",
-    )
-    p.add_argument(
-        "--cedar",
-        dest="cedar_path",
-        default=None,
-        help="Override CEDAR path (default: hitlist registry).",
-    )
+    add_predictor_arg(p, context="presentation scoring")
+    add_iedb_cedar_args(p)
     p.add_argument(
         "--skip-ms-evidence",
         action="store_true",

--- a/tsarina/cli_spanning.py
+++ b/tsarina/cli_spanning.py
@@ -22,7 +22,10 @@ import math
 import sys
 from pathlib import Path
 
-_SUPPORTED_PREDICTORS = ("mhcflurry", "netmhcpan", "netmhcpan_el")
+from .cli_common import add_iedb_cedar_args, add_predictor_arg
+from .cli_common import parse_lengths as _parse_lengths
+from .cli_common import split_csv as _split_csv
+
 _SUPPORTED_FORMATS = ("table", "wide", "long")
 _SUPPORTED_PANELS = (
     "iedb27_ab",
@@ -40,17 +43,6 @@ _DEFAULT_SELECTION_ALLOWLIST = "PRAME,CTAG1A/CTAG1B,MAGEA4"
 _DEFAULT_VITAL_TISSUE_MAX_NTPM = 2.0
 _DEFAULT_CANCER_RNA_THRESHOLD = 2.0
 _DEFAULT_CANCER_TYPE_PREVALENCE_FLOOR = 0.05
-
-
-def _split_csv(value: str) -> list[str]:
-    return [s.strip() for s in value.split(",") if s.strip()]
-
-
-def _parse_lengths(value: str) -> tuple[int, ...]:
-    try:
-        return tuple(int(x) for x in _split_csv(value))
-    except ValueError as e:
-        raise argparse.ArgumentTypeError(f"--lengths must be integers: {value!r}") from e
 
 
 def _configure_parser(p: argparse.ArgumentParser) -> argparse.ArgumentParser:
@@ -191,12 +183,7 @@ def _configure_parser(p: argparse.ArgumentParser) -> argparse.ArgumentParser:
         action="store_false",
         help="Allow CTA peptides that also appear in non-CTA proteins.",
     )
-    p.add_argument(
-        "--predictor",
-        choices=_SUPPORTED_PREDICTORS,
-        default="mhcflurry",
-        help="mhctools predictor (default mhcflurry).",
-    )
+    add_predictor_arg(p, context="pMHC presentation scoring")
     p.add_argument(
         "--monoallelic-ms-max-percentile",
         type=float,
@@ -230,13 +217,13 @@ def _configure_parser(p: argparse.ArgumentParser) -> argparse.ArgumentParser:
         help="Max percentile for prediction-only candidates when enabled (default 0.1).",
     )
     p.add_argument(
+        # Deprecated shortcut (sets all MS-supported tier cutoffs at once); hidden
+        # from --help in favor of the explicit per-tier --*-ms-max-percentile flags.
+        # Still honored, with a stderr deprecation warning, for back-compat.
         "--max-percentile",
         type=float,
         default=None,
-        help=(
-            "Deprecated shortcut: set all MS-supported tier cutoffs to this value. "
-            "Does not enable predicted-only candidates."
-        ),
+        help=argparse.SUPPRESS,
     )
     p.add_argument(
         "--peptides-per-cell",
@@ -276,16 +263,7 @@ def _configure_parser(p: argparse.ArgumentParser) -> argparse.ArgumentParser:
             "affinity percentile rank. Requires the external NetMHCpan backend."
         ),
     )
-    p.add_argument(
-        "--iedb-path",
-        default=None,
-        help="Optional explicit IEDB ligand CSV; default uses cached hitlist observations.",
-    )
-    p.add_argument(
-        "--cedar-path",
-        default=None,
-        help="Optional explicit CEDAR CSV; default uses cached hitlist observations.",
-    )
+    add_iedb_cedar_args(p)
     p.add_argument(
         "--format",
         choices=_SUPPORTED_FORMATS,
@@ -308,28 +286,41 @@ def _configure_parser(p: argparse.ArgumentParser) -> argparse.ArgumentParser:
         action="store_true",
         help=(
             "Show automatically selected CTAs that have no selected pMHCs after "
-            "peptide, exclusivity, public-MS, and prediction gates. Explicit --ctas "
-            "requests are always preserved."
+            "peptide, exclusivity, public-MS, and prediction gates. Note: passing "
+            "--ctas forces this on (explicit requests are always preserved)."
         ),
     )
     p.add_argument(
-        "--no-progress",
-        dest="progress",
-        action="store_false",
-        help="Suppress progress messages and scoring progress bars.",
+        "--progress",
+        choices=("auto", "on", "off"),
+        default="auto",
+        help=(
+            "Progress reporting: 'auto' = messages + bars when stderr is a TTY "
+            "(default); 'on' = force messages and bars; 'off' = silent."
+        ),
     )
+    # Fine-grained bar override (applies only when progress != off). Kept for
+    # back-compat; --progress is the preferred single control.
     p.add_argument(
         "--progress-bars",
         dest="progress_bars",
         action="store_true",
         default=None,
-        help="Force tqdm progress bars for chunked scoring.",
+        help=argparse.SUPPRESS,
     )
     p.add_argument(
         "--no-progress-bars",
         dest="progress_bars",
         action="store_false",
-        help="Disable tqdm progress bars while keeping progress messages.",
+        help=argparse.SUPPRESS,
+    )
+    # Deprecated alias for --progress off.
+    p.add_argument(
+        "--no-progress",
+        dest="progress",
+        action="store_const",
+        const="off",
+        help=argparse.SUPPRESS,
     )
     p.add_argument(
         "--score-chunk-size",
@@ -382,12 +373,26 @@ def handle(args: argparse.Namespace) -> None:
     else:
         min_restriction_confidence = tuple(v.upper() for v in args.min_restriction_confidence)
 
+    if args.max_percentile is not None:
+        print(
+            "Warning: --max-percentile is deprecated; use the per-tier "
+            "--monoallelic-ms-max-percentile / --sample-allele-ms-max-percentile / "
+            "--unrestricted-ms-max-percentile flags.",
+            file=sys.stderr,
+        )
+
     def _on_progress(msg: str) -> None:
         print(msg, file=sys.stderr)
 
+    show_progress = args.progress != "off"
     progress_bar = False
-    if args.progress:
-        progress_bar = sys.stderr.isatty() if args.progress_bars is None else args.progress_bars
+    if show_progress:
+        if args.progress_bars is not None:
+            progress_bar = args.progress_bars
+        elif args.progress == "on":
+            progress_bar = True
+        else:  # auto
+            progress_bar = sys.stderr.isatty()
 
     output_format = "long" if args.format == "table" else args.format
     df = spanning_pmhc_set(
@@ -422,7 +427,7 @@ def handle(args: argparse.Namespace) -> None:
         cedar_path=args.cedar_path,
         output_format=output_format,
         include_empty_ctas=True if args.ctas is not None else args.show_empty_ctas,
-        on_progress=_on_progress if args.progress else None,
+        on_progress=_on_progress if show_progress else None,
         progress_bar=progress_bar,
         score_chunk_size=args.score_chunk_size,
         progress_file=sys.stderr,

--- a/tsarina/version.py
+++ b/tsarina/version.py
@@ -10,4 +10,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "1.7.0"
+__version__ = "1.8.0"


### PR DESCRIPTION
Acts on the CLI audit (duplication + confusing features). All changes are **back-compat** via deprecation aliases — no hard breaks.

## Duplication removed
- **`tsarina/cli_common.py`** — one source of truth for `split_csv`, `parse_lengths`, `SUPPORTED_PREDICTORS`, and arg-adders (`add_iedb_cedar_args`, `add_predictor_arg`, `warn_ignored_flags`). `hits`/`personalize`/`panel` each re-declared these, which let defaults/help drift.
- **IEDB/CEDAR override unified** — every scoring subcommand now accepts **both** `--iedb`/`--cedar` and `--iedb-path`/`--cedar-path` (previously `panel` only took `--iedb-path`; `hits`/`personalize` only `--iedb`, so a flag learned on one errored on another).

## Confusing features fixed
- **Silent mode switches** — `hits --healthy-tissue` and `hits --skip-ms-evidence` now **warn** (stderr) listing the filtering/aggregation flags they ignore, and say so in `--help`, instead of silently dropping them.
- **panel progress** — three overlapping flags (`--no-progress`, `--progress-bars`, `--no-progress-bars`) collapsed into one **`--progress {auto,on,off}`**; the old three kept as hidden back-compat aliases.
- **panel `--max-percentile`** — the self-described "deprecated shortcut" is now hidden from `--help` and emits a deprecation warning when used (still honored).
- **panel `--show-empty-ctas`** — help now notes that `--ctas` forces it on.
- **personalize `--mtec-matrix`** — add `--mtec-matrix-path` (matches its `mtec_matrix_path` dest); old spelling kept as alias.
- **`data` vs `data sources`** — `data sources download` → **`data sources fetch`** (verb unified with `data fetch`; `download` kept as deprecated alias). `data list --all` now shows the full catalog (soft-deprecating `data available`), and `data list` cross-points to `data sources list`.

## Not done (deliberately)
Did **not** convert `hits --healthy-tissue` into a subcommand — that would force `tsarina hits query ...` and break the primary `tsarina hits --gene` invocation. The warn-on-ignored-flags approach achieves the goal (no silent ignores) without breaking the common path.

## Tests
New: `test_cli_common.py` (shared helpers + iedb alias), panel deprecated-flag back-compat parse + hidden-from-help, `--iedb` alias. Existing count tests updated. **415 pass**; lint/format clean. Minor bump 1.7.0 → 1.8.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)