### PR TITLE
Sanity-check fixes: reference fetch, cutoff semantics, MS classification

### DIFF
--- a/tests/test_cli_reference.py
+++ b/tests/test_cli_reference.py
@@ -120,6 +120,57 @@ def test_reference_fetch_continues_past_failures(monkeypatch, capsys):
     assert "hpa_normal_tissue" in err and "Failed to fetch" in err
 
 
+def test_is_hpa_dataset_distinguishes_kinds():
+    from tsarina import reference_data
+
+    assert reference_data.is_hpa_dataset("hpa_rna_consensus")
+    assert reference_data.is_hpa_dataset("hpa_normal_tissue")
+    # The rolling NCBI dataset is not version-pinned to an HPA release.
+    assert not reference_data.is_hpa_dataset("ncbi_gene_info")
+    # Unknown datasets are not HPA (no spec to honor --hpa-version).
+    assert not reference_data.is_hpa_dataset("does_not_exist")
+
+
+def test_reference_fetch_hpa_version_only_forwarded_to_hpa_datasets(monkeypatch, capsys):
+    """`fetch all --hpa-version vNN` applies the version only to HPA datasets.
+
+    Regression: the version was forwarded to *every* dataset, so the rolling
+    ``ncbi_gene_info`` (which has no vNN release) raised and aborted the run
+    with exit 1 even though both HPA files downloaded fine.
+    """
+    from tsarina import reference_data
+
+    seen = {}
+
+    def _fake_download(name, version=None, force=False):
+        seen[name] = version
+        return f"/cache/{name}"
+
+    monkeypatch.setattr(reference_data, "download", _fake_download)
+    args = argparse.Namespace(names=[], hpa_version="v23", force=False)
+    cli._reference_fetch(args)  # must not raise / exit
+
+    assert seen["hpa_rna_consensus"] == "v23"
+    assert seen["hpa_normal_tissue"] == "v23"
+    assert seen["ncbi_gene_info"] is None
+
+
+def test_reference_path_hpa_version_not_forwarded_to_non_hpa(monkeypatch, capsys):
+    """`path <ncbi> --hpa-version vNN` ignores the version for non-HPA datasets."""
+    from tsarina import reference_data
+
+    seen = {}
+
+    def _fake_local_path(name, version=None):
+        seen[name] = version
+        return f"/cache/{name}"
+
+    monkeypatch.setattr(reference_data, "local_path", _fake_local_path)
+    args = argparse.Namespace(name="ncbi_gene_info", hpa_version="v23")
+    cli._reference_path(args)
+    assert seen["ncbi_gene_info"] is None
+
+
 def test_data_bare_defaults_to_list(monkeypatch, capsys):
     """Bare `tsarina data` routes to list (not a usage error), like reference.
 

--- a/tests/test_tiers.py
+++ b/tests/test_tiers.py
@@ -332,6 +332,26 @@ def test_ms_recurrent_healthy():
     assert result.iloc[0]["ms_restriction"] == "RECURRENT_HEALTHY"
 
 
+def test_ms_unclassified_for_source_free_evidence():
+    # A peptide with MS evidence but no classifiable source flag (e.g. cell-line
+    # only, which the classifier ignores) must be UNCLASSIFIED_MS, *not*
+    # NO_MS_DATA -- the gene does have MS data, just none we can place.
+    hits = pd.DataFrame(
+        {
+            "peptide": ["ABCDEFGH"],
+            "src_cancer": [False],
+            "src_healthy_tissue": [False],
+            "src_healthy_reproductive": [False],
+            "src_healthy_thymus": [False],
+            "source_tissue": ["cell_line"],
+        }
+    )
+    gene_map = pd.DataFrame({"peptide": ["ABCDEFGH"], "gene_name": ["GENE1"]})
+    result = aggregate_gene_ms_safety(hits, gene_map)
+    assert result.iloc[0]["ms_peptide_count"] > 0
+    assert result.iloc[0]["ms_restriction"] == "UNCLASSIFIED_MS"
+
+
 def test_ms_cta_exclusive_counts_are_separate_from_all_cta_counts():
     hits = pd.DataFrame(
         {

--- a/tests/test_tiers.py
+++ b/tests/test_tiers.py
@@ -36,7 +36,7 @@ def test_rna_restriction_levels():
 
 
 def test_ms_restriction_values():
-    assert len(MS_RESTRICTION_VALUES) == 5
+    assert len(MS_RESTRICTION_VALUES) == 6
 
 
 def test_confidence_values():

--- a/tsarina/cancer_expression.py
+++ b/tsarina/cancer_expression.py
@@ -63,14 +63,22 @@ def cta_cancer_expression_features(
     )
     ihc_features = _ihc_features(ihc, cancer_type_prevalence_floor=cancer_type_prevalence_floor)
 
+    if rna_features.empty and ihc_features.empty:
+        return rna_features  # empty frame with [gene_id, symbol]
     if rna_features.empty:
-        return ihc_features
-    if ihc_features.empty:
+        out = ihc_features
+    elif ihc_features.empty:
         out = rna_features
     else:
         out = rna_features.merge(ihc_features, on=["gene_id", "symbol"], how="left")
 
     defaults = {
+        # RNA features are absent when there is no cancer RNA prevalence for
+        # these genes; default them so tumor_prevalence_panel_score still
+        # computes (the function's documented output) instead of KeyError-ing.
+        "cancer_rna_prevalent_cancer_type_count": 0,
+        "cancer_rna_sample_prevalence": 0.0,
+        "cancer_rna_max_cancer_type_prevalence": 0.0,
         "cancer_ihc_total_samples": 0,
         "cancer_ihc_detected_samples": 0,
         "cancer_ihc_medium_high_samples": 0,

--- a/tsarina/cli.py
+++ b/tsarina/cli.py
@@ -171,8 +171,11 @@ def _reference_fetch(args: argparse.Namespace) -> None:
     # Attempt every dataset; a single flaky URL shouldn't abort a "fetch all".
     failures = []
     for name in names:
+        # --hpa-version only applies to HPA datasets; the rolling NCBI dataset
+        # has no such version and would otherwise fail a "fetch all" run.
+        version = args.hpa_version if reference_data.is_hpa_dataset(name) else None
         try:
-            path = reference_data.download(name, version=args.hpa_version, force=args.force)
+            path = reference_data.download(name, version=version, force=args.force)
         except reference_data.ReferenceDataError as e:
             print(f"Error: {name}: {e}", file=sys.stderr)
             failures.append(name)
@@ -186,8 +189,9 @@ def _reference_fetch(args: argparse.Namespace) -> None:
 def _reference_path(args: argparse.Namespace) -> None:
     from . import reference_data
 
+    version = args.hpa_version if reference_data.is_hpa_dataset(args.name) else None
     try:
-        print(reference_data.local_path(args.name, version=args.hpa_version))
+        print(reference_data.local_path(args.name, version=version))
     except reference_data.ReferenceDataError as e:
         print(f"Error: {e}", file=sys.stderr)
         sys.exit(1)

--- a/tsarina/evidence.py
+++ b/tsarina/evidence.py
@@ -78,16 +78,16 @@ def CTA_evidence() -> pd.DataFrame:
         True if no HPA protein data AND maximum RNA nTPM < 2.
     protein_restriction : str
         Protein-based tissue restriction: ``TESTIS``, ``PLACENTAL``,
-        or ``NO_DATA`` (no protein data).
+        ``REPRODUCTIVE``, ``SOMATIC``, or ``NO_DATA`` (no protein data).
     protein_testis, protein_ovary, protein_placenta : str
         Per-tissue IHC detection: ``"True"`` / ``"False"`` if protein
         data exists, empty string if no protein data.
     rna_restriction : str
         RNA-based tissue restriction: ``TESTIS``, ``PLACENTAL``,
-        ``REPRODUCTIVE``, or ``NO_DATA``.
+        ``REPRODUCTIVE``, ``SOMATIC``, or ``NO_DATA``.
     rna_restriction_level : str
-        RNA restriction quality: ``STRICT`` / ``MODERATE`` / ``PERMISSIVE``
-        or empty.
+        RNA restriction quality: ``STRICT`` / ``MODERATE`` / ``PERMISSIVE`` /
+        ``LEAKY`` or ``NO_DATA``.
     rna_testis_ntpm, rna_ovary_ntpm, rna_placenta_ntpm : float
         Per-tissue RNA expression (nTPM) from HPA consensus.
     rna_max_somatic_tissue : str

--- a/tsarina/peptides.py
+++ b/tsarina/peptides.py
@@ -186,7 +186,10 @@ def cta_peptides(
                 continue
             try:
                 seq = t.protein_sequence
-            except Exception:
+            except (ValueError, KeyError, TypeError):
+                # pyensembl raises these for transcripts lacking a usable
+                # translation; let unexpected errors surface rather than
+                # silently dropping the transcript.
                 continue
             if seq and len(seq) > best_length:
                 best_transcript = t
@@ -273,7 +276,11 @@ def _non_cta_overlapping_peptides(
                 continue
             try:
                 protein = transcript.protein_sequence
-            except Exception:
+            except (ValueError, KeyError, TypeError):
+                # pyensembl raises these for transcripts lacking a usable
+                # translation. Narrowed deliberately: silently swallowing every
+                # error here could skip a non-CTA protein and let a peptide pass
+                # as CTA-exclusive when it is not.
                 continue
             if not protein:
                 continue

--- a/tsarina/personalize.py
+++ b/tsarina/personalize.py
@@ -398,7 +398,9 @@ def _attach_ms_evidence(
         },
         cell_line_output=None,
     )
-    combined = combined.merge(hit_agg, on="peptide", how="left")
+    # validate="m:1": hit_agg is one row per peptide; fail loudly rather than
+    # silently multiply candidate rows if that invariant ever breaks.
+    combined = combined.merge(hit_agg, on="peptide", how="left", validate="m:1")
 
     int_cols = {"ms_hit_count", "ms_allele_count"}
     bool_cols = {"ms_in_cancer", "ms_in_healthy_tissue"}

--- a/tsarina/reference_data.py
+++ b/tsarina/reference_data.py
@@ -153,6 +153,16 @@ def resolve_version(name: str, version: str | None = None) -> str:
     return version
 
 
+def is_hpa_dataset(name: str) -> bool:
+    """True if *name* is version-pinned to an HPA release (honors ``--hpa-version``).
+
+    Non-HPA datasets (e.g. the rolling NCBI gene_info) ignore an HPA version, so
+    callers should not forward ``--hpa-version`` to them.
+    """
+    spec = REFERENCE_DATASETS.get(name)
+    return bool(spec and spec["kind"] == "hpa")
+
+
 def local_path(name: str, version: str | None = None) -> Path:
     """Return the expected cache path for *name*/*version* (may not exist yet)."""
     version = resolve_version(name, version)

--- a/tsarina/selection.py
+++ b/tsarina/selection.py
@@ -34,7 +34,6 @@ import pandas as pd
 def greedy_select_genes(
     candidate_df: pd.DataFrame,
     n_genes: int = 10,
-    coverage_col: str = "candidate_pmhc_count",
     ms_col: str | None = "ms_hit_count",
     expression_col: str | None = "source_tpm",
     mtec_col: str | None = "mean_mtec_tpm",
@@ -52,8 +51,6 @@ def greedy_select_genes(
         plus optional scoring columns. One row per gene-peptide pair.
     n_genes
         Number of genes to select (default 10).
-    coverage_col
-        Column with pMHC candidate count per gene (computed if missing).
     ms_col
         Column for MS evidence count tie-breaking. None to skip.
     expression_col

--- a/tsarina/spanning.py
+++ b/tsarina/spanning.py
@@ -1961,13 +1961,16 @@ def _candidate_rows(
             if tier == "unrestricted_ms" and key not in evidence_stats:
                 key = (peptide, None, tier)
             tier_evidence = evidence_stats.get(key)
-            if tier_evidence is not None and percentile < cutoffs[tier]:
+            # Inclusive: the docstrings call these the *maximum* percentile, and
+            # personalize._assign_tiers uses an inclusive (<=) cutoff too.
+            if tier_evidence is not None and percentile <= cutoffs[tier]:
                 chosen_tier = tier
                 evidence = tier_evidence
                 break
 
         if chosen_tier is None:
-            if not include_predicted_only or percentile >= cutoffs["predicted_only"]:
+            # Inclusive maximum: reject only when strictly above the cutoff.
+            if not include_predicted_only or percentile > cutoffs["predicted_only"]:
                 continue
             chosen_tier = "predicted_only"
             evidence = {

--- a/tsarina/tiers.py
+++ b/tsarina/tiers.py
@@ -31,7 +31,7 @@ unified ``restriction`` with ``restriction_confidence``.
 **MS** (IEDB/CEDAR via hitlist, runtime):
 
 - ``ms_restriction``: CANCER_ONLY / EXPECTED_TISSUE / SINGLETON_HEALTHY /
-  RECURRENT_HEALTHY / NO_MS_DATA.
+  RECURRENT_HEALTHY / UNCLASSIFIED_MS / NO_MS_DATA.
 
 **Synthesized**:
 
@@ -60,6 +60,9 @@ MS_RESTRICTION_VALUES: list[str] = [
     "EXPECTED_TISSUE",
     "SINGLETON_HEALTHY",
     "RECURRENT_HEALTHY",
+    # Has MS evidence, but every observation is from an unclassified source
+    # (e.g. cell-line-only). Distinct from NO_MS_DATA (no MS evidence at all).
+    "UNCLASSIFIED_MS",
     "NO_MS_DATA",
 ]
 
@@ -172,10 +175,11 @@ _ALL_REPRODUCTIVE: frozenset[str] = _NON_SOMATIC | frozenset({"endometrium 1", "
 def assign_protein_restriction(row: pd.Series) -> str:
     """Assign tissue restriction from IHC protein data.
 
-    Returns one of: TESTIS, PLACENTAL, REPRODUCTIVE, SOMATIC, or empty.
+    Returns one of: TESTIS, PLACENTAL, REPRODUCTIVE, SOMATIC, or NO_DATA.
     Each single-tissue value means *only* that core tissue detected.
     REPRODUCTIVE means multiple reproductive tissues.
     SOMATIC means non-reproductive tissue detected.
+    NO_DATA means no protein expression data (after dropping thymus).
     """
     tissues = _parse_protein_tissues(str(row.get("protein_strict_expression", "")))
     if not tissues:
@@ -717,7 +721,10 @@ def _classify_gene_ms_restriction(row: pd.Series) -> str:
             return "EXPECTED_TISSUE"
         if n_cancer > 0:
             return "CANCER_ONLY"
-        return "NO_MS_DATA"
+        # MS peptides exist (n_pep > 0) but none carry a classifiable source
+        # flag (cancer/reproductive/thymus/somatic) -- e.g. cell-line-only
+        # evidence. Not the same as having no MS data.
+        return "UNCLASSIFIED_MS"
 
     if n_somatic == 1 and n_somatic_tissues <= 1:
         return "SINGLETON_HEALTHY"

--- a/tsarina/version.py
+++ b/tsarina/version.py
@@ -10,4 +10,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "1.10.0"
+__version__ = "1.11.0"


### PR DESCRIPTION
A sanity-check pass over the codebase turned up a handful of real issues. Each is fixed here with a focused change; all 424 tests pass, lint + format clean.

## Confirmed bugs
- **`tsarina reference fetch --hpa-version vNN` (fetch-all) always exited 1.** The flag was forwarded to *every* dataset, but the rolling `ncbi_gene_info` has no `vNN` version → `ReferenceDataError` → failure + `sys.exit(1)`, even though both HPA files downloaded fine. Now `--hpa-version` is only applied to HPA datasets (new `reference_data.is_hpa_dataset` helper), in both `fetch` and `path`.
- **`cancer_expression`: empty-RNA edge dropped the score column.** When RNA features were empty but IHC features existed, the function returned the IHC-only frame, missing the documented `tumor_prevalence_panel_score` and all `cancer_rna_*` columns (KeyError risk). Now the RNA columns are defaulted and the score always computes.
- **`tiers`: cell-line-only MS evidence was mislabeled `NO_MS_DATA`.** A peptide with MS evidence but no classifiable source flag (e.g. `src_cell_line` only — which the classifier ignores) returned `NO_MS_DATA` despite `ms_peptide_count > 0`. Now returns a distinct **`UNCLASSIFIED_MS`** category. *(See note below — this embeds a small scientific judgment.)*

## Consistency / hardening
- **`spanning`: percentile cutoffs made inclusive** (`<=` for MS tiers, `>` for predicted-only rejection), matching the "Maximum percentile" docstrings and the inclusive cutoff already used by `personalize._assign_tiers`. Previously a peptide exactly at the cutoff was dropped in one pipeline but kept in the other.
- **`personalize`: ms-hit merge now `validate="m:1"`** — fail loudly instead of silently multiplying candidate rows if `aggregate_ms_hits_by_peptide` ever returns >1 row/peptide.
- **`peptides`: narrowed `except Exception` → `(ValueError, KeyError, TypeError)`** around `protein_sequence`, so a real error can't masquerade as a missing translation. Matters most in `_non_cta_overlapping_peptides`, where silently skipping a non-CTA protein could let a peptide pass as CTA-exclusive when it isn't.
- **`selection`: removed the dead, misleading `coverage_col` parameter** (never read; docstring claimed "computed if missing").
- Docstring fixes for restriction return-value sets (`tiers`, `evidence`) that omitted `SOMATIC` / `REPRODUCTIVE` / `LEAKY` / `NO_DATA`.

## Note for review
`UNCLASSIFIED_MS` is a new `MS_RESTRICTION_VALUES` entry (ranked just above `NO_MS_DATA`; counts as an evidence source with no confidence bonus). The conservative choice was to *not* assert that cell-line evidence is cancer evidence. The alternative — folding `src_cell_line` into `has_cancer` so these classify as `CANCER_ONLY` — is reasonable if you consider immunopeptidomics cell lines tumor-derived. Happy to switch if you prefer that.

Version: 1.10.0 → 1.11.0