### PR TITLE
Export personalize as personalized_targets (no submodule shadow); drop leading-paren CLI lines

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ peps = viral_peptides("hpv16")                    # all viral peptides
 human_exclusive = human_exclusive_viral_peptides("hpv16")  # default clinical helper
 ```
 
-`personalize()` and `target_peptides()` use the human-exclusive viral helper by
+`personalized_targets()` and `target_peptides()` use the human-exclusive viral helper by
 default, dropping viral k-mers that also occur anywhere in the human proteome.
 `cancer_specific_viral_peptides()` is available for exploratory workflows that
 allow overlaps with CTA proteins while excluding non-CTA overlaps.
@@ -192,9 +192,9 @@ Every IEDB/CEDAR mass spec observation is classified by biological context:
 The main entry point for clinical use:
 
 ```python
-from tsarina.personalize import personalize
+from tsarina import personalized_targets
 
-targets = personalize(
+targets = personalized_targets(
     # Patient HLA type
     hla_alleles=["HLA-A*02:01", "HLA-A*24:02", "HLA-B*07:02", "HLA-B*44:02",
                  "HLA-C*07:02", "HLA-C*05:01"],

--- a/docs/index.md
+++ b/docs/index.md
@@ -110,7 +110,7 @@ peps = viral_peptides("hpv16")                    # all viral peptides
 human_exclusive = human_exclusive_viral_peptides("hpv16")  # default clinical helper
 ```
 
-`personalize()` and `target_peptides()` use the human-exclusive viral helper by
+`personalized_targets()` and `target_peptides()` use the human-exclusive viral helper by
 default, dropping viral k-mers that also occur anywhere in the human proteome.
 `cancer_specific_viral_peptides()` is available for exploratory workflows that
 allow overlaps with CTA proteins while excluding non-CTA overlaps.
@@ -173,9 +173,9 @@ Every IEDB/CEDAR mass spec observation is classified by biological context:
 The main entry point for clinical use:
 
 ```python
-from tsarina.personalize import personalize
+from tsarina import personalized_targets
 
-targets = personalize(
+targets = personalized_targets(
     # Patient HLA type
     hla_alleles=["HLA-A*02:01", "HLA-A*24:02", "HLA-B*07:02", "HLA-B*44:02",
                  "HLA-C*07:02", "HLA-C*05:01"],

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -12,8 +12,10 @@
 
 """The headline analysis verbs are importable from the top level.
 
-(`personalize` is the exception — it stays at `tsarina.personalize.personalize`
-to avoid shadowing the same-named submodule.)"""
+The personalize workflow is exported as `personalized_targets` (a distinct name
+that doesn't shadow the `tsarina.personalize` submodule); `personalize` remains a
+back-compat alias inside that module.
+"""
 
 import tsarina
 
@@ -22,17 +24,20 @@ def test_headline_verbs_importable():
     from tsarina import (  # noqa: F401
         HOTSPOT_MUTATIONS,
         mutant_peptides,
+        personalized_targets,
         score_presentation,
         target_peptides,
         viral_peptides,
     )
 
+    assert callable(personalized_targets)
     assert callable(target_peptides)
     assert callable(mutant_peptides)
 
 
 def test_headline_verbs_in_all():
     for name in (
+        "personalized_targets",
         "target_peptides",
         "mutant_peptides",
         "score_presentation",
@@ -41,7 +46,9 @@ def test_headline_verbs_in_all():
         assert name in tsarina.__all__
 
 
-def test_personalize_importable_from_submodule():
+def test_personalize_alias_still_works():
+    # Back-compat: the old submodule import resolves to the renamed function.
+    from tsarina import personalized_targets
     from tsarina.personalize import personalize
 
-    assert callable(personalize)
+    assert personalize is personalized_targets

--- a/tsarina/__init__.py
+++ b/tsarina/__init__.py
@@ -47,9 +47,10 @@ from .gene_sets import (
 from .ms_evidence import cta_healthy_tissue_ms_hits
 from .mutations import HOTSPOT_MUTATIONS, mutant_peptides
 
-# NB: `personalize` (the function) is intentionally NOT re-exported here — that
-# would shadow the `tsarina.personalize` submodule. Import it from its module:
-# ``from tsarina.personalize import personalize``.
+# `personalized_targets` is the canonical name for the headline workflow; the
+# module keeps a `personalize` alias. We export the distinctly-named function
+# (not `personalize`, which would shadow the `tsarina.personalize` submodule).
+from .personalize import personalized_targets
 from .scoring import score_affinity, score_presentation
 from .targets import target_peptides
 from .tiers import (
@@ -111,6 +112,7 @@ __all__ = [
     "hpa_cancer_rna_prevalence",
     "mutant_peptides",
     "panel_names",
+    "personalized_targets",
     "score_affinity",
     "score_presentation",
     "target_peptides",

--- a/tsarina/cli.py
+++ b/tsarina/cli.py
@@ -72,7 +72,7 @@ def _data_list(args: argparse.Namespace) -> None:
         print("No datasets registered.")
         print(f"Data directory: {data_dir()}")
         print("Run 'tsarina data available' to see known datasets.")
-        print("(HPA/NCBI curation reference data is separate: `tsarina reference list`.)")
+        print("HPA/NCBI curation reference data is separate — see `tsarina reference list`.")
         return
     print(f"{'Name':<12} {'Size':>12}  {'Source':<14} Description")
     print("-" * 72)
@@ -91,8 +91,8 @@ def _data_list(args: argparse.Namespace) -> None:
         desc = meta.get("description", "")
         print(f"{name:<12} {size_str:>12}  {source_label:<14} {desc}")
     print(f"\nData directory: {data_dir()}")
-    print("(`tsarina data available` shows the full catalog; HPA/NCBI curation")
-    print(" reference data is separate: `tsarina reference list`.)")
+    print("`tsarina data available` shows the full catalog. HPA/NCBI curation")
+    print("reference data is separate — see `tsarina reference list`.")
 
 
 def _data_available(args: argparse.Namespace) -> None:

--- a/tsarina/cli_personalize.py
+++ b/tsarina/cli_personalize.py
@@ -12,7 +12,7 @@
 
 """`tsarina personalize` CLI — patient-level target prioritization.
 
-Wraps :func:`tsarina.personalize.personalize` with argparse.  IEDB/CEDAR paths
+Wraps :func:`tsarina.personalize.personalized_targets` with argparse.  IEDB/CEDAR paths
 default to whatever the user registered with ``tsarina data register …``.
 """
 
@@ -161,7 +161,7 @@ def build_parser(sub: argparse._SubParsersAction) -> argparse.ArgumentParser:
 
 def handle(args: argparse.Namespace) -> None:
     from .datasources import DatasetNotRegisteredError
-    from .personalize import personalize
+    from .personalize import personalized_targets
 
     min_restriction_confidence: tuple[str, ...] | None
     if any(v.upper() == "ANY" for v in args.min_restriction_confidence):
@@ -170,7 +170,7 @@ def handle(args: argparse.Namespace) -> None:
         min_restriction_confidence = tuple(v.upper() for v in args.min_restriction_confidence)
 
     try:
-        df = personalize(
+        df = personalized_targets(
             hla_alleles=args.hla,
             cta_expression=args.cta or None,
             mutations=args.mutations or None,

--- a/tsarina/personalize.py
+++ b/tsarina/personalize.py
@@ -43,9 +43,9 @@ Optional extra filters:
 
 Typical usage::
 
-    from tsarina.personalize import personalize
+    from tsarina import personalized_targets
 
-    targets = personalize(
+    targets = personalized_targets(
         hla_alleles=["HLA-A*02:01", "HLA-B*07:02"],
         cta_expression={"MAGEA4": 142.5, "PRAME": 87.3},
         mutations=["KRAS G12D"],
@@ -93,7 +93,7 @@ _OUTPUT_COLUMNS: tuple[str, ...] = (
 )
 
 
-def personalize(
+def personalized_targets(
     hla_alleles: list[str],
     cta_expression: dict[str, float] | None = None,
     mutations: list[str] | None = None,
@@ -350,6 +350,13 @@ def personalize(
         if col not in combined.columns:
             combined[col] = pd.NA
     return combined[list(_OUTPUT_COLUMNS)]
+
+
+# Backward-compatible alias. ``personalized_targets`` is the canonical name (it's
+# also exported from the top level, ``from tsarina import personalized_targets``);
+# ``personalize`` is retained so existing ``from tsarina.personalize import
+# personalize`` callers keep working.
+personalize = personalized_targets
 
 
 def _attach_ms_evidence(

--- a/tsarina/version.py
+++ b/tsarina/version.py
@@ -10,4 +10,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "1.21.0"
+__version__ = "1.22.0"


### PR DESCRIPTION
Follow-up to the friendliness/docs PR.

## `personalize` → top-level via a non-shadowing name
`personalize()` couldn't be exported from the package top level without shadowing the same-named `tsarina.personalize` submodule (an existing test caught it). Renamed the function to **`personalized_targets()`** — fits the `target_peptides`/`mutant_peptides`/`viral_peptides` vocabulary — and exported it top-level, so all seven headline verbs are now `from tsarina import ...`.

- `personalize` kept as a **back-compat alias** in the module (`from tsarina.personalize import personalize` still works; `personalize is personalized_targets`).
- `tsarina personalize` CLI command unchanged.
- README / docs / CLI wrapper updated to the canonical name.

## CLI output: no leading-paren lines
Per request, reworded the two `tsarina data list` footer/hint prints so no emitted line starts with `(` (dropped the wrapping parens). Audited both repos — these were the only offenders; the `(default …)` strings are mid-sentence help continuations, and hitlist had none.

## Test plan
- `test_public_api.py`: top-level `personalized_targets` import + `__all__` + the `personalize` alias identity.
- Verified `tsarina data list` emits no leading-paren lines.
- Full suite: `454 passed, 1 skipped`. `./lint.sh` clean.

Bumps 1.21.0 → 1.22.0.