### PR TITLE
Harden confidence-cap test: protein-exempt + boundary (#114 review follow-up)

### DIFF
--- a/tests/test_tiers.py
+++ b/tests/test_tiers.py
@@ -310,6 +310,17 @@ def test_confidence_capped_for_subfloor_rna_only():
     # MS evidence means real expression despite low RNA -> not capped.
     ms_row = {**base, "rna_max_ntpm": 1.6, "ms_restriction": "CANCER_ONLY"}
     assert synthesize_restriction(pd.Series(ms_row))[1] == "HIGH"
+    # Protein evidence (IHC) likewise means real expression -> not capped even
+    # at sub-floor RNA.
+    prot_row = {
+        **base,
+        "rna_max_ntpm": 1.0,
+        "protein_restriction": "TESTIS",
+        "protein_reliability": "Supported",
+    }
+    assert synthesize_restriction(pd.Series(prot_row))[1] == "HIGH"
+    # Boundary: exactly at the floor is "expressed" (cap is strict <), keeps HIGH.
+    assert synthesize_restriction(pd.Series({**base, "rna_max_ntpm": 2.0})) == ("TESTIS", "HIGH")
 
 
 # ── MS safety aggregation (unit tests with mock data) ────────────────────

--- a/tsarina/version.py
+++ b/tsarina/version.py
@@ -10,4 +10,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "1.15.0"
+__version__ = "1.15.1"


### PR DESCRIPTION
Follow-up from the PR #116 review. Adds two assertions to `test_confidence_capped_for_subfloor_rna_only` to pin behavior the existing test didn't cover:

- **Protein-exempt:** a sub-floor-RNA gene *with* IHC protein evidence keeps HIGH (the cap targets RNA-only genes, not all low-RNA genes).
- **At-floor boundary:** `rna_max_ntpm == 2.0` stays HIGH (the cap is strict `<`), locking the boundary against accidental `<=` drift.

Test-only; no behavior change. Lint clean.

Version: 1.15.0 → 1.15.1.