### PR TITLE
Subtle --help coloring (reuses hitlist's shared ColorArgumentParser)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,10 +27,10 @@ classifiers = [
 ]
 requires-python = ">=3.9"
 dependencies = [
+    # 1.45.0: shared cli_help (ColorArgumentParser) for subtle --help coloring.
     # 1.43.0: VersionedDatasetRegistry — reference_data delegates its versioned
-    # download/manifest/cache machinery to it; also the reusable download_to_file
-    # (progress + cache status + .zip/.gz decompress).
-    "hitlist>=1.43.1",
+    # download/manifest/cache machinery to it; also the reusable download_to_file.
+    "hitlist>=1.45.0",
     "mhcgnomes>=3.20.0",
     # Cache-dir resolution for `tsarina reference` (same openvax layer pyensembl
     # uses); the download/decompress itself goes through hitlist.

--- a/tests/test_cli_help_color.py
+++ b/tests/test_cli_help_color.py
@@ -1,0 +1,41 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""tsarina reuses hitlist's shared subtle help coloring (the formatter's own
+alignment/gating invariants are tested in hitlist.tests.test_cli_help)."""
+
+import contextlib
+import sys
+
+import tsarina.cli as cli
+
+
+def _help(monkeypatch, capsys, **env):
+    for k, v in env.items():
+        monkeypatch.setenv(k, v)
+    monkeypatch.setattr(sys, "argv", ["tsarina", "--help"])
+    with contextlib.suppress(SystemExit):
+        cli.main()
+    return capsys.readouterr().out
+
+
+def test_help_colored_when_forced(monkeypatch, capsys):
+    monkeypatch.delenv("NO_COLOR", raising=False)
+    out = _help(monkeypatch, capsys, FORCE_COLOR="1")
+    assert "\033[36m" in out  # subcommand names in cyan
+    assert "\033[1m" in out  # bold section headings
+
+
+def test_help_plain_when_no_color(monkeypatch, capsys):
+    monkeypatch.delenv("FORCE_COLOR", raising=False)
+    out = _help(monkeypatch, capsys, NO_COLOR="1")
+    assert "\033[" not in out

--- a/tsarina/cli.py
+++ b/tsarina/cli.py
@@ -41,6 +41,8 @@ import argparse
 import json
 import sys
 
+from hitlist.cli_help import ColorArgumentParser
+
 from .downloads import (
     available_datasets,
     data_dir,
@@ -378,7 +380,7 @@ def main() -> None:
     from . import cli_hits, cli_personalize, cli_spanning
     from .version import __version__
 
-    parser = argparse.ArgumentParser(
+    parser = ColorArgumentParser(
         prog="tsarina",
         description="tsarina: cancer-testis antigens, viral targets, and shared cancer immunotherapy peptides",
     )

--- a/tsarina/version.py
+++ b/tsarina/version.py
@@ -10,4 +10,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "1.22.1"
+__version__ = "1.23.0"


### PR DESCRIPTION
Companion to pirl-unc/hitlist#346. Makes tsarina's root parser
`hitlist.cli_help.ColorArgumentParser`, so the whole command tree gets the same
subtle help coloring as hitlist — **subcommand names in cyan, section headings
in bold** — from one line of wiring (`add_subparsers` propagates the formatter
down the tree).

One shared formatter in hitlist → the two CLIs look identical. TTY-gated; honors
`NO_COLOR` / `FORCE_COLOR`; alignment-safe (tested in hitlist).

## Test plan
- `test_cli_help_color.py`: FORCE_COLOR → cyan subcommands + bold headings;
  NO_COLOR → no escapes.
- `test_cli_no_leading_parens.py` still green (runs non-TTY → plain).
- Full suite: `470 passed, 1 skipped`. Lint clean.

Bumps `hitlist>=1.45.0` and `1.22.1 → 1.23.0`. Merge after hitlist 1.45.0 is on PyPI (it is).