### PR TITLE
Address CLI reorg review: reference tests + consistent bare-command

### DIFF
--- a/tests/test_cli_reference.py
+++ b/tests/test_cli_reference.py
@@ -1,0 +1,98 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""CLI smoke tests for ``tsarina reference`` and the bare-``data`` default.
+
+Exercises the parser wiring + dispatch end-to-end via subprocess (no network:
+``list``/``path`` only read the manifest / compute paths). The cache is
+redirected to a tmp dir so the tests never touch the real cache or download.
+"""
+
+import os
+import subprocess
+import sys
+
+
+def _run(*args: str, cache_dir, check: bool = True) -> subprocess.CompletedProcess:
+    env = {**os.environ, "TSARINA_DATA_DIR": str(cache_dir)}
+    return subprocess.run(
+        [sys.executable, "-m", "tsarina.cli", *args],
+        capture_output=True,
+        text=True,
+        check=check,
+        env=env,
+    )
+
+
+def test_reference_help_lists_subcommands(tmp_path):
+    r = _run("reference", "--help", cache_dir=tmp_path)
+    assert r.returncode == 0
+    for sub in ("list", "fetch", "path"):
+        assert sub in r.stdout
+
+
+def test_reference_bare_defaults_to_list(tmp_path):
+    # `tsarina reference` with no subcommand should list (not error).
+    r = _run("reference", cache_dir=tmp_path)
+    assert r.returncode == 0
+    assert "hpa_rna_consensus" in r.stdout
+    assert "Default HPA version" in r.stdout
+
+
+def test_reference_list_shows_all_datasets(tmp_path):
+    r = _run("reference", "list", cache_dir=tmp_path)
+    assert r.returncode == 0
+    for name in ("hpa_rna_consensus", "hpa_normal_tissue", "ncbi_gene_info"):
+        assert name in r.stdout
+
+
+def test_reference_path_prints_cache_path(tmp_path):
+    r = _run("reference", "path", "hpa_rna_consensus", cache_dir=tmp_path)
+    assert r.returncode == 0
+    out = r.stdout.strip()
+    assert out.endswith("rna_tissue_consensus.tsv")
+    assert str(tmp_path) in out
+
+
+def test_reference_path_unknown_dataset_errors(tmp_path):
+    r = _run("reference", "path", "does_not_exist", cache_dir=tmp_path, check=False)
+    assert r.returncode != 0
+    assert "unknown dataset" in (r.stderr + r.stdout)
+
+
+def test_reference_path_unknown_version_errors(tmp_path):
+    r = _run(
+        "reference",
+        "path",
+        "hpa_normal_tissue",
+        "--hpa-version",
+        "v99",
+        cache_dir=tmp_path,
+        check=False,
+    )
+    assert r.returncode != 0
+    assert "no version" in (r.stderr + r.stdout)
+
+
+def test_data_sources_removed(tmp_path):
+    # The old nested command must be gone (replaced by top-level `reference`).
+    r = _run("data", "sources", "list", cache_dir=tmp_path, check=False)
+    assert r.returncode != 0
+    assert "invalid choice: 'sources'" in (r.stderr + r.stdout)
+
+
+def test_data_bare_defaults_to_list(tmp_path):
+    # `tsarina data` with no subcommand should list (not error), like reference.
+    r = _run("data", cache_dir=tmp_path)
+    assert r.returncode == 0
+    # Either the registered table or the empty-registry hint, but never a usage error.
+    assert "Usage: tsarina data" not in (r.stderr + r.stdout)

--- a/tsarina/cli.py
+++ b/tsarina/cli.py
@@ -54,13 +54,14 @@ from .downloads import (
 
 def _data_list(args: argparse.Namespace) -> None:
     if getattr(args, "all", False):
-        _data_available(args)
+        _data_list_all(args)
         return
     datasets = list_datasets()
     if not datasets:
         print("No datasets registered.")
         print(f"Data directory: {data_dir()}")
         print("Run 'tsarina data list --all' to see known datasets.")
+        print("(HPA/NCBI curation reference data is separate: `tsarina reference list`.)")
         return
     print(f"{'Name':<12} {'Size':>12}  {'Source':<14} Description")
     print("-" * 72)
@@ -83,7 +84,7 @@ def _data_list(args: argparse.Namespace) -> None:
     print(" reference data is separate: `tsarina reference list`.)")
 
 
-def _data_available(args: argparse.Namespace) -> None:
+def _data_list_all(args: argparse.Namespace) -> None:
     datasets = available_datasets()
     registered = set(list_datasets().keys())
     print(f"{'Name':<12} {'Status':<12} Description")
@@ -253,13 +254,8 @@ def _handle_data(args: argparse.Namespace) -> None:
         "remove": _data_remove,
         "build": _data_build,
     }
-    if args.data_command is None:
-        print(
-            "Usage: tsarina data {list,register,fetch,path,remove,build}",
-            file=sys.stderr,
-        )
-        sys.exit(1)
-    handlers[args.data_command](args)
+    # Bare `tsarina data` defaults to listing, mirroring `tsarina reference`.
+    handlers[getattr(args, "data_command", None) or "list"](args)
 
 
 # ── Main entry point ────────────────────────────────────────────────────────

--- a/tsarina/version.py
+++ b/tsarina/version.py
@@ -10,4 +10,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "1.9.0"
+__version__ = "1.9.1"


### PR DESCRIPTION
Follow-up to #103, fixing the issues from its code review.

## Fixes
- **Closes the test-coverage gap** — new `tests/test_cli_reference.py` exercises the `tsarina reference` dispatch end-to-end (subprocess, cache redirected to a tmp dir, no network): `--help` lists `{list,fetch,path}`, bare `reference` defaults to `list`, `list` shows all datasets, `path` prints/validates, unknown dataset/version error. Also asserts `data sources` is gone and bare `data` lists.
- **Consistent bare-command behavior** — bare `tsarina data` now defaults to `list` (previously a usage error + exit 1), matching bare `tsarina reference`. Both data groups behave the same.
- **Rename `_data_available` → `_data_list_all`** — the `available` subcommand is gone; the function is the `list --all` view now, so the name was stale.
- **Cross-pointer in the empty-registry branch** — a user with no installed datasets now also sees the `tsarina reference list` hint.

422 tests pass (+8); lint/format clean. Patch bump 1.9.0 → 1.9.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)