### PR TITLE
Reorganize CLI: split data/reference, drop legacy flags

### DIFF
--- a/docs/curation.md
+++ b/docs/curation.md
@@ -174,7 +174,7 @@ Every gene is scored against [Human Protein Atlas](https://www.proteinatlas.org/
 > **v23** — the most recent HPA version whose download mirror serves *both*
 > `rna_tissue_consensus` (RNA) and `normal_tissue` (IHC) as a matched pair, so
 > the whole table is derived from one release. Fetch and inspect the sources
-> with `tsarina data sources {list,fetch}`; regenerate every RNA/protein
+> with `tsarina reference {list,fetch}`; regenerate every RNA/protein
 > column for the bundled table with `python scripts/regenerate_table.py`
 > (`--apply` to write). A small curated `_CROSS_REACTIVE_IHC` override in that
 > script forces the IHC to "no data" for sequence-near-identical paralog

--- a/docs/index.md
+++ b/docs/index.md
@@ -253,7 +253,7 @@ scoring, evidence-tier construction, and final selection. Interactive terminals
 also get a `tqdm` scoring progress bar; MHCflurry still scores all alleles in
 one batch by default because chunking repeats its allele-independent processing
 model work. Use `--score-chunk-size` only when you explicitly want chunking, or
-`--no-progress` / `--no-progress-bars` to suppress progress output.
+`--progress off` to suppress progress output.
 
 Use `--selection-allowlist`, `--no-vital-tissue-filter`,
 `--vital-tissue-max-ntpm`, and `--allow-non-magea4-mage-family` to tune
@@ -351,7 +351,7 @@ Tsarina uses the shared hitlist data registry for external datasets:
 
 ```bash
 # See what data is available
-tsarina data available
+tsarina data list --all
 
 # Auto-download viral proteomes from UniProt
 tsarina data fetch hpv16
@@ -380,6 +380,10 @@ tsarina data path iedb
 
 Storage location: `~/.hitlist/` (override with `HITLIST_DATA_DIR` env var).
 `tsarina data` delegates registry and cache management to hitlist.
+
+The separate **`tsarina reference`** command manages the version-pinned HPA/NCBI
+curation reference data (RNA consensus, IHC `normal_tissue`, NCBI `gene_info`)
+used to regenerate the bundled CTA table — `tsarina reference {list,fetch,path}`.
 
 IEDB column indices are resolved dynamically from CSV headers, with fallback to known defaults -- robust to IEDB schema changes.
 

--- a/scripts/cta_sources.py
+++ b/scripts/cta_sources.py
@@ -13,15 +13,15 @@
 """Reproducible source-data fetchers for the CTA curation scripts.
 
 Thin wrappers over :mod:`tsarina.reference_data` (the versioned download/cache
-layer also exposed as ``tsarina data sources``), so the curation scripts and the
+layer also exposed as ``tsarina reference``), so the curation scripts and the
 CLI share one version-stamped cache.  Each helper accepts an optional explicit
 local path/URL override; otherwise it returns the cached pinned-version copy,
 downloading on demand.
 
 Inspect or pre-fetch from the CLI::
 
-    tsarina data sources list
-    tsarina data sources fetch
+    tsarina reference list
+    tsarina reference fetch
 """
 
 from __future__ import annotations

--- a/scripts/regenerate_table.py
+++ b/scripts/regenerate_table.py
@@ -21,7 +21,7 @@ current 51-tissue consensus, and ``rna_max_ntpm`` is below a per-tissue value in
 253 rows (impossible within one snapshot).  See the tissue-derivation audit.
 
 This script re-derives **all RNA and protein/IHC columns** for **every existing
-row** from a single pinned HPA release (``tsarina data sources``; default v23 --
+row** from a single pinned HPA release (``tsarina reference``; default v23 --
 the newest release serving both ``rna_tissue_consensus`` and ``normal_tissue``),
 using the same generators the per-gene ``add_cta_gene.py`` uses, so the whole
 table is internally consistent and reproducible from one release.  Identity,

--- a/tests/test_cli_common.py
+++ b/tests/test_cli_common.py
@@ -16,13 +16,14 @@ def test_parse_lengths_ok_and_error():
         cli_common.parse_lengths("8,x")
 
 
-def test_iedb_cedar_aliases_share_dest():
+def test_iedb_cedar_args_map_to_path_dests():
     p = argparse.ArgumentParser()
     cli_common.add_iedb_cedar_args(p)
     assert p.parse_args(["--iedb", "a"]).iedb_path == "a"
-    assert p.parse_args(["--iedb-path", "b"]).iedb_path == "b"
     assert p.parse_args(["--cedar", "c"]).cedar_path == "c"
-    assert p.parse_args(["--cedar-path", "d"]).cedar_path == "d"
+    # The historical *-path spellings are gone (single canonical spelling).
+    with pytest.raises(SystemExit):
+        p.parse_args(["--iedb-path", "b"])
 
 
 def test_add_predictor_arg_choices_and_default():

--- a/tests/test_cli_spanning.py
+++ b/tests/test_cli_spanning.py
@@ -21,6 +21,8 @@ library-level coverage in ``test_spanning.py``.
 import subprocess
 import sys
 
+import pytest
+
 HEADLINE_FLAGS = (
     "--cta-count",
     "--ctas",
@@ -46,12 +48,14 @@ PANEL_ONLY_FLAGS = (
     "--predictor",
 )
 
-#: Deprecated flags hidden from --help but still parsed for back-compat.
-DEPRECATED_HIDDEN_FLAGS = (
+#: Flags removed in the CLI reorg (must no longer parse).
+REMOVED_FLAGS = (
     "--max-percentile",
     "--no-progress",
     "--progress-bars",
     "--no-progress-bars",
+    "--iedb-path",
+    "--cedar-path",
 )
 
 
@@ -71,48 +75,27 @@ def test_panel_help_exits_zero():
         assert flag in r.stdout, f"missing help text for {flag}"
 
 
-def test_panel_deprecated_flags_hidden_from_help():
-    r = _run_cli("panel", "--help")
-    for flag in DEPRECATED_HIDDEN_FLAGS:
-        assert flag not in r.stdout, f"{flag} should be hidden from --help"
+def test_panel_removed_flags_rejected():
+    """Flags dropped in the reorg must no longer be accepted."""
+    import argparse
+
+    from tsarina import cli_spanning
+
+    for flag in REMOVED_FLAGS:
+        p = argparse.ArgumentParser()
+        cli_spanning._configure_parser(p)
+        with pytest.raises(SystemExit):
+            p.parse_args([flag, "x"])
 
 
-def test_panel_deprecated_flags_still_parse():
-    """Hidden deprecated flags must keep working (back-compat aliases)."""
+def test_panel_progress_and_iedb_parse():
     import argparse
 
     from tsarina import cli_spanning
 
     p = argparse.ArgumentParser()
     cli_spanning._configure_parser(p)
-    args = p.parse_args(
-        [
-            "--max-percentile",
-            "1.0",
-            "--no-progress",
-            "--progress-bars",
-            "--iedb-path",
-            "x.csv",
-            "--cedar-path",
-            "y.csv",
-            "--ctas",
-            "MAGEA4",
-        ]
-    )
-    assert args.max_percentile == 1.0
-    assert args.progress == "off"
-    assert args.progress_bars is True
-    assert args.iedb_path == "x.csv"
-    assert args.cedar_path == "y.csv"
-
-
-def test_panel_iedb_alias_matches_iedb_path():
-    import argparse
-
-    from tsarina import cli_spanning
-
-    p = argparse.ArgumentParser()
-    cli_spanning._configure_parser(p)
+    assert p.parse_args(["--progress", "off"]).progress == "off"
     assert p.parse_args(["--iedb", "z.csv"]).iedb_path == "z.csv"
 
 

--- a/tsarina/cli.py
+++ b/tsarina/cli.py
@@ -14,21 +14,21 @@
 
 Usage::
 
-    tsarina data list                           # show registered datasets
-    tsarina data available                      # show all known datasets
-    tsarina data register iedb /path/to/file    # register a manual download
-    tsarina data fetch hpv16                    # auto-download a viral proteome
-    tsarina data fetch hpv16 --force            # re-download
-    tsarina data path iedb                      # print path to registered file
-    tsarina data remove iedb                    # unregister (keeps the file)
-    tsarina data build                          # build the observations index
-    tsarina data build --force                  # rebuild from scratch
+    # MS evidence datasets (IEDB / CEDAR / viral proteomes + the index)
+    tsarina data list [--all]                   # installed datasets (--all = full catalog)
+    tsarina data fetch hpv16                     # auto-download a viral proteome
+    tsarina data register iedb /path/to/file     # register a manual download
+    tsarina data path iedb                       # print path to a dataset
+    tsarina data remove iedb                      # unregister (keeps the file)
+    tsarina data build [--force]                 # build the observations index
 
-    tsarina data sources list                    # HPA/NCBI curation data: versions + cache
-    tsarina data sources fetch                    # fetch all (pinned HPA version)
-    tsarina data sources fetch hpa_normal_tissue --hpa-version v23
-    tsarina data sources path hpa_rna_consensus  # print cached path
+    # Curation reference data (HPA RNA/IHC + NCBI gene_info), version-pinned
+    tsarina reference list                       # versions + cache status
+    tsarina reference fetch                       # fetch all (pinned HPA version)
+    tsarina reference fetch hpa_normal_tissue --hpa-version v23
+    tsarina reference path hpa_rna_consensus     # print cached path
 
+    # Analysis
     tsarina personalize --hla HLA-A*02:01,... --cta PRAME=87.3 -o targets.csv
     tsarina hits --gene PRAME --allele HLA-A*24:02
     tsarina panel -o panel.csv
@@ -60,7 +60,7 @@ def _data_list(args: argparse.Namespace) -> None:
     if not datasets:
         print("No datasets registered.")
         print(f"Data directory: {data_dir()}")
-        print("Run 'tsarina data available' to see known datasets.")
+        print("Run 'tsarina data list --all' to see known datasets.")
         return
     print(f"{'Name':<12} {'Size':>12}  {'Source':<14} Description")
     print("-" * 72)
@@ -80,7 +80,7 @@ def _data_list(args: argparse.Namespace) -> None:
         print(f"{name:<12} {size_str:>12}  {source_label:<14} {desc}")
     print(f"\nData directory: {data_dir()}")
     print("(`tsarina data list --all` shows the full catalog; HPA/NCBI curation")
-    print(" reference data is separate: `tsarina data sources list`.)")
+    print(" reference data is separate: `tsarina reference list`.)")
 
 
 def _data_available(args: argparse.Namespace) -> None:
@@ -141,64 +141,86 @@ def _fmt_bytes(size: int | None) -> str:
     return f"{size} B"
 
 
-def _data_sources(args: argparse.Namespace) -> None:
+# ── reference subcommands (HPA / NCBI curation data) ────────────────────────
+
+
+def _reference_list(args: argparse.Namespace) -> None:
     from . import reference_data
 
-    action = getattr(args, "sources_command", None) or "list"
-    if action == "list":
-        rows = reference_data.status()
-        print(f"{'Dataset':<20} {'Cached':<8} {'Version':<10} {'Size':>9}  Description")
-        print("-" * 92)
-        for r in rows:
-            cached = "yes" if r["cached"] else "no"
-            ver = r["cached_version"] or f"({r['default_version']})"
-            print(
-                f"{r['name']:<20} {cached:<8} {ver:<10} {_fmt_bytes(r['bytes']):>9}  "
-                f"{r['description']}"
-            )
-        print(f"\nCache directory: {reference_data.cache_dir()}")
+    rows = reference_data.status()
+    print(f"{'Dataset':<20} {'Cached':<8} {'Version':<10} {'Size':>9}  Description")
+    print("-" * 92)
+    for r in rows:
+        cached = "yes" if r["cached"] else "no"
+        ver = r["cached_version"] or f"({r['default_version']})"
         print(
-            "Default HPA version: "
-            f"{reference_data.DEFAULT_HPA_VERSION} "
-            "(only release serving both RNA consensus and normal_tissue)"
+            f"{r['name']:<20} {cached:<8} {ver:<10} {_fmt_bytes(r['bytes']):>9}  {r['description']}"
         )
-        return
-    if action in ("fetch", "download"):
-        if action == "download":
-            print(
-                "Note: 'data sources download' is now 'data sources fetch' "
-                "(verb unified with 'data fetch').",
-                file=sys.stderr,
-            )
-        names = args.names or list(reference_data.REFERENCE_DATASETS)
-        for name in names:
-            try:
-                path = reference_data.download(name, version=args.hpa_version, force=args.force)
-            except reference_data.ReferenceDataError as e:
-                print(f"Error: {e}", file=sys.stderr)
-                sys.exit(1)
-            print(f"Ready: {name} -> {path}")
-        return
-    if action == "path":
-        from . import reference_data as rd
+    print(f"\nCache directory: {reference_data.cache_dir()}")
+    print(
+        f"Default HPA version: {reference_data.DEFAULT_HPA_VERSION} "
+        "(only release serving both RNA consensus and normal_tissue)"
+    )
 
+
+def _reference_fetch(args: argparse.Namespace) -> None:
+    from . import reference_data
+
+    names = args.names or list(reference_data.REFERENCE_DATASETS)
+    for name in names:
         try:
-            print(rd.local_path(args.name, version=args.hpa_version))
-        except rd.ReferenceDataError as e:
+            path = reference_data.download(name, version=args.hpa_version, force=args.force)
+        except reference_data.ReferenceDataError as e:
             print(f"Error: {e}", file=sys.stderr)
             sys.exit(1)
-        return
+        print(f"Ready: {name} -> {path}")
+
+
+def _reference_path(args: argparse.Namespace) -> None:
+    from . import reference_data
+
+    try:
+        print(reference_data.local_path(args.name, version=args.hpa_version))
+    except reference_data.ReferenceDataError as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+def _build_reference_parser(sub: argparse._SubParsersAction) -> None:
+    ref = sub.add_parser(
+        "reference",
+        help="Versioned HPA/NCBI curation reference data (RNA, IHC, gene_info)",
+    )
+    ref_sub = ref.add_subparsers(dest="reference_command")
+    ref_sub.add_parser("list", help="Show reference datasets, versions, and cache status")
+    p_fetch = ref_sub.add_parser("fetch", help="Fetch reference dataset(s); default: all")
+    p_fetch.add_argument("names", nargs="*", help="Dataset name(s); default: all")
+    p_fetch.add_argument("--hpa-version", default=None, help="HPA release (e.g. v23)")
+    p_fetch.add_argument("--force", "-f", action="store_true", help="Re-download")
+    p_path = ref_sub.add_parser("path", help="Print the cache path for a dataset")
+    p_path.add_argument("name", help="Dataset name")
+    p_path.add_argument("--hpa-version", default=None, help="HPA release (e.g. v23)")
+
+
+def _handle_reference(args: argparse.Namespace) -> None:
+    handlers = {
+        "list": _reference_list,
+        "fetch": _reference_fetch,
+        "path": _reference_path,
+    }
+    handlers[getattr(args, "reference_command", None) or "list"](args)
 
 
 def _build_data_parser(sub: argparse._SubParsersAction) -> None:
-    data_parser = sub.add_parser("data", help="Manage external datasets")
+    data_parser = sub.add_parser(
+        "data", help="MS evidence datasets (IEDB/CEDAR/viral) + observations index"
+    )
     data_sub = data_parser.add_subparsers(dest="data_command")
 
-    p_list = data_sub.add_parser("list", help="Show registered datasets (--all for full catalog)")
+    p_list = data_sub.add_parser("list", help="Show installed datasets (--all for full catalog)")
     p_list.add_argument(
         "--all", action="store_true", help="Show the full catalog, not just installed datasets."
     )
-    data_sub.add_parser("available", help="Alias for `list --all` (full catalog)")
 
     p_reg = data_sub.add_parser("register", help="Register a local file")
     p_reg.add_argument("name", help="Dataset name (e.g. iedb, cedar)")
@@ -221,40 +243,19 @@ def _build_data_parser(sub: argparse._SubParsersAction) -> None:
     )
     p_build.add_argument("--force", "-f", action="store_true", help="Rebuild from scratch")
 
-    p_src = data_sub.add_parser(
-        "sources",
-        help="Manage versioned HPA/NCBI curation reference data (RNA, IHC, gene_info)",
-    )
-    src_sub = p_src.add_subparsers(dest="sources_command")
-    src_sub.add_parser("list", help="Show reference datasets, versions, and cache status")
-    # Primary verb is 'fetch' (matches 'tsarina data fetch'); 'download' kept as alias.
-    for verb, verb_help in (
-        ("fetch", "Fetch reference dataset(s)"),
-        ("download", "Deprecated alias of `fetch`"),
-    ):
-        p_src_dl = src_sub.add_parser(verb, help=verb_help)
-        p_src_dl.add_argument("names", nargs="*", help="Dataset name(s); default: all")
-        p_src_dl.add_argument("--hpa-version", default=None, help="HPA release (e.g. v23)")
-        p_src_dl.add_argument("--force", "-f", action="store_true", help="Re-download")
-    p_src_path = src_sub.add_parser("path", help="Print the cache path for a dataset")
-    p_src_path.add_argument("name", help="Dataset name")
-    p_src_path.add_argument("--hpa-version", default=None, help="HPA release (e.g. v23)")
-
 
 def _handle_data(args: argparse.Namespace) -> None:
     handlers = {
         "list": _data_list,
-        "available": _data_available,
         "register": _data_register,
         "fetch": _data_fetch,
         "path": _data_path,
         "remove": _data_remove,
         "build": _data_build,
-        "sources": _data_sources,
     }
     if args.data_command is None:
         print(
-            "Usage: tsarina data {list,available,register,fetch,path,remove,build,sources}",
+            "Usage: tsarina data {list,register,fetch,path,remove,build}",
             file=sys.stderr,
         )
         sys.exit(1)
@@ -274,6 +275,7 @@ def main() -> None:
     sub = parser.add_subparsers(dest="command")
 
     _build_data_parser(sub)
+    _build_reference_parser(sub)
     cli_personalize.build_parser(sub)
     cli_hits.build_parser(sub)
     cli_spanning.build_parser(sub)
@@ -293,6 +295,8 @@ def main() -> None:
 
     if args.command == "data":
         _handle_data(args)
+    elif args.command == "reference":
+        _handle_reference(args)
     elif args.command == "personalize":
         cli_personalize.handle(args)
     elif args.command == "hits":

--- a/tsarina/cli_common.py
+++ b/tsarina/cli_common.py
@@ -37,22 +37,15 @@ def parse_lengths(value: str) -> tuple[int, ...]:
 
 
 def add_iedb_cedar_args(parser: argparse.ArgumentParser) -> None:
-    """Add IEDB/CEDAR path overrides with a consistent spelling everywhere.
-
-    Both ``--iedb``/``--cedar`` and ``--iedb-path``/``--cedar-path`` are
-    accepted (the latter are kept so the historical ``panel`` spelling keeps
-    working); all map to ``iedb_path`` / ``cedar_path``.
-    """
+    """Add the IEDB/CEDAR path overrides, spelled the same on every subcommand."""
     parser.add_argument(
         "--iedb",
-        "--iedb-path",
         dest="iedb_path",
         default=None,
         help="Explicit IEDB ligand CSV path (default: hitlist data registry).",
     )
     parser.add_argument(
         "--cedar",
-        "--cedar-path",
         dest="cedar_path",
         default=None,
         help="Explicit CEDAR ligand CSV path (default: hitlist data registry).",

--- a/tsarina/cli_personalize.py
+++ b/tsarina/cli_personalize.py
@@ -110,7 +110,6 @@ def build_parser(sub: argparse._SubParsersAction) -> argparse.ArgumentParser:
     )
     p.add_argument(
         "--mtec-matrix-path",
-        "--mtec-matrix",
         dest="mtec_matrix_path",
         default=None,
         help="Path to mTEC gene TPM matrix (TSV); gates CTAs by thymic expression.",
@@ -119,7 +118,7 @@ def build_parser(sub: argparse._SubParsersAction) -> argparse.ArgumentParser:
         "--mtec-max-tpm",
         type=float,
         default=1.0,
-        help="Maximum mean mTEC TPM when --mtec-matrix is given (default 1.0).",
+        help="Maximum mean mTEC TPM when --mtec-matrix-path is given (default 1.0).",
     )
     p.add_argument(
         "--no-require-human-exclusive-viral",

--- a/tsarina/cli_spanning.py
+++ b/tsarina/cli_spanning.py
@@ -217,15 +217,6 @@ def _configure_parser(p: argparse.ArgumentParser) -> argparse.ArgumentParser:
         help="Max percentile for prediction-only candidates when enabled (default 0.1).",
     )
     p.add_argument(
-        # Deprecated shortcut (sets all MS-supported tier cutoffs at once); hidden
-        # from --help in favor of the explicit per-tier --*-ms-max-percentile flags.
-        # Still honored, with a stderr deprecation warning, for back-compat.
-        "--max-percentile",
-        type=float,
-        default=None,
-        help=argparse.SUPPRESS,
-    )
-    p.add_argument(
         "--peptides-per-cell",
         type=int,
         default=3,
@@ -295,32 +286,9 @@ def _configure_parser(p: argparse.ArgumentParser) -> argparse.ArgumentParser:
         choices=("auto", "on", "off"),
         default="auto",
         help=(
-            "Progress reporting: 'auto' = messages + bars when stderr is a TTY "
-            "(default); 'on' = force messages and bars; 'off' = silent."
+            "Progress reporting: 'auto' = messages + scoring bars when stderr is a "
+            "TTY (default); 'on' = force both; 'off' = silent."
         ),
-    )
-    # Fine-grained bar override (applies only when progress != off). Kept for
-    # back-compat; --progress is the preferred single control.
-    p.add_argument(
-        "--progress-bars",
-        dest="progress_bars",
-        action="store_true",
-        default=None,
-        help=argparse.SUPPRESS,
-    )
-    p.add_argument(
-        "--no-progress-bars",
-        dest="progress_bars",
-        action="store_false",
-        help=argparse.SUPPRESS,
-    )
-    # Deprecated alias for --progress off.
-    p.add_argument(
-        "--no-progress",
-        dest="progress",
-        action="store_const",
-        const="off",
-        help=argparse.SUPPRESS,
     )
     p.add_argument(
         "--score-chunk-size",
@@ -373,26 +341,16 @@ def handle(args: argparse.Namespace) -> None:
     else:
         min_restriction_confidence = tuple(v.upper() for v in args.min_restriction_confidence)
 
-    if args.max_percentile is not None:
-        print(
-            "Warning: --max-percentile is deprecated; use the per-tier "
-            "--monoallelic-ms-max-percentile / --sample-allele-ms-max-percentile / "
-            "--unrestricted-ms-max-percentile flags.",
-            file=sys.stderr,
-        )
-
     def _on_progress(msg: str) -> None:
         print(msg, file=sys.stderr)
 
     show_progress = args.progress != "off"
-    progress_bar = False
-    if show_progress:
-        if args.progress_bars is not None:
-            progress_bar = args.progress_bars
-        elif args.progress == "on":
-            progress_bar = True
-        else:  # auto
-            progress_bar = sys.stderr.isatty()
+    if not show_progress:
+        progress_bar = False
+    elif args.progress == "on":
+        progress_bar = True
+    else:  # auto
+        progress_bar = sys.stderr.isatty()
 
     output_format = "long" if args.format == "table" else args.format
     df = spanning_pmhc_set(
@@ -418,7 +376,6 @@ def handle(args: argparse.Namespace) -> None:
         unrestricted_ms_max_percentile=args.unrestricted_ms_max_percentile,
         include_predicted_only=args.include_predicted_only,
         predicted_only_max_percentile=args.predicted_only_max_percentile,
-        max_percentile=args.max_percentile,
         peptides_per_cell=args.peptides_per_cell,
         group_identical_cta_pmhcs=args.group_identical_cta_pmhcs,
         group_identical_cta_peptide_sets=args.group_identical_cta_peptide_sets,

--- a/tsarina/reference_data.py
+++ b/tsarina/reference_data.py
@@ -21,7 +21,7 @@ for example, serves the RNA consensus but not ``normal_tissue`` -- only the
 pinned ``v23`` archive carries both, so the two must be fetched as a matched
 pair).
 
-Surfaced on the CLI as ``tsarina data sources {list,download,path}`` -- the
+Surfaced on the CLI as ``tsarina reference {list,fetch,path}`` -- the
 HPA/NCBI counterpart of the hitlist-backed ``tsarina data`` (IEDB/CEDAR/viral).
 
 Cache layout (one subdir per dataset+version, plus a JSON manifest)::
@@ -220,7 +220,7 @@ def ensure(name: str, version: str | None = None) -> Path:
 
 
 def status() -> list[dict]:
-    """Return one status row per dataset for ``tsarina data sources list``."""
+    """Return one status row per dataset for ``tsarina reference list``."""
     manifest = _read_manifest()
     rows = []
     for name, spec in sorted(REFERENCE_DATASETS.items()):

--- a/tsarina/version.py
+++ b/tsarina/version.py
@@ -10,4 +10,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "1.8.0"
+__version__ = "1.9.0"


### PR DESCRIPTION
Acts on "forget cli compat, make it more logically organized." A clean break — no deprecation aliases.

## Command tree
The old `data` command crammed two unrelated domains together: hitlist MS-evidence verbs *plus* a nested `data sources` for HPA/NCBI curation data. Split into two sibling top-level groups with parallel verbs:

```
tsarina
├── data        MS evidence (IEDB/CEDAR/viral + observations index)
│   └── list [--all] · fetch · path · register · remove · build
├── reference   HPA/NCBI curation reference data (RNA, IHC, gene_info)
│   └── list · fetch · path
├── hits
├── panel
└── personalize
```

`reference` (singular) matches the backing `reference_data.py` module and the "reference data" convention (HPA/NCBI lookups); avoids `references`, which collides with the citation sense already used by `hits --format refs`.

## Removed (no aliases)
| Old | New |
|---|---|
| `data sources …` | `tsarina reference …` |
| `data available` | `data list --all` |
| `data sources download` | `reference fetch` |
| panel `--max-percentile` | per-tier `--*-ms-max-percentile` flags |
| panel `--no-progress` / `--progress-bars` / `--no-progress-bars` | single `--progress {auto,on,off}` |
| `--iedb-path` / `--cedar-path` | `--iedb` / `--cedar` (every command) |
| personalize `--mtec-matrix` | `--mtec-matrix-path` |

## Kept
The `cli_common` shared helpers from the prior consolidation (`split_csv`, `parse_lengths`, predictor/iedb-cedar adders, mode-switch warnings on `hits --healthy-tissue`/`--skip-ms-evidence`).

## Tests/docs
Tests now assert the removed flags are **rejected**; docs/scripts/module docstrings point at the new commands. Net −59 lines. 414 pass; lint/format clean. Bump 1.8.0 → 1.9.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)