### PR TITLE
reference_data: delegate cache dir + download to datacache (like pyensembl)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,9 @@ dependencies = [
     # already required for the post-1.30.46 gene-column sidecar re-attach.
     "hitlist>=1.30.57",
     "mhcgnomes>=3.20.0",
+    # Cache-dir resolution + download/decompress for `tsarina reference`
+    # (same openvax layer pyensembl uses).
+    "datacache",
     "pandas",
     "numpy",
     "tqdm",

--- a/tests/test_reference_data.py
+++ b/tests/test_reference_data.py
@@ -1,6 +1,7 @@
-import io
+from __future__ import annotations
+
 import json
-import zipfile
+from pathlib import Path
 
 import pytest
 
@@ -10,28 +11,27 @@ from tsarina import reference_data
 @pytest.fixture
 def isolated_cache(tmp_path, monkeypatch):
     monkeypatch.setenv("TSARINA_DATA_DIR", str(tmp_path))
-    return tmp_path / "sources"
+    # cache_dir() = get_data_dir(subdir="tsarina", envkey=...) / "sources"
+    return tmp_path / "tsarina" / "sources"
 
 
-def _fake_zip(member_name: str, content: bytes) -> bytes:
-    buf = io.BytesIO()
-    with zipfile.ZipFile(buf, "w") as zf:
-        zf.writestr(member_name, content)
-    return buf.getvalue()
+def _stub_downloader(monkeypatch, content: bytes, counter: dict | None = None):
+    """Replace datacache's fetch/decompress with one that writes *content*.
 
+    datacache normally downloads + decompresses to ``full_path``; the stub
+    simulates the post-decompress result so the tests stay offline.
+    """
 
-class _FakeResponse:
-    def __init__(self, payload):
-        self._payload = payload
+    def _impl(full_path, download_url, timeout=None, use_wget_if_available=False):
+        if counter is not None:
+            counter["n"] += 1
+        Path(full_path).write_bytes(content)
 
-    def read(self):
-        return self._payload
-
-    def __enter__(self):
-        return self
-
-    def __exit__(self, *a):
-        return False
+    monkeypatch.setattr(
+        reference_data.datacache.download,
+        "_download_and_decompress_if_necessary",
+        _impl,
+    )
 
 
 def test_resolve_version_defaults_and_errors():
@@ -44,11 +44,8 @@ def test_resolve_version_defaults_and_errors():
         reference_data.resolve_version("does_not_exist")
 
 
-def test_download_extracts_zip_and_records_manifest(isolated_cache, monkeypatch):
-    payload = _fake_zip("rna_tissue_consensus.tsv", b"Gene\tTissue\tnTPM\n")
-    monkeypatch.setattr(
-        reference_data.urllib.request, "urlopen", lambda *a, **k: _FakeResponse(payload)
-    )
+def test_download_writes_file_and_records_manifest(isolated_cache, monkeypatch):
+    _stub_downloader(monkeypatch, b"Gene\tTissue\tnTPM\n")
 
     path = reference_data.download("hpa_rna_consensus", version="v23")
     assert path.exists()
@@ -64,27 +61,19 @@ def test_download_extracts_zip_and_records_manifest(isolated_cache, monkeypatch)
 
 
 def test_download_reuses_cache_unless_forced(isolated_cache, monkeypatch):
-    calls = {"n": 0}
-
-    def _count(*a, **k):
-        calls["n"] += 1
-        return _FakeResponse(_fake_zip("normal_tissue.tsv", b"x"))
-
-    monkeypatch.setattr(reference_data.urllib.request, "urlopen", _count)
+    counter = {"n": 0}
+    _stub_downloader(monkeypatch, b"x", counter)
 
     reference_data.download("hpa_normal_tissue")
     reference_data.ensure("hpa_normal_tissue")  # cached -> no new fetch
-    assert calls["n"] == 1
+    assert counter["n"] == 1
     reference_data.download("hpa_normal_tissue", force=True)
-    assert calls["n"] == 2
+    assert counter["n"] == 2
 
 
 def test_status_reflects_cache_state(isolated_cache, monkeypatch):
-    monkeypatch.setattr(
-        reference_data.urllib.request,
-        "urlopen",
-        lambda *a, **k: _FakeResponse(_fake_zip("rna_tissue_consensus.tsv", b"y")),
-    )
+    _stub_downloader(monkeypatch, b"y")
+
     before = {r["name"]: r for r in reference_data.status()}
     assert before["hpa_rna_consensus"]["cached"] is False
 
@@ -95,10 +84,21 @@ def test_status_reflects_cache_state(isolated_cache, monkeypatch):
     assert "v23" in after["hpa_rna_consensus"]["available_versions"]
 
 
-def test_non_zip_payload_written_verbatim(isolated_cache, monkeypatch):
+def test_download_failure_raises_reference_error(isolated_cache, monkeypatch):
+    def _boom(full_path, download_url, timeout=None, use_wget_if_available=False):
+        raise OSError("network down")
+
     monkeypatch.setattr(
-        reference_data.urllib.request, "urlopen", lambda *a, **k: _FakeResponse(b"\x1f\x8bRAWGZ")
+        reference_data.datacache.download, "_download_and_decompress_if_necessary", _boom
     )
+    with pytest.raises(reference_data.ReferenceDataError):
+        reference_data.download("ncbi_gene_info")
+
+
+def test_gz_payload_kept_verbatim(isolated_cache, monkeypatch):
+    # gene_info is a .gz whose local name keeps the .gz suffix (datacache leaves
+    # it compressed); the stub mirrors that by writing the raw bytes.
+    _stub_downloader(monkeypatch, b"\x1f\x8bRAWGZ")
     path = reference_data.download("ncbi_gene_info")
     assert path.read_bytes() == b"\x1f\x8bRAWGZ"
     assert path.name == "Homo_sapiens.gene_info.gz"

--- a/tsarina/reference_data.py
+++ b/tsarina/reference_data.py
@@ -24,25 +24,25 @@ pair).
 Surfaced on the CLI as ``tsarina reference {list,fetch,path}`` -- the
 HPA/NCBI counterpart of the hitlist-backed ``tsarina data`` (IEDB/CEDAR/viral).
 
