### PR TITLE
Group identical-protein paralogs SSX4/SSX4B and MAGEA2/MAGEA2B at pMHC level

### DIFF
--- a/tests/test_spanning.py
+++ b/tests/test_spanning.py
@@ -1421,6 +1421,54 @@ def test_xage1_explicit_group_panel_preserves_member_genes(monkeypatch):
     assert grouped["cta_members"] == "XAGE1A;XAGE1B"
 
 
+def test_ssx4_explicit_group_panel_preserves_member_genes(monkeypatch):
+    # SSX4 (ENSG00000268009) and SSX4B (ENSG00000269791) encode the identical
+    # 188-aa SSX4 protein, so an identical peptide observed under both must
+    # collapse to a single SSX4/SSX4B antigen — the CTAG1A/CTAG1B (NY-ESO-1) and
+    # XAGE1A/XAGE1B situation. Selecting via the bare "SSX4" alias resolves to the
+    # explicit group and the panel reports both member genes.
+    peptides = pd.DataFrame(
+        {
+            "peptide": ["SSX4PEP1", "SSX4PEP1", "PAGE2PEP1"],
+            "length": [9, 9, 9],
+            "gene_name": ["SSX4", "SSX4B", "PAGE2"],
+            "gene_id": ["E20", "E21", "E22"],
+        }
+    )
+    monkeypatch.setattr(
+        "tsarina.peptides.cta_exclusive_peptides", lambda **kw: peptides, raising=True
+    )
+    monkeypatch.setattr(
+        "tsarina.gene_sets.CTA_gene_names",
+        lambda: {"SSX4", "SSX4B", "PAGE2"},
+        raising=True,
+    )
+    monkeypatch.setattr(
+        "tsarina.loader.cta_dataframe",
+        lambda: pd.DataFrame(
+            {
+                "Symbol": ["SSX4", "SSX4B", "PAGE2"],
+                "ms_cta_exclusive_cancer_peptide_count": [3, 2, 1],
+            }
+        ),
+        raising=True,
+    )
+
+    long = spanning_pmhc_set(
+        ctas=["SSX4", "PAGE2"],  # selected by the bare SSX4 alias
+        alleles=["HLA-A*02:01"],
+        max_percentile=10.0,
+        peptides_per_cell=1,
+        output_format="long",
+    )
+
+    assert "SSX4/SSX4B" in long.attrs["cta_order"]
+    group = next(g for g in long.attrs["cta_groups"] if g["cta"] == "SSX4/SSX4B")
+    assert group["members"] == ["SSX4", "SSX4B"]
+    grouped = long[long["cta"] == "SSX4/SSX4B"].iloc[0]
+    assert grouped["cta_members"] == "SSX4;SSX4B"
+
+
 def test_automatic_backfill_counts_distinct_cta_pmhc_groups(monkeypatch):
     peptides = pd.DataFrame(
         {

--- a/tsarina/spanning.py
+++ b/tsarina/spanning.py
@@ -106,6 +106,34 @@ _XAGE1_ALIASES = {
     "XAGE1BXAGE1A",
     "GAGED2",
 }
+#: SSX4 (ENSG00000268009) and SSX4B (ENSG00000269791) are two distinct chrX loci
+#: that encode the *identical* 188-aa (and 153-aa) SSX4 protein — the same
+#: situation as CTAG1A/CTAG1B (NY-ESO-1) and XAGE1A/XAGE1B.  They are one antigen
+#: at the pMHC level, so group them to avoid double-counting identical peptides.
+#: HGNC names the primary locus ``SSX4`` (not ``SSX4A``); ``SSX4A`` is accepted as
+#: a non-standard alias since the symmetric A/B naming is a plausible expectation.
+_SSX4_GROUP_LABEL = "SSX4/SSX4B"
+_SSX4_ALIASES = {
+    "SSX4",
+    "SSX4A",
+    "SSX4B",
+    "SSX4AB",
+    "SSX4SSX4B",
+    "SSX4BSSX4",
+}
+#: MAGEA2 (ENSG00000268606) and MAGEA2B (ENSG00000183305) likewise encode the
+#: identical 314-aa MAGE-A2 protein at distinct chrX loci.  ``MAGEA2A`` is an
+#: HGNC-listed alias of MAGEA2.  Grouped for the same pMHC-dedup reason; note the
+#: pair is also subject to the non-MAGEA4 MAGE-family default exclusion.
+_MAGEA2_GROUP_LABEL = "MAGEA2/MAGEA2B"
+_MAGEA2_ALIASES = {
+    "MAGEA2",
+    "MAGEA2A",
+    "MAGEA2B",
+    "MAGEA2AB",
+    "MAGEA2MAGEA2B",
+    "MAGEA2BMAGEA2",
+}
 _DEFAULT_SELECTION_ALLOWLIST = ("PRAME", _CTAG1_GROUP_LABEL, "MAGEA4")
 _DEFAULT_VITAL_TISSUE_MAX_NTPM = 2.0
 _DEFAULT_EXCLUDE_NON_MAGEA4_MAGE_FAMILY = True
@@ -116,13 +144,18 @@ _DEFAULT_ANNOTATE_NETMHCPAN_AFFINITY = False
 _CTA_GROUPS: dict[str, tuple[str, ...]] = {
     _CTAG1_GROUP_LABEL: ("CTAG1A", "CTAG1B"),
     _XAGE1_GROUP_LABEL: ("XAGE1A", "XAGE1B"),
+    _SSX4_GROUP_LABEL: ("SSX4", "SSX4B"),
+    _MAGEA2_GROUP_LABEL: ("MAGEA2", "MAGEA2B"),
 }
 
 #: Compact (uppercase-alphanumeric) alias -> grouped CTA label.  Single source
-#: of truth for resolving NY-ESO-1 / XAGE1 style names to their group.
+#: of truth for resolving NY-ESO-1 / XAGE1 / SSX4 / MAGEA2 style names to their
+#: identical-protein group.
 _GROUP_ALIAS_TO_LABEL: dict[str, str] = {
     **dict.fromkeys(_CTAG1_ALIASES, _CTAG1_GROUP_LABEL),
     **dict.fromkeys(_XAGE1_ALIASES, _XAGE1_GROUP_LABEL),
+    **dict.fromkeys(_SSX4_ALIASES, _SSX4_GROUP_LABEL),
+    **dict.fromkeys(_MAGEA2_ALIASES, _MAGEA2_GROUP_LABEL),
 }
 
 _VITAL_TISSUE_RNA_COLUMNS: tuple[str, ...] = (

--- a/tsarina/version.py
+++ b/tsarina/version.py
@@ -10,4 +10,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "1.12.1"
+__version__ = "1.13.0"


### PR DESCRIPTION
## Summary

Groups two identical-protein CTA paralog pairs at the pMHC level so their shared peptides aren't double-counted in a panel — exactly like the existing **CTAG1A/CTAG1B** (NY-ESO-1) and **XAGE1A/XAGE1B** groups.

| Group | Loci | Shared protein |
|---|---|---|
| `SSX4/SSX4B` | ENSG00000268009 + ENSG00000269791 | identical 188-aa (and 153-aa) SSX4 |
| `MAGEA2/MAGEA2B` | ENSG00000268606 + ENSG00000183305 | identical 314-aa MAGE-A2 |

Both verified byte-identical against Ensembl 111 (both shared isoforms match). Registered as explicit `_CTA_GROUPS` entries with member aliases, mirroring the CTAG1/XAGE1 pattern. Selecting via the bare `SSX4` alias now resolves to `SSX4/SSX4B` and the panel reports both member genes.

## On the naming question

HGNC names the primary loci **`SSX4`** and **`MAGEA2`** — there is no `SSX4A`/`MAGEA2A` *gene*. The symmetric A/B naming exists only for CTAG1 and XAGE1. So the group labels are `SSX4/SSX4B` and `MAGEA2/MAGEA2B`. `SSX4A`/`MAGEA2A` are still accepted as aliases that resolve to the group (a plausible thing for a user to type; `MAGEA2A` is in fact an HGNC-listed alias of MAGEA2).

## Scope — what this does NOT do

This is **pMHC-level grouping only**. It does **not** sum TPM to proteoform level. The current cross-member expression aggregation (`_tcga_summary_for_cta`) is **`max`, TCGA-only, and private** — it never sums per-sample TPM. The real fix — a **public, cross-dataset, proteoform-level TPM-sum API** (sum each sample's TPM across identical-protein members *before* prevalence/percentile, uniformly for CTAG1A/B, XAGE1A/B, SSX4/SSX4B, MAGEA2/MAGEA2B, …) — lands separately in **cancerdata**, the only layer with per-sample matrices across all datasets. Tracked as follow-up.

## Notes

- MAGEA2 is subject to the non-MAGEA4 MAGE-family default exclusion and MAGEA2B is `never_expressed`, so the MAGEA2 group is inert in default panels but correct when those filters are off.
- **Stacked on #111** (`add-placental-antigens`) — it needs SSX4B/MAGEA2B present in the CTA table. Merge #111 first, then this retargets to `main`.

## Verification

- `./format.sh`, `./lint.sh` clean; `./test.sh` → **430 passed** (adds `test_ssx4_explicit_group_panel_preserves_member_genes`, mirroring the XAGE1 group test)
- Version bumped 1.12.1 → 1.13.0
