### PR TITLE
Fragment-model QC: refuse stub gene models at addition time (closes #108)

### DIFF
--- a/scripts/add_cta_gene.py
+++ b/scripts/add_cta_gene.py
@@ -216,6 +216,23 @@ def build_row(spec: dict, consensus: pd.DataFrame, columns: list[str], consensus
     sub = consensus[consensus["Gene"] == ensg]
     if sub.empty:
         raise SystemExit(f"{spec['Symbol']} ({ensg}) not found in consensus TSV")
+
+    # Refuse degenerate fragment gene models (tsarina#108). A candidate whose
+    # annotated protein is a stub -- e.g. GAGE12B's 7-aa ENSG00000236737, the
+    # shared GAGE C-terminus -- is a mis-annotation, not an antigen, and its HPA
+    # gene-level nTPM is quantification noise. Unlike a reproductive-filter
+    # failure (recorded as passes_filters=False below), this is never a valid
+    # candidate, so refuse it at addition time where pyensembl data is available.
+    from tsarina.qc import MIN_CTA_PROTEIN_AA, gene_max_protein_length
+
+    protein_length = gene_max_protein_length(ensg)
+    if protein_length is None or protein_length < MIN_CTA_PROTEIN_AA:
+        raise SystemExit(
+            f"{spec['Symbol']} ({ensg}): longest protein is "
+            f"{protein_length} aa (< {MIN_CTA_PROTEIN_AA} aa floor); "
+            "refusing to add a fragment gene model."
+        )
+
     ntpm = {t.strip().lower(): float(v) for t, v in zip(sub["Tissue"], sub["nTPM"])}
 
     core = CORE_REPRODUCTIVE_TISSUES

--- a/tests/test_qc.py
+++ b/tests/test_qc.py
@@ -1,0 +1,132 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Fragment-model QC (tsarina#108).
+
+Flagging logic is exercised with an injected ``length_fn`` so it runs in CI,
+which does not download pyensembl reference data. A single integration test
+hits real pyensembl and skips when the data is unavailable.
+"""
+
+import pandas as pd
+import pytest
+
+from tsarina.qc import (
+    MIN_CTA_PROTEIN_AA,
+    find_fragment_gene_models,
+    gene_max_protein_length,
+)
+
+
+def _df(rows):
+    return pd.DataFrame(rows, columns=["Symbol", "Ensembl_Gene_ID"])
+
+
+def _lengths(mapping):
+    """Build a length_fn from a {gene_id: length|None} dict."""
+    return lambda gene_id: mapping.get(gene_id)
+
+
+def test_floor_separates_real_cta_from_fragment():
+    # The floor must sit above the canonical fragment (GAGE12B, 7 aa) and below
+    # the smallest real CTA in the bundled table (PRM1, 51 aa).
+    assert 7 < MIN_CTA_PROTEIN_AA < 51
+
+
+def test_flags_fragment_not_real_genes():
+    df = _df(
+        [
+            ("GAGE12B", "ENSG00000236737"),  # 7-aa stub
+            ("GAGE10", "ENSG00000215274"),  # 116-aa real GAGE
+            ("MAGEA1", "ENSG00000198681"),  # full-length
+        ]
+    )
+    length_fn = _lengths(
+        {
+            "ENSG00000236737": 7,
+            "ENSG00000215274": 116,
+            "ENSG00000198681": 309,
+        }
+    )
+    flagged = find_fragment_gene_models(df, length_fn=length_fn)
+    assert len(flagged) == 1
+    assert flagged[0]["symbol"] == "GAGE12B"
+    assert flagged[0]["gene_id"] == "ENSG00000236737"
+    assert flagged[0]["protein_length"] == 7
+    assert flagged[0]["reason"] == "fragment"
+
+
+def test_small_but_real_cta_not_flagged():
+    # PRM1 (protamine 1) is a legitimate 51-aa CTA; it must not be flagged.
+    df = _df([("PRM1", "ENSG00000175646")])
+    flagged = find_fragment_gene_models(df, length_fn=_lengths({"ENSG00000175646": 51}))
+    assert flagged == []
+
+
+def test_flags_gene_with_no_protein():
+    df = _df([("FOO", "ENSG09999999999")])
+    flagged = find_fragment_gene_models(df, length_fn=_lengths({"ENSG09999999999": None}))
+    assert len(flagged) == 1
+    assert flagged[0]["reason"] == "no_protein"
+    assert flagged[0]["protein_length"] is None
+
+
+def test_handles_versioned_and_multivalue_ids():
+    # Versioned IDs are stripped; ;-separated cells are split and each checked.
+    df = _df([("X", "ENSG00000236737.3"), ("Y", "ENSG00000215274;ENSG00000236737")])
+    length_fn = _lengths({"ENSG00000236737": 7, "ENSG00000215274": 116})
+    flagged = find_fragment_gene_models(df, length_fn=length_fn)
+    # Both X and Y's second ID resolve to the 7-aa fragment.
+    assert {f["symbol"] for f in flagged} == {"X", "Y"}
+    assert all(f["gene_id"] == "ENSG00000236737" for f in flagged)
+
+
+def test_clean_table_returns_empty():
+    df = _df([("A", "ENSG1"), ("B", "ENSG2")])
+    flagged = find_fragment_gene_models(df, length_fn=_lengths({"ENSG1": 120, "ENSG2": 300}))
+    assert flagged == []
+
+
+def test_custom_floor_is_respected():
+    df = _df([("A", "ENSG1")])
+    # 80 aa passes the default floor but trips a stricter 100-aa floor.
+    assert find_fragment_gene_models(df, length_fn=_lengths({"ENSG1": 80})) == []
+    flagged = find_fragment_gene_models(df, length_fn=_lengths({"ENSG1": 80}), min_protein_aa=100)
+    assert len(flagged) == 1
+
+
+# ── Integration: real pyensembl (skips when reference data is absent) ──────────
+
+
+def _ensembl_or_skip():
+    try:
+        from pyensembl import EnsemblRelease
+
+        ensembl = EnsemblRelease(112)
+        ensembl.gene_by_id("ENSG00000198681")  # probe: triggers data load
+        return ensembl
+    except Exception as exc:  # data not downloaded in this environment (e.g. CI)
+        pytest.skip(f"pyensembl release 112 data unavailable: {exc}")
+
+
+def test_real_pyensembl_lengths_for_known_genes():
+    ensembl = _ensembl_or_skip()
+    # GAGE12B is the 7-aa fragment; GAGE10 is the 116-aa real GAGE.
+    assert gene_max_protein_length("ENSG00000236737", ensembl=ensembl) == 7
+    assert gene_max_protein_length("ENSG00000215274", ensembl=ensembl) == 116
+
+
+def test_shipped_table_has_no_fragment_models():
+    _ensembl_or_skip()
+    # The bundled CTA universe must contain no fragment / no-protein gene models.
+    flagged = find_fragment_gene_models()
+    assert flagged == [], f"fragment gene models in shipped table: {flagged}"

--- a/tsarina/qc.py
+++ b/tsarina/qc.py
@@ -1,0 +1,159 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Quality-control checks for the curated CTA universe.
+
+The headline check is :func:`find_fragment_gene_models`, which flags candidate
+CTA Ensembl gene IDs whose annotated protein is a degenerate **fragment** rather
+than a real antigen.  This is the GAGE12B failure mode (tsarina#108): the ID
+``ENSG00000236737`` is a 117-bp, single-exon locus with a 7-residue ORF (the
+shared GAGE C-terminus), so its HPA gene-level nTPM is quantification noise on a
+malformed model rather than evidence of a real cancer-testis antigen.
+
+Detection uses a conservative **absolute** protein-length floor rather than the
+"< 50% of paralog-family median" heuristic first proposed in tsarina#108.  Real
+CTAs can be genuinely small -- the shortest in the bundled table is PRM1
+(protamine 1) at 51 aa, with several SPANX/XAGE members at 72-81 aa -- so a
+family-relative rule risks flagging legitimate small antigens, and grouping
+paralog "families" from symbols alone is unreliable.  A floor well below the
+smallest real CTA (51 aa) and well above a true fragment (GAGE12B, 7 aa) cleanly
+separates the two without that ambiguity.
+
+The length lookup is injectable (``length_fn``) so the flagging logic is unit-
+testable without pyensembl reference data, which CI does not download.
+"""
+
+from __future__ import annotations
+
+from typing import Callable
+
+import pandas as pd
+
+#: Minimum plausible protein length (aa) for a real CTA.  Below this a candidate
+#: is treated as a fragment / mis-annotated model.  Chosen conservatively: the
+#: smallest legitimate CTA in the bundled table is PRM1 at 51 aa, and the
+#: canonical fragment (GAGE12B, tsarina#108) is 7 aa, so this floor flags gross
+#: fragments without false-positiving on small-but-real antigens.
+MIN_CTA_PROTEIN_AA = 30
+
+
+def gene_max_protein_length(
+    gene_id: str,
+    *,
+    ensembl_release: int = 112,
+    ensembl=None,
+) -> int | None:
+    """Length (aa) of the longest protein-coding transcript for *gene_id*.
+
+    Returns ``None`` if the gene is unknown or has no translatable
+    protein-coding transcript.  Pass a pre-built ``ensembl``
+    (:class:`pyensembl.EnsemblRelease`) to amortize the lookup across many
+    genes.
+    """
+    if ensembl is None:
+        from pyensembl import EnsemblRelease
+
+        ensembl = EnsemblRelease(ensembl_release)
+
+    unversioned = str(gene_id).split(".")[0].strip()
+    try:
+        gene = ensembl.gene_by_id(unversioned)
+    except ValueError:
+        return None
+
+    best = 0
+    for transcript in gene.transcripts:
+        if transcript.biotype != "protein_coding":
+            continue
+        try:
+            protein = transcript.protein_sequence
+        except (ValueError, KeyError, TypeError):
+            # pyensembl raises these for transcripts lacking a usable
+            # translation; skip them rather than letting one bad transcript
+            # mask the gene's real protein-coding transcripts.
+            continue
+        if protein and len(protein) > best:
+            best = len(protein)
+    return best or None
+
+
+def find_fragment_gene_models(
+    df: pd.DataFrame | None = None,
+    *,
+    min_protein_aa: int = MIN_CTA_PROTEIN_AA,
+    length_fn: Callable[[str], int | None] | None = None,
+    ensembl_release: int = 112,
+) -> list[dict]:
+    """Flag CTA-table gene IDs whose annotated protein is a fragment.
+
+    Parameters
+    ----------
+    df
+        CTA evidence table (defaults to the bundled table via
+        :func:`tsarina.loader.cta_dataframe`).  Must have ``Symbol`` and
+        ``Ensembl_Gene_ID`` columns; the latter may hold ``;``-separated IDs.
+    min_protein_aa
+        Protein-length floor; IDs strictly below it are flagged ``"fragment"``.
+    length_fn
+        ``gene_id -> length_aa | None`` lookup.  Injectable so the flagging
+        logic is testable without pyensembl data.  Defaults to a pyensembl-
+        backed lookup at ``ensembl_release``.
+    ensembl_release
+        Ensembl release for the default ``length_fn``.
+
+    Returns
+    -------
+    list[dict]
+        One entry per flagged ID: ``{"symbol", "gene_id", "protein_length",
+        "reason"}``.  ``reason`` is ``"fragment"`` (length below the floor) or
+        ``"no_protein"`` (no protein-coding transcript at all).  Empty list when
+        every ID resolves to a plausible protein.
+    """
+    if df is None:
+        from .loader import cta_dataframe
+
+        df = cta_dataframe()
+
+    if length_fn is None:
+        from pyensembl import EnsemblRelease
+
+        ensembl = EnsemblRelease(ensembl_release)
+
+        def length_fn(gene_id: str) -> int | None:
+            return gene_max_protein_length(gene_id, ensembl=ensembl)
+
+    flagged: list[dict] = []
+    for symbol, id_cell in df[["Symbol", "Ensembl_Gene_ID"]].itertuples(index=False):
+        for raw_id in str(id_cell).split(";"):
+            gene_id = raw_id.split(".")[0].strip()
+            if not gene_id:
+                continue
+            length = length_fn(gene_id)
+            if length is None:
+                flagged.append(
+                    {
+                        "symbol": symbol,
+                        "gene_id": gene_id,
+                        "protein_length": None,
+                        "reason": "no_protein",
+                    }
+                )
+            elif length < min_protein_aa:
+                flagged.append(
+                    {
+                        "symbol": symbol,
+                        "gene_id": gene_id,
+                        "protein_length": length,
+                        "reason": "fragment",
+                    }
+                )
+    return flagged

--- a/tsarina/version.py
+++ b/tsarina/version.py
@@ -10,4 +10,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "1.13.0"
+__version__ = "1.14.0"


### PR DESCRIPTION
Closes #108. Systematizes the manual audit that caught GAGE12B (a degenerate 117-bp, 7-aa gene model) so the next one is refused automatically.

## What
- **`tsarina/qc.py`** — `find_fragment_gene_models(df, length_fn=...)` flags CTA-table gene IDs whose longest pyensembl protein is below a floor (or has no protein-coding transcript). `gene_max_protein_length()` does the lookup.
- **`scripts/add_cta_gene.py`** — `build_row` now refuses (SystemExit) any candidate whose protein is a fragment, *before* adding it. This is where GAGE12B would have been stopped, and it matters more now that filter failures are recorded as `passes_filters=False` rather than refused (#111).

## Design notes
- **Absolute floor (30 aa), not the #108 family-median heuristic.** Real CTAs can be genuinely small — the smallest in the table is **PRM1 at 51 aa**, with several SPANX/XAGE at 72–81 — so a "< 50% of family median" rule risks flagging legitimate small antigens, and grouping paralog families from symbols alone is unreliable. The floor sits well above the fragment (GAGE12B, 7 aa) and below the smallest real CTA (51 aa).
- **CI-safe.** CI doesn't download pyensembl data, so the flagging logic takes an injectable `length_fn` and is unit-tested without it. One integration test hits real pyensembl (incl. a table-wide no-fragments check) and **skips** when the data is absent — but still runs at release time (`deploy.sh` → `test.sh` on a dev machine with data).

## Verification
- 9 new tests; full suite **439 passed**, lint clean.
- Confirmed `build_row` refuses GAGE12B (`longest protein is 7 aa < 30 aa floor`) and all 388 shipped genes clear the floor.

Version: 1.13.0 → 1.14.0.