### PR TITLE
No CLI help line starts with '(' (full output-surface sweep + guard test)

### DIFF
--- a/tests/test_cli_no_leading_parens.py
+++ b/tests/test_cli_no_leading_parens.py
@@ -1,0 +1,65 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Guard: no rendered CLI line should begin with '(' — a parenthetical aside at
+the start of a line reads awkwardly.
+
+Exercises the runnable output surface (every command's --help, which renders all
+argparse help/description/epilog, plus the list/reference/error paths) and
+asserts no emitted line starts with an open paren after indentation. Pinned to
+COLUMNS=80 because argparse wraps help to the terminal width, and a parenthetical
+can land at the start of a *wrapped* continuation line at narrow widths.
+
+Run in-process (not via subprocess) so the heavy CLI imports happen once.
+"""
+
+import contextlib
+import sys
+
+import pytest
+
+import tsarina.cli as cli
+
+# Commands that run without a built index or network access.
+_COMMANDS = [
+    ["--help"],
+    ["data", "--help"],
+    ["data", "list"],
+    ["data", "available"],
+    ["build", "--help"],
+    ["build", "observations", "--help"],
+    ["reference", "--help"],
+    ["reference", "list"],
+    ["reference", "path", "hpa_rna_consensus"],
+    ["hits", "--help"],
+    ["personalize", "--help"],
+    ["panel", "--help"],
+    ["data", "path", "definitely-not-a-dataset"],  # error path (stderr)
+    ["data", "remove", "definitely-not-a-dataset"],  # warn path (stderr)
+]
+
+
+def _offending(text: str) -> list[str]:
+    return [ln for ln in text.splitlines() if ln.lstrip().startswith("(")]
+
+
+@pytest.mark.parametrize("argv", _COMMANDS, ids=lambda a: " ".join(a))
+def test_no_cli_line_starts_with_paren(argv, monkeypatch, capsys, tmp_path):
+    monkeypatch.setenv("TSARINA_DATA_DIR", str(tmp_path))
+    monkeypatch.setenv("COLUMNS", "80")  # deterministic help wrapping
+    monkeypatch.setattr(sys, "argv", ["tsarina", *argv])
+    # --help and error paths exit; we only care about the emitted text.
+    with contextlib.suppress(SystemExit):
+        cli.main()
+    captured = capsys.readouterr()
+    offenders = _offending(captured.out) + _offending(captured.err)
+    assert not offenders, f"`tsarina {' '.join(argv)}` emitted leading-paren line(s): {offenders}"

--- a/tsarina/cli_common.py
+++ b/tsarina/cli_common.py
@@ -58,7 +58,7 @@ def add_predictor_arg(parser: argparse.ArgumentParser, *, context: str) -> None:
         "--predictor",
         choices=SUPPORTED_PREDICTORS,
         default="mhcflurry",
-        help=f"mhctools predictor for {context} (default mhcflurry).",
+        help=f"mhctools predictor for {context}. Defaults to mhcflurry.",
     )
 
 

--- a/tsarina/cli_hits.py
+++ b/tsarina/cli_hits.py
@@ -158,8 +158,8 @@ def build_parser(sub: argparse._SubParsersAction) -> argparse.ArgumentParser:
         "--mono-allelic-only",
         action="store_true",
         help=(
-            "Keep only hits with direct mono-allelic evidence (observed on a "
-            "cell line expressing a single HLA allele).  Excludes multi-allelic "
+            "Keep only hits with direct mono-allelic evidence, i.e. observed on a "
+            "cell line expressing a single HLA allele.  Excludes multi-allelic "
             "studies where the allele was assigned by a predictor (NetMHCpan / "
             "MHCflurry) rather than observed directly."
         ),
@@ -198,8 +198,8 @@ def build_parser(sub: argparse._SubParsersAction) -> argparse.ArgumentParser:
         help=(
             "Mode switch: output this gene's per-peptide healthy-SOMATIC-tissue "
             "MS hits (tissue, allele, allele_set, provenance, pmid, vital_organ "
-            "flag) instead of the cancer-MS aggregation. Reproductive/thymic hits "
-            "(expected for CTAs) are excluded. Only --gene/--uniprot, --mhc-class, "
+            "flag) instead of the cancer-MS aggregation. Reproductive/thymic hits, "
+            "expected for CTAs, are excluded. Only --gene/--uniprot, --mhc-class, "
             "--species, --output apply; other flags are ignored. See "
             "cta_healthy_tissue_ms_hits()."
         ),

--- a/tsarina/cli_personalize.py
+++ b/tsarina/cli_personalize.py
@@ -97,15 +97,15 @@ def build_parser(sub: argparse._SubParsersAction) -> argparse.ArgumentParser:
         "--min-cta-tpm",
         type=float,
         default=2.0,
-        help="Minimum CTA expression in TPM to include (default 2.0).",
+        help="Minimum CTA expression in TPM to include. Defaults to 2.0.",
     )
     p.add_argument(
         "--min-restriction-confidence",
         type=_split_csv,
         default=["HIGH", "MODERATE"],
         help=(
-            "Allowed CTA restriction_confidence bins, comma-separated "
-            "(default 'HIGH,MODERATE'; pass 'ANY' to disable)."
+            "Allowed CTA restriction_confidence bins, comma-separated. "
+            "Defaults to 'HIGH,MODERATE'; pass 'ANY' to disable."
         ),
     )
     p.add_argument(
@@ -118,7 +118,7 @@ def build_parser(sub: argparse._SubParsersAction) -> argparse.ArgumentParser:
         "--mtec-max-tpm",
         type=float,
         default=1.0,
-        help="Maximum mean mTEC TPM when --mtec-matrix-path is given (default 1.0).",
+        help="Maximum mean mTEC TPM when --mtec-matrix-path is given. Defaults to 1.0.",
     )
     p.add_argument(
         "--no-require-human-exclusive-viral",

--- a/tsarina/cli_spanning.py
+++ b/tsarina/cli_spanning.py
@@ -100,8 +100,8 @@ def _configure_parser(p: argparse.ArgumentParser) -> argparse.ArgumentParser:
         type=_split_csv,
         default=["HIGH", "MODERATE"],
         help=(
-            "Allowed restriction_confidence bins, comma-separated (default "
-            "'HIGH,MODERATE'; pass 'ANY' to disable)."
+            "Allowed restriction_confidence bins, comma-separated. "
+            "Defaults to 'HIGH,MODERATE'; pass 'ANY' to disable."
         ),
     )
     p.add_argument(
@@ -188,7 +188,7 @@ def _configure_parser(p: argparse.ArgumentParser) -> argparse.ArgumentParser:
         "--monoallelic-ms-max-percentile",
         type=float,
         default=2.0,
-        help="Max percentile for mono-allelic MS-supported pMHCs (default 2.0).",
+        help="Max percentile for mono-allelic MS-supported pMHCs. Defaults to 2.0.",
     )
     p.add_argument(
         "--sample-allele-ms-max-percentile",
@@ -196,7 +196,7 @@ def _configure_parser(p: argparse.ArgumentParser) -> argparse.ArgumentParser:
         default=1.0,
         help=(
             "Max percentile for multi-allelic MS support where the panel allele is "
-            "best among the exact or donor-set candidate alleles (default 1.0)."
+            "best among the exact or donor-set candidate alleles. Defaults to 1.0."
         ),
     )
     p.add_argument(
@@ -278,7 +278,7 @@ def _configure_parser(p: argparse.ArgumentParser) -> argparse.ArgumentParser:
         help=(
             "Show automatically selected CTAs that have no selected pMHCs after "
             "peptide, exclusivity, public-MS, and prediction gates. Note: passing "
-            "--ctas forces this on (explicit requests are always preserved)."
+            "--ctas forces this on; explicit requests are always preserved."
         ),
     )
     p.add_argument(

--- a/tsarina/version.py
+++ b/tsarina/version.py
@@ -10,4 +10,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "1.22.0"
+__version__ = "1.22.1"


### PR DESCRIPTION
Follow-up: extend the leading-paren cleanup from author-written `print()` lines to the **full rendered CLI output surface**.

## What the sweep found
Running every command's `--help` (which renders all argparse help/description/epilog) plus the list/reference/error paths at the standard **80-column** width, argparse **wraps** several help strings so a parenthetical aside lands at the *start* of a continuation line — e.g.:

```
  --predictor PRED      mhctools predictor for scoring
                        (default mhcflurry).
```

These don't show up grepping for `print("(`; they're width-dependent argparse wrapping. Reworded the offenders to fold the aside into the sentence (no parens):
- shared defaults (`--predictor`, `--min-restriction-confidence`, `--min-cta-tpm`, `--mtec-max-tpm`, the percentile cutoffs): `(default X)` → `Defaults to X.`
- `hits --mono-allelic-only` / `--healthy-tissue`: dropped the `(observed …)` / `(expected for CTAs)` parentheticals.

## Guard test
`test_cli_no_leading_parens.py` runs the commands **in-process at `COLUMNS=80`** (fast — one import; ~0.4s) and asserts no emitted stdout/stderr line starts with `(`. Catches regressions at the standard width.

hitlist's surface was swept too (bare banner + all `--help` + list/qc/export) — already clean, no changes needed.

## Test plan
- 14 guard cases pass; full suite `468 passed, 1 skipped`; `./lint.sh` clean.

Bumps 1.22.0 → 1.22.1.