### PR TITLE
Remove redundant import-only smoke test (test suite audit)

### DIFF
--- a/tests/test_panels.py
+++ b/tests/test_panels.py
@@ -2,10 +2,6 @@ import pandas as pd
 import pytest
 
 
-def test_panels_module_imports():
-    from tsarina import panels  # noqa: F401
-
-
 def _panel_targets() -> pd.DataFrame:
     return pd.DataFrame(
         {

--- a/tsarina/version.py
+++ b/tsarina/version.py
@@ -10,4 +10,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "1.14.0"
+__version__ = "1.14.1"


### PR DESCRIPTION
Removes `test_panels_module_imports`, which did `from tsarina import panels` with **no assertion**. Every other test in `test_panels.py` imports `build_panel_matrix` from the module, so the import is already exercised — if it broke, those tests would fail at import. The smoke test added zero coverage.

## Context: full-suite "dumb test" audit
This is the **only** genuinely dead test found in an audit of all ~36 test files. The suite is otherwise disciplined. Tests that *look* tautological were examined and deliberately kept because they guard curated scientific data against drift the structural tests miss:

- **Constant-list pins** (`RESTRICTION_VALUES`, `CORE_REPRODUCTIVE_TISSUES`, …) pin order/membership that drives ranking and reproductive-fraction logic. Reordering a list still passes the monotonic-rank tests, so the explicit pin is the *only* guard.
- **Panel-size pins** (`IEDB27`=27, `global51`=51) catch exact-size drift the nested-subset tests miss (an allele dropped *within* a superset still passes subset checks).
- **"No-assert" tests** flagged by a naive scan are almost all `pytest.raises`/`pytest.warns` error-path tests (real assertions) or monkeypatched contract guards.

## Verification
`tests/test_panels.py` 6 tests pass; lint clean.

Version: 1.14.0 → 1.14.1.