### PR TITLE
Harden CLI per fresh review: hermetic tests, resilient reference fetch

### DIFF
--- a/tests/test_cli_reference.py
+++ b/tests/test_cli_reference.py
@@ -10,16 +10,21 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""CLI smoke tests for ``tsarina reference`` and the bare-``data`` default.
+"""CLI smoke tests for ``tsarina reference`` plus the bare-``data`` default.
 
-Exercises the parser wiring + dispatch end-to-end via subprocess (no network:
-``list``/``path`` only read the manifest / compute paths). The cache is
-redirected to a tmp dir so the tests never touch the real cache or download.
+The ``reference`` checks run end-to-end via subprocess (no network: ``list`` /
+``path`` only read the manifest / compute paths), isolated to a tmp cache via
+``TSARINA_DATA_DIR`` (the env var ``reference_data`` honors). The bare-``data``
+routing check is a hermetic unit test that stubs the hitlist-delegated
+``list_datasets`` rather than touching hitlist's own data dir.
 """
 
+import argparse
 import os
 import subprocess
 import sys
+
+import tsarina.cli as cli
 
 
 def _run(*args: str, cache_dir, check: bool = True) -> subprocess.CompletedProcess:
@@ -90,9 +95,41 @@ def test_data_sources_removed(tmp_path):
     assert "invalid choice: 'sources'" in (r.stderr + r.stdout)
 
 
-def test_data_bare_defaults_to_list(tmp_path):
-    # `tsarina data` with no subcommand should list (not error), like reference.
-    r = _run("data", cache_dir=tmp_path)
-    assert r.returncode == 0
-    # Either the registered table or the empty-registry hint, but never a usage error.
-    assert "Usage: tsarina data" not in (r.stderr + r.stdout)
+def test_reference_fetch_continues_past_failures(monkeypatch, capsys):
+    """`fetch all` attempts every dataset even if one fails, then exits non-zero."""
+    import pytest
+
+    from tsarina import reference_data
+
+    attempted = []
+
+    def _fake_download(name, version=None, force=False):
+        attempted.append(name)
+        if name == "hpa_normal_tissue":
+            raise reference_data.ReferenceDataError("boom")
+        return f"/cache/{name}"
+
+    monkeypatch.setattr(reference_data, "download", _fake_download)
+    args = argparse.Namespace(names=[], hpa_version=None, force=False)
+    with pytest.raises(SystemExit) as exc:
+        cli._reference_fetch(args)
+    assert exc.value.code == 1
+    # All three datasets were attempted despite the middle one failing.
+    assert set(attempted) == set(reference_data.REFERENCE_DATASETS)
+    err = capsys.readouterr().err
+    assert "hpa_normal_tissue" in err and "Failed to fetch" in err
+
+
+def test_data_bare_defaults_to_list(monkeypatch, capsys):
+    """Bare `tsarina data` routes to list (not a usage error), like reference.
+
+    Hermetic: stubs the hitlist-delegated registry calls so the test owns its
+    state instead of reading hitlist's real data dir.
+    """
+    monkeypatch.setattr(cli, "list_datasets", lambda: {})
+    monkeypatch.setattr(cli, "data_dir", lambda: "/tmp/does-not-matter")
+    cli._handle_data(argparse.Namespace(data_command=None))
+    out = capsys.readouterr().out
+    assert "No datasets registered" in out
+    # The empty-registry branch points users at the separate reference command.
+    assert "tsarina reference list" in out

--- a/tsarina/cli.py
+++ b/tsarina/cli.py
@@ -15,18 +15,18 @@
 Usage::
 
     # MS evidence datasets (IEDB / CEDAR / viral proteomes + the index)
