### PR TITLE
Friendlier CLI + discoverable headline verbs + accurate docs

### DIFF
--- a/tests/test_cli_data_friendliness.py
+++ b/tests/test_cli_data_friendliness.py
@@ -1,0 +1,50 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""CLI friendliness: --version, actionable unknown-dataset errors, and a
+non-silent `data remove` on a typo."""
+
+import os
+import subprocess
+import sys
+
+from tsarina.version import __version__
+
+
+def _run(*args, cache_dir):
+    env = {**os.environ, "TSARINA_DATA_DIR": str(cache_dir)}
+    return subprocess.run(
+        [sys.executable, "-m", "tsarina.cli", *args],
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+
+def test_version_flag(tmp_path):
+    r = _run("--version", cache_dir=tmp_path)
+    assert r.returncode == 0
+    assert __version__ in r.stdout
+
+
+def test_data_path_unknown_is_actionable(tmp_path):
+    r = _run("data", "path", "definitely-not-a-dataset", cache_dir=tmp_path)
+    assert r.returncode == 1
+    # Friendly message (lists the catalog), not a leaked KeyError repr.
+    assert "unknown dataset" in r.stderr.lower()
+    assert "data available" in r.stderr
+
+
+def test_data_remove_typo_is_not_silent_success(tmp_path):
+    r = _run("data", "remove", "never-registered-xyz", cache_dir=tmp_path)
+    assert r.returncode == 1
+    assert "nothing to do" in r.stderr.lower()

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -1,0 +1,47 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""The headline analysis verbs are importable from the top level.
+
+(`personalize` is the exception — it stays at `tsarina.personalize.personalize`
+to avoid shadowing the same-named submodule.)"""
+
+import tsarina
+
+
+def test_headline_verbs_importable():
+    from tsarina import (  # noqa: F401
+        HOTSPOT_MUTATIONS,
+        mutant_peptides,
+        score_presentation,
+        target_peptides,
+        viral_peptides,
+    )
+
+    assert callable(target_peptides)
+    assert callable(mutant_peptides)
+
+
+def test_headline_verbs_in_all():
+    for name in (
+        "target_peptides",
+        "mutant_peptides",
+        "score_presentation",
+        "viral_peptides",
+    ):
+        assert name in tsarina.__all__
+
+
+def test_personalize_importable_from_submodule():
+    from tsarina.personalize import personalize
+
+    assert callable(personalize)

--- a/tsarina/__init__.py
+++ b/tsarina/__init__.py
@@ -45,6 +45,13 @@ from .gene_sets import (
     cta_symbol_for_alias,
 )
 from .ms_evidence import cta_healthy_tissue_ms_hits