-Cache layout (one subdir per dataset+version, plus a JSON manifest)::
+Cache dir resolution + download/decompress are delegated to **datacache** (the
+same openvax layer pyensembl uses), so we don't hand-roll them.  The base dir is
+``$TSARINA_DATA_DIR`` if set, else a platform-appropriate ``appdirs`` dir (e.g.
+``~/Library/Caches/tsarina`` on macOS).  Layout (one subdir per dataset+version,
+plus a JSON manifest this module adds on top of datacache)::
 
     <cache>/sources/<name>/<version>/<filename>
     <cache>/sources/manifest.json
-
-The cache dir is ``$TSARINA_DATA_DIR`` if set, else ``<repo>/.cache`` when run
-from a source checkout, else ``~/.cache/tsarina``.
 """
 
 from __future__ import annotations
 
 import hashlib
-import io
 import json
-import os
-import urllib.request
-import zipfile
 from datetime import datetime, timezone
 from pathlib import Path
+
+import datacache
+import datacache.download
 
 #: Default HPA release.  ``v23`` is the most recent HPA version whose download
 #: mirror serves *both* ``rna_tissue_consensus`` and ``normal_tissue`` as a
@@ -94,20 +94,22 @@ class ReferenceDataError(RuntimeError):
 # ── Cache location ───────────────────────────────────────────────────────────
 
 
+#: Env var pointing the cache at a custom location (mirrors pyensembl's
+#: ``PYENSEMBL_CACHE_DIR``).  When unset, datacache picks a platform-appropriate
+#: dir via ``appdirs`` (e.g. ``~/Library/Caches/tsarina`` on macOS).
+CACHE_DIR_ENV_KEY = "TSARINA_DATA_DIR"
+
+
 def cache_dir() -> Path:
-    """Return the reference-data cache directory (created on demand)."""
-    env = os.environ.get("TSARINA_DATA_DIR")
-    if env:
-        base = Path(env).expanduser()
-    else:
-        repo_cache = Path(__file__).resolve().parent.parent / ".cache"
-        # Use the repo's .cache only from a source checkout (where scripts/ lives).
-        if (repo_cache.parent / "scripts").is_dir():
-            base = repo_cache
-        else:
-            base = Path.home() / ".cache" / "tsarina"
-    sources = base / "sources"
-    sources.mkdir(parents=True, exist_ok=True)
+    """Return the reference-data cache directory (created on demand).
+
+    Delegates dir resolution to ``datacache.get_data_dir`` -- the same
+    download/cache layer pyensembl uses -- so tsarina, pyensembl, and other
+    openvax tools share one convention instead of hand-rolling cache paths.
+    """
+    base = datacache.get_data_dir(subdir="tsarina", envkey=CACHE_DIR_ENV_KEY)
+    sources = Path(base) / "sources"
+    datacache.ensure_dir(str(sources))
     return sources
 
 
@@ -165,21 +167,13 @@ def is_cached(name: str, version: str | None = None) -> bool:
 # ── Download ─────────────────────────────────────────────────────────────────
 
 
-def _extract_to(raw: bytes, url: str, dest: Path) -> None:
-    """Write *raw* (a .zip or plain payload) to *dest*, unzipping if needed."""
-    dest.parent.mkdir(parents=True, exist_ok=True)
-    if url.endswith(".zip"):
-        with zipfile.ZipFile(io.BytesIO(raw)) as zf:
-            member = next(n for n in zf.namelist() if n.endswith(dest.suffix))
-            dest.write_bytes(zf.read(member))
-    else:
-        dest.write_bytes(raw)
-
-
 def download(name: str, version: str | None = None, *, force: bool = False) -> Path:
     """Download *name*/*version* into the cache and record it in the manifest.
 
     Returns the local path.  A cached copy is reused unless ``force=True``.
+    The actual fetch + ``.zip``/``.gz`` decompression is delegated to datacache
+    (same as pyensembl); this layer adds the dataset registry, version pinning,
+    and the provenance manifest that datacache does not provide.
     """
     version = resolve_version(name, version)
     spec = _dataset(name)
@@ -189,13 +183,15 @@ def download(name: str, version: str | None = None, *, force: bool = False) -> P
     if dest.exists() and not force:
         return dest
 
+    datacache.ensure_dir(str(dest.parent))
     try:
-        with urllib.request.urlopen(url, timeout=600) as response:
-            raw = response.read()
-    except Exception as e:  # surface any network/HTTP failure uniformly
+        datacache.download._download_and_decompress_if_necessary(
+            full_path=str(dest),
+            download_url=url,
+            timeout=600,
+        )
+    except Exception as e:  # surface any network/HTTP/decompress failure uniformly
         raise ReferenceDataError(f"failed to download {name} ({url}): {e}") from e
-
-    _extract_to(raw, url, dest)
 
     manifest = _read_manifest()
     manifest[name] = {

--- a/tsarina/version.py
+++ b/tsarina/version.py
@@ -10,4 +10,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "1.9.2"
+__version__ = "1.10.0"


### PR DESCRIPTION
Answers the "why not datacache?" question. hitlist and tsarina each hand-rolled cache-dir resolution + download, while **pyensembl** (same openvax ecosystem) already uses `datacache` for exactly this. `reference_data` now does too.

## Change
- **`cache_dir()`** → `datacache.get_data_dir(subdir="tsarina", envkey="TSARINA_DATA_DIR")` + `ensure_dir`. Platform-appropriate via `appdirs` (e.g. `~/Library/Caches/tsarina`) when the env var is unset, replacing the bespoke repo-`.cache` / `~/.cache` fallback.
- **`download()`** → `datacache.download._download_and_decompress_if_necessary(...)` — the same helper pyensembl's `download_cache` calls (`download_cache.py:229`) — replacing the hand-rolled `urllib` fetch + `zipfile`/`_extract_to`. Handles `.zip` and `.gz`.
- Dropped `urllib`, `zipfile`, `io`, and the bespoke dir logic.

The **value-add datacache doesn't provide stays here**: the dataset registry, HPA **version pinning** (v23 vs latest), and the sha256/version/timestamp **manifest**.

## Dependency
`datacache` promoted to a **direct** dependency — it was only transitive via the *optional* `pyensembl` extra, but `tsarina reference` / the curation scripts are core.

## Verification
Real end-to-end: `tsarina reference fetch hpa_rna_consensus` downloads the `.zip` and **decompresses to the identical 37,949,495-byte TSV** as the old path; manifest sha recorded. Reference-data tests rewritten to stub datacache's downloader (offline). **424 tests pass**; lint/format clean.

## Behavior change (intended)
Cache location moves from `<repo>/.cache/sources` (dev) / `~/.cache/tsarina` to the appdirs dir (`~/Library/Caches/tsarina/sources`), matching pyensembl. Existing cached files are simply re-fetched once on next use (idempotent).

> Companion: I'll file a hitlist issue proposing it adopt `datacache.get_data_dir` for its `~/.hitlist` resolution too, for ecosystem consistency.

Minor bump 1.9.2 → 1.10.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)