-    tsarina data list [--all]                   # installed datasets (--all = full catalog)
-    tsarina data fetch hpv16                     # auto-download a viral proteome
-    tsarina data register iedb /path/to/file     # register a manual download
-    tsarina data path iedb                       # print path to a dataset
-    tsarina data remove iedb                      # unregister (keeps the file)
-    tsarina data build [--force]                 # build the observations index
+    tsarina data list [--all]                 # installed datasets (--all = full catalog)
+    tsarina data fetch hpv16                  # auto-download a viral proteome
+    tsarina data register iedb /path/to/file  # register a manual download
+    tsarina data path iedb                    # print path to a dataset
+    tsarina data remove iedb                  # unregister (keeps the file)
+    tsarina data build [--force]              # build the observations index
 
     # Curation reference data (HPA RNA/IHC + NCBI gene_info), version-pinned
-    tsarina reference list                       # versions + cache status
-    tsarina reference fetch                       # fetch all (pinned HPA version)
+    tsarina reference list                    # versions + cache status
+    tsarina reference fetch                   # fetch all (pinned HPA version)
     tsarina reference fetch hpa_normal_tissue --hpa-version v23
-    tsarina reference path hpa_rna_consensus     # print cached path
+    tsarina reference path hpa_rna_consensus  # print cached path
 
     # Analysis
     tsarina personalize --hla HLA-A*02:01,... --cta PRAME=87.3 -o targets.csv
@@ -168,13 +168,19 @@ def _reference_fetch(args: argparse.Namespace) -> None:
     from . import reference_data
 
     names = args.names or list(reference_data.REFERENCE_DATASETS)
+    # Attempt every dataset; a single flaky URL shouldn't abort a "fetch all".
+    failures = []
     for name in names:
         try:
             path = reference_data.download(name, version=args.hpa_version, force=args.force)
         except reference_data.ReferenceDataError as e:
-            print(f"Error: {e}", file=sys.stderr)
-            sys.exit(1)
+            print(f"Error: {name}: {e}", file=sys.stderr)
+            failures.append(name)
+            continue
         print(f"Ready: {name} -> {path}")
+    if failures:
+        print(f"Failed to fetch: {', '.join(failures)}", file=sys.stderr)
+        sys.exit(1)
 
 
 def _reference_path(args: argparse.Namespace) -> None:

--- a/tsarina/version.py
+++ b/tsarina/version.py
@@ -10,4 +10,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "1.9.1"
+__version__ = "1.9.2"


### PR DESCRIPTION
A fresh critical pass over the post-reorg CLI surfaced three fixable items (the rest reviewed clean).

## Fixes
- **Hermetic tests (the real one).** The bare-`data` routing test was non-hermetic: it set `TSARINA_DATA_DIR`, but the hitlist-backed `data` commands read `HITLIST_DATA_DIR` / `~/.hitlist`, so the test was reading the dev's real registry. Rather than reach into hitlist's env var from a tsarina test (coupling smell — thanks for the catch), rewrote it as a **unit test that stubs the delegated `list_datasets`**. The `reference` subprocess tests keep using our own `TSARINA_DATA_DIR`; the `data sources`-removed test errors at argparse parse time so it never touches the registry.
- **`reference fetch` resilience.** The default `fetch all` aborted on the first failed download. Now it **attempts every dataset, reports failures, and exits non-zero at the end** — one flaky URL no longer kills the batch. Added a unit test.
- **Docstring alignment** of the usage block (cosmetic).

## Filed upstream
- [pirl-unc/hitlist#289](https://github.com/pirl-unc/hitlist/issues/289) — `tsarina data fetch <manual-dataset>` surfaces hitlist's "run `hitlist data register …`" message, which names the wrong tool for downstream CLIs.

## Reviewed clean (no change)
Dispatch defaulting (`getattr(... ) or "list"`), argparse dest/default mapping, `_data_fetch`/`_data_path` exception handling, the `spanning` alias path, and `reference_data` itself. `info`/`refresh` re-exports in `downloads.py` are an intentional compat surface — left as-is.

423 tests pass (+1); lint/format clean. Patch bump 1.9.1 → 1.9.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)