### PR TITLE
Fix NaN crash + NaN cutoff bypass in tiering/panel; gate RNA-agreement bonus

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
     # 1.43.0: VersionedDatasetRegistry — reference_data delegates its versioned
     # download/manifest/cache machinery to it; also the reusable download_to_file
     # (progress + cache status + .zip/.gz decompress).
-    "hitlist>=1.43.0",
+    "hitlist>=1.43.1",
     "mhcgnomes>=3.20.0",
     # Cache-dir resolution for `tsarina reference` (same openvax layer pyensembl
     # uses); the download/decompress itself goes through hitlist.

--- a/tests/test_spanning.py
+++ b/tests/test_spanning.py
@@ -1091,6 +1091,46 @@ def test_unrestricted_ms_tier_uses_processing_evidence(monkeypatch):
     assert row["ms_samples"] == "tumor"
 
 
+def test_nan_percentile_not_admitted_as_predicted_only(monkeypatch):
+    """C8: an unscored peptide (NaN presentation_percentile) must NOT slip
+    through as predicted_only. `nan > cutoff` is False, so without the explicit
+    guard it would be admitted despite having no presentation evidence."""
+    import numpy as np
+
+    empty_hits = pd.DataFrame(
+        columns=[
+            "peptide",
+            "mhc_restriction",
+            "mhc_allele_provenance",
+            "mhc_allele_set",
+            "is_monoallelic",
+        ]
+    )
+    monkeypatch.setattr(
+        "tsarina.ms_evidence.load_public_ms_hits", lambda peptides, **kw: empty_hits
+    )
+
+    def fake_score(peptides, alleles, predictor):
+        return pd.DataFrame(
+            [
+                {"peptide": p, "allele": a, "presentation_percentile": np.nan}
+                for p in peptides
+                for a in alleles
+            ]
+        )
+
+    monkeypatch.setattr("tsarina.scoring.score_presentation", fake_score)
+
+    out = spanning_pmhc_set(
+        ctas=["MAGEA4"],
+        alleles=["HLA-A*02:01"],
+        include_predicted_only=True,
+        predicted_only_max_percentile=0.2,
+        output_format="long",
+    )
+    assert out.empty  # NaN-percentile peptides rejected, not admitted
+
+
 def test_predicted_only_is_optional_and_last_priority(monkeypatch):
     empty_hits = pd.DataFrame(
         columns=[

--- a/tests/test_tiers.py
+++ b/tests/test_tiers.py
@@ -8,6 +8,8 @@ from tsarina.tiers import (
     RNA_RESTRICTION_LEVELS,
     aggregate_gene_ms_safety,
     assign_all_axes,
+    assign_rna_restriction,
+    assign_rna_restriction_level,
     confidence_rank,
     ms_restriction_rank,
     restriction_rank,
@@ -292,6 +294,64 @@ def test_assign_all_axes_matches_csv():
     assert (
         recomputed["restriction_confidence"].fillna("") == df["restriction_confidence"].fillna("")
     ).all()
+
+
+def test_rna_restriction_handles_nan_somatic_count():
+    """Regression: a present-but-NaN rna_somatic_detected_count (left-merge miss)
+    must not crash int() — it aborts the whole df.apply tiering pass otherwise."""
+    import numpy as np
+
+    row = pd.Series(
+        {
+            "rna_testis_ntpm": 5.0,
+            "rna_ovary_ntpm": 0.0,
+            "rna_placenta_ntpm": 0.0,
+            "rna_somatic_detected_count": np.nan,  # the crash trigger
+        }
+    )
+    assert assign_rna_restriction(row) == "TESTIS"  # NaN somatic -> 0 -> not somatic
+
+    lvl_row = pd.Series(
+        {"rna_deflated_reproductive_frac": 0.99, "rna_somatic_detected_count": np.nan}
+    )
+    assert assign_rna_restriction_level(lvl_row) in RNA_RESTRICTION_LEVELS
+
+
+def test_somatic_protein_not_boosted_by_disagreeing_reproductive_rna():
+    """C7: protein=SOMATIC genuinely disagrees with rna=REPRODUCTIVE, so the
+    agreement bonus must NOT fire (which would inflate the unsafe SOMATIC call to
+    HIGH and pass the selection filter)."""
+    row = pd.Series(
+        {
+            "protein_restriction": "SOMATIC",
+            "protein_reliability": "",
+            "rna_restriction": "REPRODUCTIVE",
+            "rna_restriction_level": "STRICT",
+            "ms_restriction": "NO_MS_DATA",
+        }
+    )
+    tissue, conf = synthesize_restriction(row)
+    assert tissue == "SOMATIC"
+    assert conf != "HIGH"
+
+
+def test_testis_protein_still_credited_by_coarse_reproductive_rna():
+    """The legitimate case the clause exists for: protein=TESTIS (a finer call)
+    agrees with rna=REPRODUCTIVE (coarser) — testis IS reproductive — so the
+    bonus still applies."""
+    row = pd.Series(
+        {
+            "protein_restriction": "TESTIS",
+            "protein_reliability": "",
+            "rna_restriction": "REPRODUCTIVE",
+            "rna_restriction_level": "STRICT",
+            "ms_restriction": "NO_MS_DATA",
+            "rna_max_ntpm": 5.0,
+        }
+    )
+    tissue, conf = synthesize_restriction(row)
+    assert tissue == "TESTIS"
+    assert conf == "HIGH"
 
 
 def test_confidence_capped_for_subfloor_rna_only():

--- a/tsarina/spanning.py
+++ b/tsarina/spanning.py
@@ -2050,7 +2050,15 @@ def _candidate_rows(
 
         if chosen_tier is None:
             # Inclusive maximum: reject only when strictly above the cutoff.
-            if not include_predicted_only or percentile > cutoffs["predicted_only"]:
+            # An unscored peptide (NaN percentile) is not a predicted binder and
+            # must be rejected explicitly — `nan > cutoff` is False, so without
+            # this guard it would slip through as `predicted_only` (matches the
+            # pd.notna filter in _score_lookup).
+            if (
+                not include_predicted_only
+                or pd.isna(percentile)
+                or percentile > cutoffs["predicted_only"]
+            ):
                 continue
             chosen_tier = "predicted_only"
             evidence = {

--- a/tsarina/tiers.py
+++ b/tsarina/tiers.py
@@ -46,10 +46,26 @@ import pandas as pd
 
 from .tissues import HPA_EXPRESSION_FLOOR_NTPM, PERMISSIVE_REPRODUCTIVE_TISSUES
 
+
+def _int0(value) -> int:
+    """``int(value)`` that treats NaN/None as 0 -- a *missing* count, not a crash.
+
+    ``row.get(col, 0)`` only guards a *missing* key; a present-but-NaN cell
+    (common on a left-merge miss against the HPA RNA consensus) would otherwise
+    reach ``int(nan)`` and raise ``ValueError``, aborting the whole ``df.apply``
+    tiering pass on a single bad row.
+    """
+    return 0 if pd.isna(value) else int(value)
+
+
 # ── Constants ──────────────────────────────────────────────────────────────
 
 #: Tissue restriction categories (shared across protein, RNA, synthesis).
 RESTRICTION_VALUES: list[str] = ["TESTIS", "PLACENTAL", "REPRODUCTIVE", "SOMATIC"]
+
+#: The reproductive-tissue restriction categories. RNA's coarse "REPRODUCTIVE"
+#: call only *agrees* with a protein call that is itself reproductive.
+_REPRODUCTIVE_RESTRICTIONS: frozenset[str] = frozenset({"TESTIS", "PLACENTAL", "REPRODUCTIVE"})
 
 #: RNA restriction quality levels, ordered strictest → loosest.
 RNA_RESTRICTION_LEVELS: list[str] = ["STRICT", "MODERATE", "PERMISSIVE", "LEAKY"]
@@ -226,7 +242,7 @@ def assign_rna_restriction(row: pd.Series) -> str:
     testis = float(row.get("rna_testis_ntpm", 0) or 0)
     ovary = float(row.get("rna_ovary_ntpm", 0) or 0)
     placenta = float(row.get("rna_placenta_ntpm", 0) or 0)
-    somatic_count = int(row.get("rna_somatic_detected_count", 0) or 0)
+    somatic_count = _int0(row.get("rna_somatic_detected_count", 0))
 
     has_testis = testis >= 1.0
     has_ovary = ovary >= 1.0
@@ -262,7 +278,7 @@ def assign_rna_restriction_level(row: pd.Series) -> str:
     if frac < 0:
         return "NO_DATA"
 
-    somatic_count = int(row.get("rna_somatic_detected_count", 0) or 0)
+    somatic_count = _int0(row.get("rna_somatic_detected_count", 0))
     rna_is_reproductive = somatic_count == 0
 
     if rna_is_reproductive and frac >= 0.99:
@@ -312,7 +328,16 @@ def synthesize_restriction(row: pd.Series) -> tuple[str, str]:
 
     if rna_has_data:
         sources += 1
-        rna_agrees = rna_r == tissue or (rna_r == "REPRODUCTIVE" and protein_has_data)
+        # Credit RNA's coarse "REPRODUCTIVE" as agreeing with a finer protein
+        # call only when that call is itself reproductive (TESTIS/PLACENTAL).
+        # A SOMATIC protein call genuinely *disagrees* with reproductive RNA, so
+        # it must not earn the agreement bonus (which would otherwise inflate a
+        # least-safe SOMATIC call to HIGH confidence and pass the selection
+        # filter). Latent today — 0 bundled CTAs hit the SOMATIC case — but a
+        # defensive gate against a future regeneration producing one.
+        rna_agrees = rna_r == tissue or (
+            rna_r == "REPRODUCTIVE" and tissue in _REPRODUCTIVE_RESTRICTIONS
+        )
         if rna_agrees:
             score += 1.0
             if rna_level == "STRICT":

--- a/tsarina/version.py
+++ b/tsarina/version.py
@@ -10,4 +10,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "1.20.0"
+__version__ = "1.20.1"


### PR DESCRIPTION
Three correctness fixes from the holistic review (each with a regression test).

| Fix | Before | After |
|---|---|---|
| NaN crash (`tiers.py`) | `int(row.get("rna_somatic_detected_count",0) or 0)` raised on a **present-but-NaN** cell (left-merge miss vs HPA RNA) — inside `df.apply`, so **one row aborted the whole tiering pass** | `_int0()` helper (NaN/None → 0) |
| NaN bypasses panel cutoff (`spanning.py`) | unscored peptide (`NaN` percentile) admitted as `predicted_only` (`nan > cutoff` is False) | reject `NaN` explicitly (matches `_score_lookup`'s `pd.notna`) |
| RNA-agreement on SOMATIC (`tiers.py`, C7) | bonus fired when protein=`SOMATIC` disagreed with rna=`REPRODUCTIVE`, inflating a least-safe call to HIGH → passes selection filter | gate on chosen tissue being reproductive |

**On C7 (the one you asked me to investigate):** I traced the bundled table — **0 of 393 CTAs** hit the `SOMATIC`+`REPRODUCTIVE` branch, and the cross-reactive-IHC rescue is handled separately by the regen-script override (those 4 genes have `protein_restriction=NO_DATA`, not SOMATIC). So this is a **zero-impact defensive gate** against a future regeneration producing such a gene; the 2 legitimate cases (protein TESTIS/PLACENTAL + rna REPRODUCTIVE) keep their bonus. The stored-table consistency test still passes unchanged, confirming no current gene is affected.

## Test plan
- 4 new regression tests (NaN-somatic, NaN-percentile, SOMATIC-not-boosted, TESTIS-still-credited).
- Full suite: `448 passed, 1 skipped`. `./lint.sh` clean.

Bumps `hitlist>=1.43.1` (pulls its data-layer correctness fixes) and `1.20.0 → 1.20.1`.