+from .mutations import HOTSPOT_MUTATIONS, mutant_peptides
+
+# NB: `personalize` (the function) is intentionally NOT re-exported here — that
+# would shadow the `tsarina.personalize` submodule. Import it from its module:
+# ``from tsarina.personalize import personalize``.
+from .scoring import score_affinity, score_presentation
+from .targets import target_peptides
 from .tiers import (
     CONFIDENCE_VALUES,
     MS_RESTRICTION_VALUES,
@@ -60,11 +67,13 @@ from .tissues import (
     PERMISSIVE_REPRODUCTIVE_TISSUES,
 )
 from .version import __version__
+from .viral import viral_peptides
 
 __all__ = [
     "CONFIDENCE_VALUES",
     "CORE_REPRODUCTIVE_TISSUES",
     "EXTENDED_REPRODUCTIVE_TISSUES",
+    "HOTSPOT_MUTATIONS",
     "HPA_ADAPTIVE_PROTEIN_RNA_THRESHOLDS",
     "IEDB27_AB",
     "MS_RESTRICTION_VALUES",
@@ -100,5 +109,10 @@ __all__ = [
     "get_panel",
     "hpa_cancer_ihc_prevalence",
     "hpa_cancer_rna_prevalence",
+    "mutant_peptides",
     "panel_names",
+    "score_affinity",
+    "score_presentation",
+    "target_peptides",
+    "viral_peptides",
 ]

--- a/tsarina/cli.py
+++ b/tsarina/cli.py
@@ -15,12 +15,13 @@
 Usage::
 
     # MS evidence datasets (IEDB / CEDAR / viral proteomes + the index)
-    tsarina data list [--all]                 # installed datasets (--all = full catalog)
+    tsarina data list                         # installed datasets
+    tsarina data available                    # full catalog (installed or not)
     tsarina data fetch hpv16                  # auto-download a viral proteome
     tsarina data register iedb /path/to/file  # register a manual download
     tsarina data path iedb                    # print path to a dataset
     tsarina data remove iedb                  # unregister (keeps the file)
-    tsarina data build [--force]              # build the observations index
+    tsarina build observations [--force]      # build the observations index
 
     # Curation reference data (HPA RNA/IHC + NCBI gene_info), version-pinned
     tsarina reference list                    # versions + cache status
@@ -122,18 +123,40 @@ def _data_fetch(args: argparse.Namespace) -> None:
         sys.exit(1)
 
 
+def _unknown_dataset(name: str) -> None:
+    """Print a friendly 'unknown dataset' error (lists the catalog) and exit 1.
+
+    Matches the `tsarina reference` error style instead of leaking a KeyError repr.
+    """
+    known = ", ".join(sorted(available_datasets())) or "(none)"
+    print(
+        f"Error: unknown dataset '{name}'. Known: {known}.\n"
+        f"  See `tsarina data available`; fetch with `tsarina data fetch {name}` "
+        f"or register a local file with `tsarina data register {name} <path>`.",
+        file=sys.stderr,
+    )
+    sys.exit(1)
+
+
 def _data_path(args: argparse.Namespace) -> None:
     try:
         p = get_path(args.name)
         print(str(p))
-    except (KeyError, FileNotFoundError) as e:
+    except KeyError:
+        _unknown_dataset(args.name)
+    except FileNotFoundError as e:
         print(f"Error: {e}", file=sys.stderr)
         sys.exit(1)
 
 
 def _data_remove(args: argparse.Namespace) -> None:
-    remove(args.name)
-    print(f"Unregistered '{args.name}' (file not deleted).")
+    if not remove(args.name, delete_file=getattr(args, "delete", False)):
+        print(f"No dataset '{args.name}' was registered (nothing to do).", file=sys.stderr)
+        sys.exit(1)
+    if getattr(args, "delete", False):
+        print(f"Unregistered and deleted '{args.name}'.")
+    else:
+        print(f"Unregistered '{args.name}' (file kept on disk).")
 
 
 def _data_refresh(args: argparse.Namespace) -> None:
@@ -148,7 +171,9 @@ def _data_refresh(args: argparse.Namespace) -> None:
 def _data_info(args: argparse.Namespace) -> None:
     try:
         print(json.dumps(info(args.name), indent=2, default=str))
-    except (KeyError, ValueError) as e:
+    except KeyError:
+        _unknown_dataset(args.name)
+    except ValueError as e:
         print(f"Error: {e}", file=sys.stderr)
         sys.exit(1)
 
@@ -297,8 +322,9 @@ def _build_data_parser(sub: argparse._SubParsersAction) -> None:
     p_path = data_sub.add_parser("path", help="Print path to a dataset")
     p_path.add_argument("name", help="Dataset name")
 
-    p_rm = data_sub.add_parser("remove", help="Unregister a dataset (keeps file)")
+    p_rm = data_sub.add_parser("remove", help="Unregister a dataset (keeps file by default)")
     p_rm.add_argument("name", help="Dataset name")
+    p_rm.add_argument("--delete", action="store_true", help="Also delete the cached file")
 
     p_build = data_sub.add_parser(
         "build",
@@ -350,11 +376,13 @@ def _handle_build(args: argparse.Namespace) -> None:
 
 def main() -> None:
     from . import cli_hits, cli_personalize, cli_spanning
+    from .version import __version__
 
     parser = argparse.ArgumentParser(
         prog="tsarina",
         description="tsarina: cancer-testis antigens, viral targets, and shared cancer immunotherapy peptides",
     )
+    parser.add_argument("--version", action="version", version=f"tsarina {__version__}")
     sub = parser.add_subparsers(dest="command")
 
     _build_data_parser(sub)

--- a/tsarina/cli_hits.py
+++ b/tsarina/cli_hits.py
@@ -85,7 +85,7 @@ def build_parser(sub: argparse._SubParsersAction) -> argparse.ArgumentParser:
             "resolution / MHC class.  Output includes semicolon-joined "
             "gene_names / gene_ids / protein_ids so paralogous attribution "
             "is preserved (e.g. MAGE family peptides).  Build the index once "
-            "with `tsarina data build` — it auto-builds on first use otherwise."
+            "with `tsarina build observations` — it auto-builds on first use otherwise."
         ),
     )
     target = p.add_mutually_exclusive_group(required=True)
@@ -536,6 +536,13 @@ def handle(args: argparse.Namespace) -> None:
         hits = hits[hits["is_monoallelic"]].copy()
 
     if hits.empty:
+        # An empty result is otherwise indistinguishable from "unknown gene" or
+        # "command didn't run" — say so on stderr (output stays pipe-clean).
+        print(
+            f"No public MS hits for gene '{gene}' with the current filters "
+            f"(check the spelling; try --include-binding-assays or --skip-ms-evidence).",
+            file=sys.stderr,
+        )
         _write(args.output, pd.DataFrame({"peptide": pd.Series(dtype=str)}))
         return
 

--- a/tsarina/evidence.py
+++ b/tsarina/evidence.py
@@ -12,7 +12,7 @@
 
 """CTA evidence table access with HPA tissue-restriction columns.
 
-The evidence table contains one row per CTA gene (358 genes from multiple
+The evidence table contains one row per CTA gene (curated from multiple
 source databases), annotated with Human Protein Atlas v23 protein and RNA
 tissue expression data and the three-axis tier results.
 """
@@ -139,7 +139,7 @@ def CTA_detailed_evidence(
         from hitlist data registry.
     genes
         Gene symbols to compute MS restriction for.  If None, uses all
-        CTA genes (slower — enumerates peptides for all 358 genes).
+        CTA genes (slower — enumerates peptides for every CTA gene).
 
     TCGA tumor RNA prevalence columns (always added):
     ``tcga_sample_count``, ``tcga_cancer_type_count``, ``tcga_max_ptpm``,

--- a/tsarina/gene_sets.py
+++ b/tsarina/gene_sets.py
@@ -330,7 +330,7 @@ def CTA_by_axes(
         Column to return (``"Symbol"`` or ``"Ensembl_Gene_ID"``).
     filtered_only
         If True (default), restrict to genes passing the HPA filter.
-        Set to False to query the full 358-gene CTA universe.
+        Set to False to query the full CTA universe (the entire bundled table).
     """
     df = cta_dataframe()
     mask = True

--- a/tsarina/spanning.py
+++ b/tsarina/spanning.py
@@ -1079,7 +1079,7 @@ def _select_cta_batch(
         raise RuntimeError(
             "tsarina panel requires the hitlist observations index for public-MS "
             "evidence. Register IEDB/CEDAR data if needed, then run "
-            "`tsarina data build --force`."
+            "`tsarina build observations --force`."
         ) from e
     _report_progress(on_progress, f"Loaded {len(hits)} public MS evidence rows.")
 

--- a/tsarina/version.py
+++ b/tsarina/version.py
@@ -10,4 +10,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "1.20.1"
+__version__ = "1.21.0"


### PR DESCRIPTION
Tier-2 (friendliness) + Tier-3 (docs/API) items from the holistic review.

## Friendliness
- **`tsarina --version`** (hitlist had it; tsarina didn't).
- **Stale deprecation targets** — `tsarina hits --help`, the panel error, and the CLI docstring pointed at the deprecated `tsarina data build`; now `tsarina build observations`.
- **`data remove <typo>` no longer fakes success** — warns + exits 1 when nothing was registered (hitlist 1.44.0's `remove()` now reports existence). Adds `--delete` for parity.
- **Actionable unknown-dataset errors** — `data path`/`data info` on a bad name now print `unknown dataset; known: ...` (matching `tsarina reference`) instead of leaking a `KeyError` repr.
- **Empty `hits` result** prints a stderr note — you can tell "no hits" from "unknown gene" from "didn't run".

## Docs / API
- **Top-level headline verbs**: `from tsarina import target_peptides, mutant_peptides, HOTSPOT_MUTATIONS, score_presentation, score_affinity, viral_peptides`. (`personalize` intentionally stays at `tsarina.personalize.personalize` — exporting it would shadow the same-named submodule; caught by an existing test.)
- **Drop stale "358 genes"** from 3 docstrings (the bundled table is well past that and grows).

## Test plan
- New `test_public_api.py` (verb imports + the personalize-submodule note) and `test_cli_data_friendliness.py` (`--version`, unknown-dataset error, remove-typo exit 1).
- Full suite: `454 passed, 1 skipped`. `./lint.sh` clean.

Bumps 1.20.1 → 1.21.0. Final batch of the holistic review (Tier-1 correctness shipped in hitlist 1.43.1 / tsarina 1.20.1).