### PR TITLE
Reorganize documentation by workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,427 +3,105 @@
 [![Tests](https://github.com/pirl-unc/tsarina/actions/workflows/tests.yml/badge.svg)](https://github.com/pirl-unc/tsarina/actions/workflows/tests.yml)
 [![PyPI](https://img.shields.io/pypi/v/tsarina.svg)](https://pypi.org/project/tsarina/)
 
-Personalized cancer immunotherapy target selection from curated shared antigen data.
+Tsarina selects shared cancer immunotherapy targets for an individual patient
+or a population HLA panel.
 
-Perseus weaves patient-specific tumor characteristics (mutations, CTA expression, viral infections, HLA type) together with curated public mass spectrometry evidence to produce prioritized lists of targetable peptide-MHC complexes. The name reflects the goal: using shared, public knowledge to personalize cancer immunotherapy -- like Perseus using borrowed divine weapons to slay Medusa.
+It starts with reusable cancer-testis antigen (CTA), oncogenic-virus, and
+recurrent-mutation targets. It then combines tumor context, public
+immunopeptidomics evidence, healthy-tissue safety evidence, and predicted HLA
+presentation to produce ranked peptide-MHC (pMHC) candidates.
 
-## Concept
+## Choose a workflow
 
-The core insight is that many cancer-targetable peptides are **shared across patients**: cancer-testis antigens are recurrently activated in tumors, oncogenic viruses produce the same foreign proteins in every infected cell, and hotspot driver mutations generate identical mutant peptides across thousands of patients. Unlike private passenger-mutation neoantigens that require individual whole-exome sequencing, these shared targets can be curated once and reused.
+| Goal | Entry point | Result |
+|---|---|---|
+| Prioritize targets for one patient | `tsarina personalize` or `personalized_targets()` | Ranked CTA, viral, and mutant pMHCs for that patient's HLA type and tumor |
+| Design an off-the-shelf CTA panel | `tsarina panel` | CTA × HLA matrix with evidence tiers and population-coverage estimates |
+| Inspect public peptide observations | `tsarina hits` | Cancer, healthy-tissue, and restriction evidence for specified peptides |
 
-Perseus combines curated shared targets with per-patient tumor data to produce a prioritized list of peptide-MHC complexes.
-
-**Shared targets** (curated once, reused across patients):
-- **CTA genes** — the current oncoref canonical set, enriched with tsarina MS safety evidence
-- **Viral proteomes** — 9 oncogenic viruses (HPV, EBV, HBV, HCV, HTLV-1, HIV, HHV-8, MCPyV, MCV)
-- **Hotspot mutations** — 19 recurrent mutations across 8 driver genes
-
-**Public annotation data** (used to score and filter targets):
-- **Mass spec evidence** — IEDB/CEDAR immunopeptidomics observations
-- **Tissue expression** — HPA RNA (50 tissues) + IHC protein (63 tissues)
-- **HLA allele panels** — population-representative panels (27–53 alleles per region)
-
-**Patient data** (per-individual):
-- HLA type (Class I alleles)
-- Tumor RNA-seq (CTA expression in TPM)
-- Detected mutations (cross-referenced against hotspot list)
-- Viral status (HPV, EBV, etc.)
-
-Perseus filters shared targets through the patient's HLA type and tumor profile, then ranks the results into a **prioritized target list** annotated with:
-- **Public MS evidence** — number of independent IEDB/CEDAR references, source context (cancer vs. healthy tissue)
-- **Source protein abundance** — RNA expression in TPM, estimated protein abundance where HPA data permits
-- **Predicted presentation** — MHCflurry presentation percentile, NetMHCpan binding affinity
-- **Target category** — CTA, viral, or mutant, with full provenance
+Start with the [documentation guide](docs/index.md) for inputs, data setup, and
+the workflow-specific guides.
 
 ## Install
 
 ```bash
 pip install tsarina
-
-# With full functionality (pyensembl for peptide generation + gene partition):
-pip install tsarina[all]
 ```
 
-## Three target categories
-
-### CTA (cancer-testis antigens)
-
-Proteins normally restricted to reproductive tissues (testis, ovary, placenta) that become aberrantly expressed in tumors. Their tissue restriction means immune responses against them should not damage normal somatic tissues. Thymus expression is expected (AIRE-mediated central tolerance) and excluded from restriction checks.
-
-**[oncoref](https://github.com/pirl-unc/oncoref) is the sole owner of CTA
-definitions.** It supplies the candidate universe, default/filtered/excluded
-membership, aliases, HPA restriction calls, and proteoform groups. Tsarina's
-foundational CTA helpers are direct aliases of the corresponding
-`oncoref.cta` functions, so their membership always changes with the installed
-oncoref release rather than a second bundled table.
-
-`CTA_evidence()` preserves oncoref's exact row universe and columns, adding
-only a generic gene-level `ms_*` safety overlay. The overlay contains no CTA
-symbols, membership flags, specificity decisions, or HPA annotations.
-
-```python
-from tsarina import CTA_gene_names, CTA_gene_ids, CTA_evidence
-
-genes = CTA_gene_names()  # direct oncoref default set
-df = CTA_evidence()       # oncoref evidence plus tsarina's ms_* columns
-```
-
-The HPA-derived `protein_restriction`, `rna_restriction`, `restriction`, and
-`restriction_confidence` columns are owned by oncoref. Tsarina keeps
-`ms_restriction` separate in the static evidence frame and combines it
-explicitly when a live IEDB/CEDAR target-selection workflow requests an
-MS-aware synthesis.
-
-| Modality | Column | Values |
-|----------|--------|--------|
-| Protein IHC | `protein_restriction` | TESTIS / PLACENTAL / REPRODUCTIVE / SOMATIC / NO_DATA |
-| RNA | `rna_restriction` | TESTIS / PLACENTAL / REPRODUCTIVE / SOMATIC / NO_DATA |
-| RNA quality | `rna_restriction_level` | STRICT / MODERATE / PERMISSIVE |
-| MS (tsarina) | `ms_restriction` | CANCER_ONLY / EXPECTED_TISSUE / SINGLETON_HEALTHY / RECURRENT_HEALTHY |
-| HPA synthesis | `restriction` | TESTIS / PLACENTAL / REPRODUCTIVE / SOMATIC / NO_DATA |
-| HPA confidence | `restriction_confidence` | HIGH / MODERATE / LOW / NO_DATA |
-
-```python
-from tsarina import CTA_testis_restricted_gene_names, CTA_by_axes
-
-testis = CTA_testis_restricted_gene_names()
-strict_testis = CTA_by_axes(restriction="TESTIS", rna_restriction_level="STRICT")
-high_conf = CTA_by_axes(restriction="TESTIS", restriction_confidence="HIGH")
-```
-
-See [CTA ownership and downstream evidence](docs/curation.md) for the API and
-data boundary. Curation changes and corrections belong in
-[oncoref issues](https://github.com/pirl-unc/oncoref/issues), not in a Tsarina
-override.
-
-### Viral (oncogenic virus proteins)
-
-Foreign proteins from oncogenic viruses -- entirely absent from normal human tissue, making them ideal immunotherapy targets when the virus is present in the tumor.
-
-```python
-from tsarina.viral import (
-    human_exclusive_viral_peptides,
-    viral_peptides,
-)
-
-peps = viral_peptides("hpv16")                    # all viral peptides
-human_exclusive = human_exclusive_viral_peptides("hpv16")  # default clinical helper
-```
-
-`personalized_targets()` and `target_peptides()` use the human-exclusive viral helper by
-default, dropping viral k-mers that also occur anywhere in the human proteome.
-`cancer_specific_viral_peptides()` is available for exploratory workflows that
-allow overlaps with CTA proteins while excluding non-CTA overlaps.
-
-| Virus | Cancers | Key oncoproteins |
-|---|---|---|
-| HPV-16, HPV-18 | Cervical, oropharyngeal, anal | E6, E7 |
-| EBV/HHV-4 | Burkitt lymphoma, NPC, Hodgkin lymphoma | LMP1, EBNA1, LMP2A |
-| HTLV-1 | Adult T-cell leukemia/lymphoma | Tax, HBZ |
-| HBV | Hepatocellular carcinoma | HBx |
-| HCV | HCC, B-cell lymphoma | Core, NS3, NS5A |
-| KSHV/HHV-8 | Kaposi sarcoma, primary effusion lymphoma | vFLIP, vCyclin, LANA |
-| MCPyV | Merkel cell carcinoma | Large T, small T |
-| HIV-1 | Kaposi sarcoma, non-Hodgkin lymphoma | Tat, Nef |
-
-### Mutant (recurrent somatic hotspot mutations)
-
-Shared neoantigens from driver mutations that recur across thousands of patients. Unlike private passenger mutations, these produce the same mutant peptide in every patient carrying the same hotspot mutation.
-
-```python
-from tsarina.mutations import HOTSPOT_MUTATIONS, mutant_peptides
-
-df = mutant_peptides()  # all mutation-spanning 8-11mer peptides
-```
-
-| Gene | Mutations | Cancer types |
-|---|---|---|
-| KRAS | G12C, G12D, G12V, G12R, G13D | Pancreatic, colorectal, NSCLC |
-| BRAF | V600E, V600K | Melanoma, colorectal, thyroid |
-| TP53 | R175H, R248W, R273H, G245S, R249S | Pan-cancer |
-| PIK3CA | H1047R, E545K | Breast, endometrial |
-| IDH1 | R132H | Glioma, AML (peptidomics-validated vaccine target) |
-| NRAS | Q61R, Q61K | Melanoma |
-| EGFR | L858R, T790M | NSCLC |
-
-## Positive and negative peptide sets
-
-Perseus constructs both **positive sets** (cancer-specific peptides from the three target categories) and **negative sets** (peptides observed on normal non-reproductive, non-thymic tissues) using the same IEDB/CEDAR scanning infrastructure with consistent tissue classification.
-
-### Tissue source classification
-
-Every IEDB/CEDAR mass spec observation is classified by biological context:
-
-| Category | IEDB criteria | Meaning |
-|---|---|---|
-| `src_cancer` | Process Type = "Occurrence of cancer" | Peptide detected on tumor MHC |
-| `src_healthy` | Process Type = "No immunization", Disease = "healthy" or empty | Peptide detected on normal tissue |
-| `src_reproductive` | Source Tissue in {testis, ovary, placenta, ...} | Expected for CTAs |
-| `src_thymus` | Source Tissue = thymus | Expected for CTAs (AIRE-mediated) |
-| `src_cell_line` | Culture Condition = "Cell Line / Clone" | In vitro, not direct tissue |
-| `src_ebv_lcl` | Culture Condition contains "EBV transformed, B-LCL" | EBV-immortalized B cells (special case) |
-| `src_ex_vivo` | Culture Condition = "Direct Ex Vivo" | Highest confidence tissue evidence |
-
-**Positive set criteria**: peptide has `src_cancer` evidence AND is exclusive to CTA/viral/mutant source proteins (not found in non-target human proteins).
-
-**Negative set criteria**: peptide has `src_healthy` + `src_ex_vivo` evidence from non-reproductive, non-thymic tissues. These are peptides confirmed to be presented on normal somatic tissue -- targeting them would cause on-target, off-tumor toxicity.
-
-## Patient personalization
-
-The main entry point for clinical use:
-
-```python
-from tsarina import personalized_targets
-
-targets = personalized_targets(
-    # Patient HLA type
-    hla_alleles=["HLA-A*02:01", "HLA-A*24:02", "HLA-B*07:02", "HLA-B*44:02",
-                 "HLA-C*07:02", "HLA-C*05:01"],
-
-    # CTA expression (gene symbol -> TPM from RNA-seq)
-    cta_expression={"MAGEA4": 142.5, "PRAME": 87.3, "CTAG1B": 215.0},
-
-    # Detected mutations (match against hotspot list)
-    mutations=["KRAS G12D", "TP53 R175H"],
-
-    # Viral status
-    viruses=["hpv16"],
-
-    # Data sources
-    iedb_path="mhc_ligand_full.csv",
-)
-```
-
-Returns a DataFrame with columns:
-
-| Column | Description |
-|---|---|
-| `peptide` | Peptide sequence |
-| `category` | `cta`, `viral`, or `mutant` |
-| `source` | Gene name, virus, or mutation label |
-| `source_abundance_tpm` | RNA expression in tumor (CTAs only) |
-| `ms_hit_count` | Number of IEDB/CEDAR MS observations |
-| `ms_alleles` | MHC restrictions observed in public data |
-| `ms_in_cancer` | Detected in cancer samples |
-| `ms_in_healthy_somatic` | Detected in normal non-reproductive, non-thymic tissue (safety flag) |
-| `presentation_percentile` | MHCflurry presentation percentile for best patient allele |
-| `best_allele` | Patient HLA allele with best predicted presentation |
-| `binding_affinity_nm` | Predicted binding affinity (nM) |
-
-Prioritization is by: (1) public MS evidence strength, (2) source protein abundance, (3) predicted presentation quality, (4) absence of healthy-tissue MS evidence.
-
-## CTA x HLA panel matrices
-
-Build a CTA x HLA pMHC matrix for off-the-shelf panel design:
+Install the optional peptide-generation and partitioning dependencies for full
+functionality:
 
 ```bash
-tsarina panel
+pip install "tsarina[all]"
 ```
 
-Defaults:
+## Quick start
 
-- up to 25 downstream non-empty CTAs ranked by bundled HPA tumor RNA prevalence
-  breadth/sample prevalence, with lower-ranked candidates scanned as needed to
-  backfill empty downstream targets and clinical allowlist anchors pinned ahead
-  of lower-ranked candidates
-- automatic safety gates remove CTAs with vital-tissue RNA / unique healthy-MS
-  evidence, while allowlisting `PRAME`, `CTAG1A/CTAG1B`, and `MAGEA4`
-- automatic selection excludes MAGE-family CTAs other than `MAGEA4` unless they
-  are explicitly requested or allowlisted
-- `CTAG1A/CTAG1B` is treated as one grouped CTA target, with `NY-ESO-1`
-  accepted as an input alias
-- CTAs with identical enumerated peptide sets or final selected pMHC panels are
-  grouped so paralogous targets do not consume multiple automatic panel slots
-- `global53_abc` HLA-A/B/C panel
-- 8-11mer CTA-exclusive peptides
-- MHCflurry presentation scoring
-- MS-evidence-first cell selection
-- up to 3 peptides per CTA x HLA cell, ranked by MS source count, then prediction
-- readable terminal table plus coverage summary
-
-Use CSV formats for scripts:
+Prioritize targets for a patient:
 
 ```bash
-tsarina panel --format long -o panel-long.csv
-tsarina panel --format wide -o panel-wide.csv
+tsarina personalize \
+  --hla 'HLA-A*02:01,HLA-A*24:02,HLA-B*07:02' \
+  --cta 'MAGEA4=142.5,PRAME=87.3' \
+  --mutations "KRAS G12D" \
+  --viruses hpv16 \
+  --output patient-targets.csv
 ```
 
-The CLI prints progress for peptide enumeration, public-MS evidence loading,
-scoring, evidence-tier construction, and final selection. Interactive terminals
-also get a `tqdm` scoring progress bar; MHCflurry still scores all alleles in
-one batch by default because chunking repeats its allele-independent processing
-model work. Use `--score-chunk-size` only when you explicitly want chunking, or
-`--no-progress` / `--no-progress-bars` to suppress progress output.
+Build the default global CTA × HLA panel:
 
-Use `--selection-allowlist`, `--no-vital-tissue-filter`,
-`--vital-tissue-max-ntpm`, and `--allow-non-magea4-mage-family` to tune
-automatic CTA safety filtering. The default vital RNA cutoff is 2.0 nTPM;
-public healthy-MS observations in vital tissues remain exclusionary only when
-the peptide evidence maps uniquely to that CTA, unless allowlisted. Explicit
-`--ctas` accepts aliases such as `NY-ESO-1` and `MAGE-A4` and bypasses automatic
-CTA-family safety gates.
+```bash
+tsarina panel --format long --output panel.csv
+```
 
-Default automatic ranking uses `tumor_prevalence_panel_score`, computed from
-bundled HPA cancer RNA prevalence at pTPM >= 2.0 and cancer-type breadth at a
-5% sample-prevalence floor, with HPA cancer IHC as a weak tie-breaker. Public
-MS support and safety gates are recomputed from the current hitlist observations
-index for each candidate batch before pMHC scoring; packaged CTA evidence does
-not carry MS count columns. Use `--cancer-rna-threshold`,
-`--cancer-type-prevalence-floor`, or `--cta-rank-by <column>` to change the
-initial non-MS candidate ranking.
+Both workflows can use registered IEDB or CEDAR ligand exports as public
+immunopeptidomics evidence. See [Data and evidence](docs/data-and-evidence.md)
+for setup and interpretation.
 
-Automatic panel output scans lower-ranked CTA candidates to backfill CTAs with
-zero selected pMHCs after peptide enumeration, CTA-exclusivity, public-MS, and
-presentation-score gates; pass `--show-empty-ctas` to audit the top ranked
-candidates including those failures. Explicit `--ctas` requests are preserved
-even if a requested CTA has zero selected pMHCs. The "Expected Population
-Coverage Per CTA" rows are sorted by selected peptide count, then HLA-hit count,
-then estimated population coverage, and split monoallelic MS pMHC support from
-sample-genotype/deconvolved MS support.
+## Target categories
 
-Peptide enumeration may expand one target label to multiple Ensembl genes
-(`CTAG1A/CTAG1B` and the `NY-ESO-1` alias expand to `CTAG1A` and `CTAG1B`),
-but output target names stay grouped. Pass `--no-group-identical-cta-peptide-sets`
-to keep peptide-identical paralog targets separate, or `--no-group-identical-cta-pmhcs`
-to keep duplicate pMHC panels separate.
-Pass `--netmhcpan-affinity` to annotate every selected pMHC row with NetMHCpan
-BA affinity nM and affinity percentile rank. This is opt-in because it requires
-the external NetMHCpan backend and adds a second scoring pass when the main
-selector is using MHCflurry.
-
-Evidence tiers use configurable presentation percentile cutoffs:
-
-| Evidence tier | Default cutoff | Meaning |
-|---|---:|---|
-| `monoallelic_ms` | < 2.0 | Peptide observed in mono-allelic MS for that HLA |
-| `sample_allele_ms` | < 1.0 | Peptide observed in multi-allelic MS with a usable exact restriction set or donor allele set; the selected HLA must be the best predicted allele in that set, including when the row's reported restriction is only `HLA class I` |
-| `unrestricted_ms` | < 0.5 | Peptide observed by class-I MS with no usable exact or donor-set allele assignment; the selected panel HLA is assigned by prediction under this stricter cutoff |
-| `predicted_only` | < 0.1 | No MS support; excluded unless `--include-predicted-only` is passed |
-
-Available HLA panels:
-
-| Panel | Alleles | Coverage |
+| Category | Candidate source | Tumor-specific context |
 |---|---|---|
-| `iedb27_ab` | 27 | Global baseline (HLA-A/B) |
-| `iedb36_abc` | 36 | + HLA-C |
-| `global44_abc` | 44 | + East Asia, South Asia, Sub-Saharan Africa |
-| `global48_abc` | 48 | + Latin America, MENA |
-| `global51_abc_ssa` | 51 | Legacy Global-48 + additional Sub-Saharan Africa |
-| `global51_abc` | 51 | Global reference panel: IEDB A/B backbone, frequent HLA-C allotypes, and IEDB/Paul common-A/B complements |
-| `global53_abc` | 53 | Default global panel: Global-51 plus CTA-MS supported `A*29:02`, `B*15:02`, and `B*27:05`, keeping only `C*14:02` from the MHCflurry-identical C*14 pair |
+| CTA | The canonical [oncoref](https://github.com/pirl-unc/oncoref) CTA set | Tumor RNA expression and reproductive-tissue restriction |
+| Viral | Proteomes from nine oncogenic viruses | Virus detected in the tumor |
+| Mutant | Nineteen recurrent hotspots across seven driver genes | Matching mutation detected in the tumor |
 
-Regional allele frequency data from 7 geographic regions supports population-weighted coverage
-calculations. The frequency audit keeps those sub-population proxy rows separate
-from published global average allele frequencies on the same 0-1 allele-frequency
-scale. Panel coverage uses the regional weighted value when a numeric regional
-proxy exists and falls back to the published global average only when no regional
-proxy is available. For each CTA, covered allele frequencies are summed within
-each HLA locus, converted to locus carrier probability as
-`1 - (1 - locus_frequency)^2`, and then combined across loci. All default
-`global53_abc` alleles have a published global average,
-source/proxy/resolution provenance, and a nonzero coverage frequency,
-preventing known-frequency HLA hits from reporting artificial `0.0%` CTA
-coverage.
-The reference `global51_abc` panel keeps all 27 IEDB/TepiTool class-I A/B reference alleles,
-adds all 21 frequent HLA-C allotypes from the Sarkizova HLA-C peptidome coverage set,
-and fills the remaining 51-panel slots with the highest-frequency calibrated alleles
-missing from the IEDB/Paul 38 common HLA-A/B threshold set
-(`B*18:01`, `B*40:02`, `B*46:01`). The default `global53_abc` panel adds
-`A*29:02`, `B*15:02`, and `B*27:05` because these were the top missing
-alleles in a public CTA-MS evidence audit while retaining MHCflurry percentile
-rank support. It keeps `C*14:02` but excludes `C*14:03` because MHCflurry uses
-the same pseudosequence and percentile-rank calibration for both, and `C*14:02`
-had the CTA-MS support in the local audit. References: IEDB reference set
-<https://help.iedb.org/hc/en-us/articles/114094151851-HLA-allele-frequencies-and-reference-sets-with-maximal-population-coverage>,
-TepiTool allele-selection description <https://pmc.ncbi.nlm.nih.gov/articles/PMC4981331/>,
-IEDB/Paul 38 common A/B thresholds
-<https://help.iedb.org/hc/en-us/articles/114094151811-Selecting-thresholds-cut-offs-for-MHC-class-I-and-II-binding-predictions>,
-and Sarkizova et al. <https://doi.org/10.1038/s41587-019-0322-9>.
-Audit notes: all 53 default alleles resolve through MHCflurry's
-`percent_rank_calibrated_allele` lookup and produce numeric affinity percentile
-ranks. `HLA-C*15:05` remains excluded because MHCflurry supports raw affinity and
-presentation predictions for it but does not have an affinity percentile-rank
-calibration.
+Oncoref is the single authority for CTA membership, aliases, HPA restriction
+calls, and proteoform groups. Tsarina adds downstream evidence and scoring
+without maintaining a second CTA definition library. The exact boundary is
+documented in [CTA ownership and downstream evidence](docs/curation.md).
 
-## Data management
+## How ranking works
 
-Tsarina uses the shared hitlist data registry for external datasets:
+Tsarina applies the same high-level sequence across workflows:
 
-```bash
-# See what data is available
-tsarina data available
+1. choose candidates from the relevant shared-target sets;
+2. enforce tumor context and exclude non-target human peptide matches;
+3. annotate public cancer and healthy-tissue MS observations;
+4. predict presentation by the requested HLA alleles; and
+5. rank pMHCs with explicit evidence and safety provenance.
 
-# Auto-download viral proteomes from UniProt
-tsarina data fetch hpv16
-tsarina data fetch ebv
+Public MS evidence strengthens a candidate but does not redefine CTA
+membership. Healthy, direct-ex-vivo observations outside reproductive tissues
+and thymus are treated as safety evidence.
 
-# Register manually downloaded IEDB/CEDAR exports
-tsarina data register iedb /data/mhc_ligand_full.csv
-tsarina data register cedar /data/cedar-mhc-ligand-full.csv
+## Documentation
 
-# Inspect what's installed
-tsarina data list
-
-# Resolve paths for use in scripts
-tsarina data path iedb
-```
-
-### Data sources
-
-| Dataset | Source | Size | How to get |
-|---|---|---|---|
-| IEDB MHC ligand | [iedb.org](https://www.iedb.org/) | ~2 GB | Manual download (terms of use) |
-| CEDAR MHC ligand | [cedar.iedb.org](https://cedar.iedb.org/) | ~1 GB | Manual download |
-| HPV-16 proteome | [UniProt UP000006729](https://www.uniprot.org/proteomes/UP000006729) | ~3 KB | `tsarina data fetch hpv16` |
-| EBV proteome | [UniProt UP000153037](https://www.uniprot.org/proteomes/UP000153037) | ~50 KB | `tsarina data fetch ebv` |
-| *(9 viral proteomes total)* | UniProt | varies | `tsarina data fetch <name>` |
-
-Storage location: `~/.hitlist/` (override with `HITLIST_DATA_DIR` env var).
-`tsarina data` delegates registry and cache management to hitlist.
-
-IEDB column indices are resolved dynamically from CSV headers, with fallback to known defaults -- robust to IEDB schema changes.
-
-## Tissue definitions
-
-Three tiers of reproductive tissue sets for CTA restriction analysis:
-
-```python
-from tsarina.tissues import (
-    CORE_REPRODUCTIVE_TISSUES,       # {testis, ovary, placenta}
-    EXTENDED_REPRODUCTIVE_TISSUES,   # + cervix, endometrium, prostate, ...
-    PERMISSIVE_REPRODUCTIVE_TISSUES, # + breast
-    is_tissue_restricted,
-    adaptive_rna_threshold,
-)
-```
-
-## MHCflurry scoring
-
-```python
-from tsarina.scoring import score_presentation
-from tsarina.alleles import get_panel
-
-scores = score_presentation(
-    peptides=["SLYNTVATL", "GILGFVFTL"],
-    alleles=get_panel("iedb27_ab"),
-)
-```
-
-## Target naming convention
-
-Perseus uses a unified naming scheme across all target categories:
-
-| Category | `source` column | `source_detail` column | Example |
-|---|---|---|---|
-| CTA | Gene symbol | Ensembl gene ID | `MAGEA4` / `ENSG00000147381` |
-| Viral | Virus short name | UniProt protein accession | `HPV-16` / `P03126` |
-| Mutant | Mutation label | Mutation string | `KRAS G12D` / `G12D` |
+- [Documentation guide](docs/index.md) — workflow selection and shared concepts
+- [Personalized target selection](docs/personalized-targets.md) — patient
+  inputs, prioritization, and output schema
+- [CTA panel design](docs/panel-design.md) — automatic selection, evidence
+  tiers, HLA panels, and coverage
+- [Data and evidence](docs/data-and-evidence.md) — data registry, observation
+  classification, scoring, and naming
+- [CTA ownership and downstream evidence](docs/curation.md) — oncoref/Tsarina
+  responsibilities and maintenance
 
 ## Development
 
 ```bash
-./develop.sh    # install in dev mode
-./format.sh     # ruff format
-./lint.sh       # ruff check + format check
-./test.sh       # pytest with coverage
+./develop.sh
+./format.sh
+./lint.sh
+./test.sh
 ```

--- a/docs/curation.md
+++ b/docs/curation.md
@@ -1,9 +1,27 @@
 # CTA ownership and downstream evidence
 
-## One definition library
+Tsarina consumes one executable cancer-testis antigen definition:
+[oncoref](https://github.com/pirl-unc/oncoref). Tsarina enriches that definition
+with target-selection evidence, but never maintains a second CTA universe.
 
-[oncoref](https://github.com/pirl-unc/oncoref) is the sole authority for
-cancer-testis antigen definitions. It owns:
+## At a glance
+
+| Question | Owner |
+|---|---|
+| Is this gene a CTA candidate, default, filtered, excluded, or low-expression member? | oncoref |
+| What is its canonical symbol or alias? | oncoref |
+| What do HPA RNA and protein data imply about its tissue restriction? | oncoref |
+| Which CTA proteoform group contains it? | oncoref |
+| How prevalent is it across cancer samples? | Tsarina downstream features |
+| Has a peptide or gene been observed by public MS in cancer or healthy tissue? | Tsarina/hitlist evidence |
+| Which pMHCs score best for a patient or HLA panel? | Tsarina runtime selection |
+
+An oncoref release defines the CTA rows. A Tsarina evidence join may add
+columns to those rows, but it cannot create a CTA.
+
+## Definition boundary
+
+Oncoref owns:
 
 - the CTA candidate universe and gene identities;
 - default, filtered, unfiltered, low-expression, and excluded membership;
@@ -11,40 +29,43 @@ cancer-testis antigen definitions. It owns:
 - HPA RNA and protein evidence, restriction axes, and confidence; and
 - CTA proteoform groups.
 
-Tsarina does not ship a CTA definition table or recreate those decisions.
+Tsarina does not ship a CTA definition table or reproduce those decisions.
 Foundational helpers such as `CTA_gene_names`, `CTA_filtered_gene_ids`,
 `CTA_excluded_gene_names`, `CTA_testis_restricted_gene_names`, and
-`cta_symbol_for_alias` are direct aliases of their `oncoref.cta`
-implementations. Proteoform grouping is loaded from
+`cta_symbol_for_alias` directly alias their `oncoref.cta` implementations.
+Proteoform grouping comes from
 `oncoref.proteoforms.proteoform_symbol_map(scope="cta")`.
 
-This makes an installed oncoref release the single executable definition:
+The boundary is executable:
 
 ```python
 import oncoref.cta
 import tsarina.gene_sets
 
 assert tsarina.gene_sets.CTA_gene_names is oncoref.cta.cta_gene_names
-assert tsarina.gene_sets.CTA_filtered_gene_ids is oncoref.cta.cta_filtered_gene_ids
+assert (
+    tsarina.gene_sets.CTA_filtered_gene_ids
+    is oncoref.cta.cta_filtered_gene_ids
+)
 ```
 
-`CTA_evidence()` starts from `oncoref.cta.cta_evidence()`. Tsarina preserves
-the same CTA row universe and every upstream column.
+`CTA_evidence()` starts from `oncoref.cta.cta_evidence()` and preserves its
+exact row universe and upstream columns.
 
-## Tsarina's evidence layer
+## Downstream evidence flow
 
-Tsarina owns evidence used to select and score targets after CTA membership is
-known:
+After CTA membership is known, Tsarina adds evidence used for selection and
+ranking:
 
-| Evidence | Storage or source | Effect on CTA membership |
+| Evidence | Storage or source | Can change CTA membership? |
 |---|---|---|
-| Gene-level MS safety | `data/gene-ms-safety-evidence.csv` | None |
-| Live immunopeptidomics | IEDB/CEDAR through hitlist | None |
-| Cancer RNA prevalence | Derived HPA cancer-prevalence tables | None |
-| Cancer IHC prevalence | Derived HPA cancer-prevalence tables | None |
-| pMHC predictions and scoring | Runtime | None |
+| Gene-level MS safety | `data/gene-ms-safety-evidence.csv` | No |
+| Live immunopeptidomics | IEDB/CEDAR through hitlist | No |
+| Cancer RNA prevalence | Derived HPA cancer-prevalence tables | No |
+| Cancer IHC prevalence | Derived HPA cancer-prevalence tables | No |
+| pMHC prediction and scoring | Runtime | No |
 
-The static MS overlay is deliberately generic. Its schema is only:
+The static MS overlay has only this schema:
 
 ```text
 Ensembl_Gene_ID
@@ -53,20 +74,26 @@ ms_healthy_somatic_tissues
 ms_pmids
 ```
 
-It contains no symbol, CTA membership flag, specificity action, HPA
-restriction field, or proteoform definition. A left join adds these columns
-only to genes already present in oncoref's evidence frame. Consequently, an MS
-row for a non-CTA gene cannot introduce that gene into Tsarina's CTA universe.
+It contains no symbol, membership flag, specificity action, HPA restriction
+field, or proteoform definition. Tsarina left-joins these columns onto the
+oncoref evidence frame. Therefore, an overlay row for a non-CTA gene cannot
+enter the CTA universe.
 
-The HPA cancer-prevalence tables are downstream feature caches. They are
-restricted to oncoref gene IDs and do not contain CTA membership or
-specificity columns.
+The HPA cancer-prevalence tables are feature caches for downstream ranking.
+They are restricted to oncoref gene IDs and contain no CTA membership or
+specificity fields.
 
-## Restriction axes
+## Restriction axes and API behavior
 
-The static `protein_restriction`, `rna_restriction`,
-`rna_restriction_level`, `restriction`, and `restriction_confidence` columns
-come unchanged from oncoref.
+The static columns below come unchanged from oncoref:
+
+| Axis | Values or role |
+|---|---|
+| `protein_restriction` | HPA protein-IHC restriction call |
+| `rna_restriction` | HPA RNA restriction call |
+| `rna_restriction_level` | `STRICT`, `MODERATE`, or `PERMISSIVE` |
+| `restriction` | Synthesized HPA restriction |
+| `restriction_confidence` | `HIGH`, `MODERATE`, `LOW`, or `NO_DATA` |
 
 Tsarina's `ms_restriction` is an independent downstream safety axis:
 
@@ -78,31 +105,44 @@ Tsarina's `ms_restriction` is an independent downstream safety axis:
 - `NO_MS_DATA`
 
 `CTA_by_axes()` queries oncoref's row universe and membership tiers. Its only
-Tsarina extension is an optional `ms_restriction` predicate.
+Tsarina extension is the optional `ms_restriction` predicate:
 
-Live target-selection workflows can explicitly call Tsarina's
-`synthesize_restriction()` or `assign_all_axes()` to combine current
-IEDB/CEDAR MS evidence with the oncoref HPA axes. Those helpers do not derive
-or modify the upstream protein and RNA classifications.
+```python
+from tsarina import CTA_by_axes
+
+strict_testis = CTA_by_axes(
+    restriction="TESTIS",
+    rna_restriction_level="STRICT",
+)
+high_confidence = CTA_by_axes(
+    restriction="TESTIS",
+    restriction_confidence="HIGH",
+)
+```
+
+Live workflows can explicitly call `synthesize_restriction()` or
+`assign_all_axes()` to combine current IEDB/CEDAR MS evidence with the oncoref
+HPA axes. These helpers do not derive or modify the upstream protein and RNA
+classifications.
 
 ## Updating definitions
 
-To update CTA membership, evidence provenance, aliases, HPA classifications,
-or proteoform groups:
+For changes to CTA membership, aliases, HPA classifications, evidence
+provenance, or proteoform groups:
 
-1. make or request the correction in
-   [oncoref](https://github.com/pirl-unc/oncoref/issues);
-2. release oncoref; and
-3. raise Tsarina's minimum oncoref dependency if the change requires a new
-   API or data release.
+1. file the omission or error in
+   [oncoref issues](https://github.com/pirl-unc/oncoref/issues);
+2. correct and release oncoref; and
+3. raise Tsarina's minimum oncoref dependency when the correction requires a
+   new API or data release.
 
 Do not add a local CTA row, exclusion list, alias override, or fallback table
-in Tsarina. Upstream omissions and errors must be filed as oncoref issues
-instead. For example, the audit that established this ownership boundary
-reported [oncoref #435](https://github.com/pirl-unc/oncoref/issues/435) for an
-RNA/protein restriction-confidence synthesis error.
+to Tsarina. The ownership audit followed this rule by filing
+[oncoref #435](https://github.com/pirl-unc/oncoref/issues/435) for an
+RNA/protein restriction-confidence synthesis error instead of compensating
+locally.
 
-Tsarina's old local CTA regeneration and reference-data commands have been
-removed. HPA cancer-prevalence features can still be regenerated with
-`scripts/regenerate_hpa_cancer_prevalence.py`; the script takes its gene
-universe directly from `oncoref.cta.cta_evidence()`.
+Tsarina's obsolete CTA regeneration and full reference-data commands have
+been removed. The remaining HPA cancer-prevalence features can be regenerated
+with `scripts/regenerate_hpa_cancer_prevalence.py`; that script takes its gene
+universe from `oncoref.cta.cta_evidence()`.

--- a/docs/data-and-evidence.md
+++ b/docs/data-and-evidence.md
@@ -1,0 +1,220 @@
+# Data and evidence
+
+Tsarina keeps three questions separate:
+
+1. **What is the target?** CTA, viral, and mutation definitions establish the
+   candidate source.
+2. **Where has its peptide been observed?** IEDB/CEDAR observations provide
+   cancer, healthy-tissue, and HLA-restriction evidence.
+3. **Could this HLA present it?** Prediction fills gaps and compares candidate
+   peptide-allele pairs.
+
+This separation is important: downstream MS or prediction evidence can select,
+rank, or exclude a candidate, but it cannot add a gene to the canonical CTA
+universe.
+
+## Evidence model
+
+### Target definitions
+
+| Target category | Definition authority | Patient or panel context |
+|---|---|---|
+| CTA | oncoref membership, aliases, HPA restriction, and proteoform groups | Tumor expression or population cancer prevalence |
+| Viral | Tsarina's supported oncogenic-virus proteomes | Tumor viral status |
+| Mutant | Tsarina's recurrent hotspot registry | Matching tumor mutation |
+
+### Public observations
+
+IEDB and CEDAR ligand exports contribute observed peptides, sample context,
+reported HLA restrictions, donor allele sets, tissues, diseases, cell-line
+status, publications, and other provenance. Tsarina uses hitlist to normalize
+and index these records.
+
+### Prediction
+
+Presentation predictors score candidate peptides against patient alleles or a
+population panel. Prediction is used both to rank candidates and, under
+stricter thresholds, to assign an allele to peptide-level MS evidence that
+lacks a usable exact restriction.
+
+## Observation classification
+
+Each IEDB/CEDAR MS observation is classified by biological source before
+aggregation:
+
+| Flag | Source criteria | Interpretation |
+|---|---|---|
+| `src_cancer` | Process type is occurrence of cancer | Peptide observed in a tumor context |
+| `src_healthy` | No immunization and disease is healthy or empty | Peptide observed in a normal context |
+| `src_reproductive` | Tissue belongs to the reproductive definition | Expected source context for many CTAs |
+| `src_thymus` | Source tissue is thymus | Tracked separately because of AIRE-mediated expression |
+| `src_cell_line` | Culture condition is cell line or clone | In-vitro evidence rather than direct tissue |
+| `src_ebv_lcl` | EBV-transformed B lymphoblastoid cell line | Special-case transformed-cell evidence |
+| `src_ex_vivo` | Culture condition is direct ex vivo | Highest-confidence direct-tissue context |
+
+The flags are not mutually exclusive. For example, an observation can be both
+healthy and reproductive.
+
+## Positive and negative evidence
+
+Tsarina applies the same source classification to evidence supporting a target
+and evidence warning against it:
+
+- A **positive cancer peptide** has `src_cancer` evidence and is exclusive to
+  the applicable CTA, viral, or mutation source rules.
+- A **negative safety peptide** has healthy, direct-ex-vivo evidence from
+  non-reproductive, non-thymic tissue.
+
+The second category is an on-target, off-tumor warning. Personalized selection
+removes such peptides by default. Panel selection applies source- and
+peptide-level safety gates while retaining provenance for audit.
+
+Reproductive-tissue and thymus observations are not silently relabeled as
+healthy somatic risk. Cell-line and EBV-LCL observations remain distinguishable
+from direct-ex-vivo evidence.
+
+## Install and register datasets
+
+List all datasets Tsarina knows about, then inspect what is installed:
+
+```bash
+tsarina data available
+tsarina data list
+```
+
+Fetch supported remotely available assets:
+
+```bash
+tsarina data fetch hpv16
+tsarina data fetch ebv
+```
+
+IEDB and CEDAR exports must be downloaded under their source terms, then
+registered:
+
+```bash
+tsarina data register iedb /data/mhc_ligand_full.csv
+tsarina data register cedar /data/cedar-mhc-ligand-full.csv
+```
+
+Inspect metadata or resolve a registered path:
+
+```bash
+tsarina data info iedb
+tsarina data path iedb
+```
+
+Build the normalized observations index once:
+
+```bash
+tsarina build observations
+```
+
+The index is built automatically on first use if needed. Rebuild it after
+replacing an input export:
+
+```bash
+tsarina build observations --force
+```
+
+### Data sources
+
+| Dataset | Upstream source | Acquisition |
+|---|---|---|
+| IEDB MHC ligand | [IEDB](https://www.iedb.org/) | Manual export and `tsarina data register iedb …` |
+| CEDAR MHC ligand | [CEDAR](https://cedar.iedb.org/) | Manual export and `tsarina data register cedar …` |
+| Supported viral proteomes | UniProt | `tsarina data fetch <virus>` |
+| Mirrored Tsarina assets | Project data releases | `tsarina data fetch-all` |
+
+The data registry is shared with hitlist. Its default storage location is
+`~/.hitlist/`; set `HITLIST_DATA_DIR` to use another location.
+
+IEDB columns are resolved from CSV headers, with known-index fallbacks for
+compatible historical exports.
+
+## Inspect peptide observations
+
+Query all indexed MS hits attributed to a gene:
+
+```bash
+tsarina hits --gene PRAME
+```
+
+Filter the observations and include reference-level aggregation:
+
+```bash
+tsarina hits \
+  --gene PRAME \
+  --allele 'HLA-A*24:02' \
+  --mhc-class I \
+  --format refs
+```
+
+Inspect healthy somatic tissue observations separately:
+
+```bash
+tsarina hits --gene PRAME --healthy-tissue
+```
+
+The cached observations path preserves multi-gene attribution for shared
+peptides. Use `--mono-allelic-only` for direct single-allele evidence or
+`--include-binding-assays` to union binding-assay rows with MS observations.
+
+Run `tsarina hits --help` for output formats, resolution filters, raw-export
+overrides, and the theoretical peptide-enumeration mode.
+
+## Tissue definitions
+
+Tsarina re-exports oncoref's canonical reproductive-tissue sets for downstream
+analysis:
+
+```python
+from tsarina.tissues import (
+    CORE_REPRODUCTIVE_TISSUES,
+    EXTENDED_REPRODUCTIVE_TISSUES,
+    PERMISSIVE_REPRODUCTIVE_TISSUES,
+    adaptive_rna_threshold,
+    is_tissue_restricted,
+)
+```
+
+The sets progress from core reproductive tissues to broader definitions. The
+helper excludes thymus by default when deciding whether detected tissues are
+confined to the allowed set.
+
+These re-exports do not create an independent tissue definition. CTA
+restriction decisions and their underlying HPA evidence remain owned by
+oncoref; see [CTA ownership and downstream evidence](curation.md).
+
+## Presentation scoring
+
+Score an explicit peptide set against a named HLA panel:
+
+```python
+from tsarina.alleles import get_panel
+from tsarina.scoring import score_presentation
+
+scores = score_presentation(
+    peptides=["SLYNTVATL", "GILGFVFTL"],
+    alleles=get_panel("iedb27_ab"),
+)
+```
+
+The main selection workflows interpret lower presentation percentile as
+better. Personalized tier thresholds are documented in
+[Personalized target selection](personalized-targets.md); panel evidence
+thresholds are documented in [CTA panel design](panel-design.md).
+
+## Output identity and naming
+
+All target categories use the same `source`/`source_detail` relationship:
+
+| Category | `source` | `source_detail` | Example |
+|---|---|---|---|
+| CTA | Gene symbol | Ensembl gene ID | `MAGEA4` / `ENSG00000147381` |
+| Viral | Virus short name | UniProt protein accession | `HPV-16` / `P03126` |
+| Mutant | Mutation label | Mutation string | `KRAS G12D` / `G12D` |
+
+Keep both fields when joining or exporting results. `source` is the
+human-readable target label; `source_detail` preserves the underlying
+identifier needed for provenance.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,407 +1,120 @@
-# tsarina
+# Tsarina documentation
 
-[![Tests](https://github.com/pirl-unc/tsarina/actions/workflows/tests.yml/badge.svg)](https://github.com/pirl-unc/tsarina/actions/workflows/tests.yml)
-[![PyPI](https://img.shields.io/pypi/v/tsarina.svg)](https://pypi.org/project/tsarina/)
+Tsarina turns shared cancer targets into ranked peptide-MHC candidates. Use it
+to prioritize CTA, viral, and recurrent-mutation targets for one patient, or to
+design an off-the-shelf CTA panel across a population HLA set.
 
-Personalized cancer immunotherapy target selection from curated shared antigen data.
+## Start with your outcome
 
-tsarina weaves patient-specific tumor characteristics (mutations, CTA expression, viral infections, HLA type) together with curated public mass spectrometry evidence to produce prioritized lists of targetable peptide-MHC complexes. The core idea is to personalize cancer immunotherapy from shared, public knowledge rather than per-patient whole-exome discovery.
+### Prioritize targets for one patient
 
-## Concept
+Use patient HLA type plus any available CTA expression, hotspot mutations, and
+viral status. Tsarina returns ranked pMHCs with source abundance, public MS
+support, healthy-tissue safety flags, and predicted presentation.
 
-The core insight is that many cancer-targetable peptides are **shared across patients**: cancer-testis antigens are recurrently activated in tumors, oncogenic viruses produce the same foreign proteins in every infected cell, and hotspot driver mutations generate identical mutant peptides across thousands of patients. Unlike private passenger-mutation neoantigens that require individual whole-exome sequencing, these shared targets can be curated once and reused.
+Continue to [Personalized target selection](personalized-targets.md).
 
-tsarina combines curated shared targets with per-patient tumor data to produce a prioritized list of peptide-MHC complexes.
+### Design a reusable CTA panel
 
-**Shared targets** (curated once, reused across patients):
-- **CTA genes** — the current oncoref canonical set, enriched with tsarina MS safety evidence
-- **Viral proteomes** — 9 oncogenic viruses (HPV, EBV, HBV, HCV, HTLV-1, HIV, HHV-8, MCPyV, MCV)
-- **Hotspot mutations** — 19 recurrent mutations across 8 driver genes
+Use Tsarina's automatic CTA safety filters and cancer-prevalence ranking, or
+provide an explicit CTA list. Tsarina returns a CTA × HLA matrix, evidence
+tiers, and population-coverage estimates.
 
-**Public annotation data** (used to score and filter targets):
-- **Mass spec evidence** — IEDB/CEDAR immunopeptidomics observations
-- **Tissue expression** — HPA RNA (50 tissues) + IHC protein (63 tissues)
-- **HLA allele panels** — population-representative panels (27–53 alleles per region)
+Continue to [CTA panel design](panel-design.md).
 
-**Patient data** (per-individual):
-- HLA type (Class I alleles)
-- Tumor RNA-seq (CTA expression in TPM)
-- Detected mutations (cross-referenced against hotspot list)
-- Viral status (HPV, EBV, etc.)
+### Inspect peptide evidence
 
-tsarina filters shared targets through the patient's HLA type and tumor profile, then ranks the results into a **prioritized target list** annotated with:
-- **Public MS evidence** — number of independent IEDB/CEDAR references, source context (cancer vs. healthy tissue)
-- **Source protein abundance** — RNA expression in TPM, estimated protein abundance where HPA data permits
-- **Predicted presentation** — MHCflurry presentation percentile, NetMHCpan binding affinity
-- **Target category** — CTA, viral, or mutant, with full provenance
+Use the data registry to install or register IEDB and CEDAR exports, then query
+the observation index for specified peptides.
 
-## Install
+Continue to [Data and evidence](data-and-evidence.md).
 
-```bash
-pip install tsarina
+## The shared pipeline
 
-# With full functionality (pyensembl for peptide generation + gene partition):
-pip install tsarina[all]
-```
+All target-selection workflows follow the same conceptual stages:
 
-## Three target categories
+1. **Define candidates.** CTA definitions come from oncoref; viral proteins and
+   recurrent mutation hotspots come from Tsarina's target modules.
+2. **Apply biological context.** Patient workflows retain expressed CTAs and
+   detected mutations or viruses. Panel workflows rank CTAs by population-level
+   cancer prevalence.
+3. **Enforce specificity and safety.** Candidate peptides must be exclusive to
+   their intended source rules. Healthy-tissue MS observations are kept
+   separate from expected reproductive-tissue and thymus observations.
+4. **Add presentation evidence.** Public immunopeptidomics observations and HLA
+   presentation predictions establish evidence tiers.
+5. **Rank with provenance.** Results retain target identity, observation
+   evidence, prediction scores, and the reason for their rank.
 
-### CTA (cancer-testis antigens)
+These stages keep target definition distinct from downstream evidence. In
+particular, [oncoref](https://github.com/pirl-unc/oncoref) alone owns CTA
+membership, aliases, HPA restriction calls, and proteoform groups. See
+[CTA ownership and downstream evidence](curation.md) for the integration
+boundary.
 
-Proteins normally restricted to reproductive tissues (testis, ovary, placenta) that become aberrantly expressed in tumors. Their tissue restriction means immune responses against them should not damage normal somatic tissues. Thymus expression is expected (AIRE-mediated central tolerance) and excluded from restriction checks.
+## Install and prepare data
 
-**[oncoref](https://github.com/pirl-unc/oncoref) is the sole owner of CTA
-definitions.** It supplies the candidate universe, membership tiers, aliases,
-HPA restriction calls, and proteoform groups. Tsarina's foundational CTA
-helpers directly alias `oncoref.cta`; Tsarina does not ship a second CTA table.
-
-`CTA_evidence()` preserves oncoref's exact row universe and adds only a generic
-gene-level `ms_*` safety overlay with no CTA membership or HPA columns.
-
-```python
-from tsarina import CTA_gene_names, CTA_gene_ids, CTA_evidence
-
-genes = CTA_gene_names()  # direct oncoref default set
-df = CTA_evidence()       # oncoref evidence plus tsarina's ms_* columns
-```
-
-The HPA-derived restriction columns remain oncoref-owned. Tsarina keeps static
-MS safety evidence separate and combines it explicitly only in live
-IEDB/CEDAR target-selection workflows.
-
-See [CTA ownership and downstream evidence](curation.md) for the complete
-boundary. Curation corrections belong in
-[oncoref issues](https://github.com/pirl-unc/oncoref/issues).
-
-### Viral (oncogenic virus proteins)
-
-Foreign proteins from oncogenic viruses -- entirely absent from normal human tissue, making them ideal immunotherapy targets when the virus is present in the tumor.
-
-```python
-from tsarina.viral import (
-    human_exclusive_viral_peptides,
-    viral_peptides,
-)
-
-peps = viral_peptides("hpv16")                    # all viral peptides
-human_exclusive = human_exclusive_viral_peptides("hpv16")  # default clinical helper
-```
-
-`personalized_targets()` and `target_peptides()` use the human-exclusive viral helper by
-default, dropping viral k-mers that also occur anywhere in the human proteome.
-`cancer_specific_viral_peptides()` is available for exploratory workflows that
-allow overlaps with CTA proteins while excluding non-CTA overlaps.
-
-| Virus | Cancers | Key oncoproteins |
-|---|---|---|
-| HPV-16, HPV-18 | Cervical, oropharyngeal, anal | E6, E7 |
-| EBV/HHV-4 | Burkitt lymphoma, NPC, Hodgkin lymphoma | LMP1, EBNA1, LMP2A |
-| HTLV-1 | Adult T-cell leukemia/lymphoma | Tax, HBZ |
-| HBV | Hepatocellular carcinoma | HBx |
-| HCV | HCC, B-cell lymphoma | Core, NS3, NS5A |
-| KSHV/HHV-8 | Kaposi sarcoma, primary effusion lymphoma | vFLIP, vCyclin, LANA |
-| MCPyV | Merkel cell carcinoma | Large T, small T |
-| HIV-1 | Kaposi sarcoma, non-Hodgkin lymphoma | Tat, Nef |
-
-### Mutant (recurrent somatic hotspot mutations)
-
-Shared neoantigens from driver mutations that recur across thousands of patients. Unlike private passenger mutations, these produce the same mutant peptide in every patient carrying the same hotspot mutation.
-
-```python
-from tsarina.mutations import HOTSPOT_MUTATIONS, mutant_peptides
-
-df = mutant_peptides()  # all mutation-spanning 8-11mer peptides
-```
-
-| Gene | Mutations | Cancer types |
-|---|---|---|
-| KRAS | G12C, G12D, G12V, G12R, G13D | Pancreatic, colorectal, NSCLC |
-| BRAF | V600E, V600K | Melanoma, colorectal, thyroid |
-| TP53 | R175H, R248W, R273H, G245S, R249S | Pan-cancer |
-| PIK3CA | H1047R, E545K | Breast, endometrial |
-| IDH1 | R132H | Glioma, AML (peptidomics-validated vaccine target) |
-| NRAS | Q61R, Q61K | Melanoma |
-| EGFR | L858R, T790M | NSCLC |
-
-## Positive and negative peptide sets
-
-tsarina constructs both **positive sets** (cancer-specific peptides from the three target categories) and **negative sets** (peptides observed on normal non-reproductive, non-thymic tissues) using the same IEDB/CEDAR scanning infrastructure with consistent tissue classification.
-
-### Tissue source classification
-
-Every IEDB/CEDAR mass spec observation is classified by biological context:
-
-| Category | IEDB criteria | Meaning |
-|---|---|---|
-| `src_cancer` | Process Type = "Occurrence of cancer" | Peptide detected on tumor MHC |
-| `src_healthy` | Process Type = "No immunization", Disease = "healthy" or empty | Peptide detected on normal tissue |
-| `src_reproductive` | Source Tissue in {testis, ovary, placenta, ...} | Expected for CTAs |
-| `src_thymus` | Source Tissue = thymus | Expected for CTAs (AIRE-mediated) |
-| `src_cell_line` | Culture Condition = "Cell Line / Clone" | In vitro, not direct tissue |
-| `src_ebv_lcl` | Culture Condition contains "EBV transformed, B-LCL" | EBV-immortalized B cells (special case) |
-| `src_ex_vivo` | Culture Condition = "Direct Ex Vivo" | Highest confidence tissue evidence |
-
-**Positive set criteria**: peptide has `src_cancer` evidence AND is exclusive to CTA/viral/mutant source proteins (not found in non-target human proteins).
-
-**Negative set criteria**: peptide has `src_healthy` + `src_ex_vivo` evidence from non-reproductive, non-thymic tissues. These are peptides confirmed to be presented on normal somatic tissue -- targeting them would cause on-target, off-tumor toxicity.
-
-## Patient personalization
-
-The main entry point for clinical use:
-
-```python
-from tsarina import personalized_targets
-
-targets = personalized_targets(
-    # Patient HLA type
-    hla_alleles=["HLA-A*02:01", "HLA-A*24:02", "HLA-B*07:02", "HLA-B*44:02",
-                 "HLA-C*07:02", "HLA-C*05:01"],
-
-    # CTA expression (gene symbol -> TPM from RNA-seq)
-    cta_expression={"MAGEA4": 142.5, "PRAME": 87.3, "CTAG1B": 215.0},
-
-    # Detected mutations (match against hotspot list)
-    mutations=["KRAS G12D", "TP53 R175H"],
-
-    # Viral status
-    viruses=["hpv16"],
-
-    # Data sources
-    iedb_path="mhc_ligand_full.csv",
-)
-```
-
-Returns a DataFrame with columns:
-
-| Column | Description |
-|---|---|
-| `peptide` | Peptide sequence |
-| `category` | `cta`, `viral`, or `mutant` |
-| `source` | Gene name, virus, or mutation label |
-| `source_abundance_tpm` | RNA expression in tumor (CTAs only) |
-| `ms_hit_count` | Number of IEDB/CEDAR MS observations |
-| `ms_alleles` | MHC restrictions observed in public data |
-| `ms_in_cancer` | Detected in cancer samples |
-| `ms_in_healthy_somatic` | Detected in normal non-reproductive, non-thymic tissue (safety flag) |
-| `presentation_percentile` | MHCflurry presentation percentile for best patient allele |
-| `best_allele` | Patient HLA allele with best predicted presentation |
-| `binding_affinity_nm` | Predicted binding affinity (nM) |
-
-Prioritization is by: (1) public MS evidence strength, (2) source protein abundance, (3) predicted presentation quality, (4) absence of healthy-tissue MS evidence.
-
-## CTA x HLA panel matrices
-
-Build a CTA x HLA pMHC matrix for off-the-shelf panel design:
+Install the package:
 
 ```bash
-tsarina panel
+pip install "tsarina[all]"
 ```
 
-Defaults:
-
-- up to 25 downstream non-empty CTAs ranked by bundled HPA tumor RNA prevalence
-  breadth/sample prevalence, with lower-ranked candidates scanned as needed to
-  backfill empty downstream targets and clinical allowlist anchors pinned ahead
-  of lower-ranked candidates
-- automatic safety gates remove CTAs with vital-tissue RNA / unique healthy-MS
-  evidence, while allowlisting `PRAME`, `CTAG1A/CTAG1B`, and `MAGEA4`
-- automatic selection excludes MAGE-family CTAs other than `MAGEA4` unless they
-  are explicitly requested or allowlisted
-- `CTAG1A/CTAG1B` is treated as one grouped CTA target, with `NY-ESO-1`
-  accepted as an input alias
-- CTAs with identical enumerated peptide sets or final selected pMHC panels are
-  grouped so paralogous targets do not consume multiple automatic panel slots
-- `global53_abc` HLA-A/B/C panel
-- 8-11mer CTA-exclusive peptides
-- MHCflurry presentation scoring
-- MS-evidence-first cell selection
-- up to 3 peptides per CTA x HLA cell, ranked by MS source count, then prediction
-- readable terminal table plus coverage summary
-
-Use CSV formats for scripts:
+See which external datasets Tsarina can use:
 
 ```bash
-tsarina panel --format long -o panel-long.csv
-tsarina panel --format wide -o panel-wide.csv
+tsarina data available
 ```
 
-The CLI prints progress for peptide enumeration, public-MS evidence loading,
-scoring, evidence-tier construction, and final selection. Interactive terminals
-also get a `tqdm` scoring progress bar; MHCflurry still scores all alleles in
-one batch by default because chunking repeats its allele-independent processing
-model work. Use `--score-chunk-size` only when you explicitly want chunking, or
-`--progress off` to suppress progress output.
-
-Use `--selection-allowlist`, `--no-vital-tissue-filter`,
-`--vital-tissue-max-ntpm`, and `--allow-non-magea4-mage-family` to tune
-automatic CTA safety filtering. The default vital RNA cutoff is 2.0 nTPM;
-public healthy-MS observations in vital tissues remain exclusionary only when
-the peptide evidence maps uniquely to that CTA, unless allowlisted. Explicit
-`--ctas` accepts aliases such as `NY-ESO-1` and `MAGE-A4` and bypasses automatic
-CTA-family safety gates.
-
-Default automatic ranking uses `tumor_prevalence_panel_score`, computed from
-bundled HPA cancer RNA prevalence at pTPM >= 2.0 and cancer-type breadth at a
-5% sample-prevalence floor, with HPA cancer IHC as a weak tie-breaker. Public
-MS support and safety gates are recomputed from the current hitlist observations
-index for each candidate batch before pMHC scoring; packaged CTA evidence does
-not carry MS count columns. Use `--cancer-rna-threshold`,
-`--cancer-type-prevalence-floor`, or `--cta-rank-by <column>` to change the
-initial non-MS candidate ranking.
-
-Automatic panel output scans lower-ranked CTA candidates to backfill CTAs with
-zero selected pMHCs after peptide enumeration, CTA-exclusivity, public-MS, and
-presentation-score gates; pass `--show-empty-ctas` to audit the top ranked
-candidates including those failures. Explicit `--ctas` requests are preserved
-even if a requested CTA has zero selected pMHCs. The "Expected Population
-Coverage Per CTA" rows are sorted by selected peptide count, then HLA-hit count,
-then estimated population coverage, and split monoallelic MS pMHC support from
-sample-genotype/deconvolved MS support.
-
-Peptide enumeration may expand one target label to multiple Ensembl genes
-(`CTAG1A/CTAG1B` and the `NY-ESO-1` alias expand to `CTAG1A` and `CTAG1B`),
-but output target names stay grouped. Pass `--no-group-identical-cta-peptide-sets`
-to keep peptide-identical paralog targets separate, or `--no-group-identical-cta-pmhcs`
-to keep duplicate pMHC panels separate.
-Pass `--netmhcpan-affinity` to annotate every selected pMHC row with NetMHCpan
-BA affinity nM and affinity percentile rank. This is opt-in because it requires
-the external NetMHCpan backend and adds a second scoring pass when the main
-selector is using MHCflurry.
-
-Evidence tiers use configurable presentation percentile cutoffs:
-
-| Evidence tier | Default cutoff | Meaning |
-|---|---:|---|
-| `monoallelic_ms` | < 2.0 | Peptide observed in mono-allelic MS for that HLA |
-| `sample_allele_ms` | < 1.0 | Peptide observed in multi-allelic MS with a usable exact restriction set or donor allele set; the selected HLA must be the best predicted allele in that set, including when the row's reported restriction is only `HLA class I` |
-| `unrestricted_ms` | < 0.5 | Peptide observed by class-I MS with no usable exact or donor-set allele assignment; the selected panel HLA is assigned by prediction under this stricter cutoff |
-| `predicted_only` | < 0.1 | No MS support; excluded unless `--include-predicted-only` is passed |
-
-Available HLA panels:
-
-| Panel | Alleles | Coverage |
-|---|---|---|
-| `iedb27_ab` | 27 | Global baseline (HLA-A/B) |
-| `iedb36_abc` | 36 | + HLA-C |
-| `global44_abc` | 44 | + East Asia, South Asia, Sub-Saharan Africa |
-| `global48_abc` | 48 | + Latin America, MENA |
-| `global51_abc_ssa` | 51 | Legacy Global-48 + additional Sub-Saharan Africa |
-| `global51_abc` | 51 | Global reference panel: IEDB A/B backbone, frequent HLA-C allotypes, and IEDB/Paul common-A/B complements |
-| `global53_abc` | 53 | Default global panel: Global-51 plus CTA-MS supported `A*29:02`, `B*15:02`, and `B*27:05`, keeping only `C*14:02` from the MHCflurry-identical C*14 pair |
-
-Regional allele frequency data from 7 geographic regions supports population-weighted coverage
-calculations. The frequency audit keeps those sub-population proxy rows separate
-from published global average allele frequencies on the same 0-1 allele-frequency
-scale. Panel coverage uses the regional weighted value when a numeric regional
-proxy exists and falls back to the published global average only when no regional
-proxy is available. For each CTA, covered allele frequencies are summed within
-each HLA locus, converted to locus carrier probability as
-`1 - (1 - locus_frequency)^2`, and then combined across loci. All default
-`global53_abc` alleles have a published global average,
-source/proxy/resolution provenance, and a nonzero coverage frequency,
-preventing known-frequency HLA hits from reporting artificial `0.0%` CTA
-coverage.
-The reference `global51_abc` panel keeps all 27 IEDB/TepiTool class-I A/B reference alleles,
-adds all 21 frequent HLA-C allotypes from the Sarkizova HLA-C peptidome coverage set,
-and fills the remaining 51-panel slots with the highest-frequency calibrated alleles
-missing from the IEDB/Paul 38 common HLA-A/B threshold set
-(`B*18:01`, `B*40:02`, `B*46:01`). The default `global53_abc` panel adds
-`A*29:02`, `B*15:02`, and `B*27:05` because these were the top missing
-alleles in a public CTA-MS evidence audit while retaining MHCflurry percentile
-rank support. It keeps `C*14:02` but excludes `C*14:03` because MHCflurry uses
-the same pseudosequence and percentile-rank calibration for both, and `C*14:02`
-had the CTA-MS support in the local audit. References: IEDB reference set
-<https://help.iedb.org/hc/en-us/articles/114094151851-HLA-allele-frequencies-and-reference-sets-with-maximal-population-coverage>,
-TepiTool allele-selection description <https://pmc.ncbi.nlm.nih.gov/articles/PMC4981331/>,
-IEDB/Paul 38 common A/B thresholds
-<https://help.iedb.org/hc/en-us/articles/114094151811-Selecting-thresholds-cut-offs-for-MHC-class-I-and-II-binding-predictions>,
-and Sarkizova et al. <https://doi.org/10.1038/s41587-019-0322-9>.
-Audit notes: all 53 default alleles resolve through MHCflurry's
-`percent_rank_calibrated_allele` lookup and produce numeric affinity percentile
-ranks. `HLA-C*15:05` remains excluded because MHCflurry supports raw affinity and
-presentation predictions for it but does not have an affinity percentile-rank
-calibration.
-
-## Data management
-
-Tsarina uses the shared hitlist data registry for external datasets:
+Viral proteomes can be fetched automatically. IEDB and CEDAR ligand exports
+must be downloaded under their source terms and registered locally:
 
 ```bash
-# See what data is available
-tsarina data list --all
-
-# Auto-download viral proteomes from UniProt
 tsarina data fetch hpv16
-tsarina data fetch ebv
-
-# Register manually downloaded IEDB/CEDAR exports
 tsarina data register iedb /data/mhc_ligand_full.csv
 tsarina data register cedar /data/cedar-mhc-ligand-full.csv
-
-# Inspect what's installed
 tsarina data list
-
-# Resolve paths for use in scripts
-tsarina data path iedb
 ```
 
-### Data sources
+The [Data and evidence](data-and-evidence.md) guide explains storage,
+observation classification, and the evidence model.
 
-| Dataset | Source | Size | How to get |
-|---|---|---|---|
-| IEDB MHC ligand | [iedb.org](https://www.iedb.org/) | ~2 GB | Manual download (terms of use) |
-| CEDAR MHC ligand | [cedar.iedb.org](https://cedar.iedb.org/) | ~1 GB | Manual download |
-| HPV-16 proteome | [UniProt UP000006729](https://www.uniprot.org/proteomes/UP000006729) | ~3 KB | `tsarina data fetch hpv16` |
-| EBV proteome | [UniProt UP000153037](https://www.uniprot.org/proteomes/UP000153037) | ~50 KB | `tsarina data fetch ebv` |
-| *(9 viral proteomes total)* | UniProt | varies | `tsarina data fetch <name>` |
+## Core target concepts
 
-Storage location: `~/.hitlist/` (override with `HITLIST_DATA_DIR` env var).
-`tsarina data` delegates registry and cache management to hitlist.
+### Cancer-testis antigens
 
-IEDB column indices are resolved dynamically from CSV headers, with fallback to known defaults -- robust to IEDB schema changes.
+CTAs are normally restricted to reproductive tissues but can be reactivated in
+tumors. Oncoref supplies the candidate universe and HPA-derived restriction
+axes. Tsarina adds tumor prevalence, public-MS safety evidence, peptide
+enumeration, and HLA scoring after membership is known.
 
-## Tissue definitions
+### Oncogenic viruses
 
-Three oncoref-defined tiers of reproductive tissue sets are re-exported for
-downstream restriction analysis:
+Viral proteins are foreign to the human proteome. Clinical helpers default to
+human-exclusive viral peptides, removing viral k-mers that also occur in human
+proteins.
 
-```python
-from tsarina.tissues import (
-    CORE_REPRODUCTIVE_TISSUES,       # {testis, ovary, placenta}
-    EXTENDED_REPRODUCTIVE_TISSUES,   # + cervix, endometrium, prostate, ...
-    PERMISSIVE_REPRODUCTIVE_TISSUES, # + breast
-    is_tissue_restricted,
-    adaptive_rna_threshold,
-)
-```
+### Recurrent mutations
 
-## MHCflurry scoring
+Hotspot driver mutations produce shared mutant peptides in patients carrying
+the same alteration. Tsarina enumerates mutation-spanning peptides rather than
+discovering private passenger mutations from whole-exome sequencing.
 
-```python
-from tsarina.scoring import score_presentation
-from tsarina.alleles import get_panel
+## Guide map
 
-scores = score_presentation(
-    peptides=["SLYNTVATL", "GILGFVFTL"],
-    alleles=get_panel("iedb27_ab"),
-)
-```
+| Guide | Use it for |
+|---|---|
+| [Personalized target selection](personalized-targets.md) | Patient inputs, CLI and Python use, output columns, and ranking |
+| [CTA panel design](panel-design.md) | Automatic CTA selection, safety gates, evidence tiers, HLA panels, and coverage |
+| [Data and evidence](data-and-evidence.md) | Dataset setup, source classification, positive/negative evidence, scoring, and naming |
+| [CTA ownership and downstream evidence](curation.md) | The oncoref/Tsarina boundary, API behavior, and definition updates |
 
-## Target naming convention
-
-tsarina uses a unified naming scheme across all target categories:
-
-| Category | `source` column | `source_detail` column | Example |
-|---|---|---|---|
-| CTA | Gene symbol | Ensembl gene ID | `MAGEA4` / `ENSG00000147381` |
-| Viral | Virus short name | UniProt protein accession | `HPV-16` / `P03126` |
-| Mutant | Mutation label | Mutation string | `KRAS G12D` / `G12D` |
-
-## Development
+For the current command-line surface, use:
 
 ```bash
-./develop.sh    # install in dev mode
-./format.sh     # ruff format
-./lint.sh       # ruff check + format check
-./test.sh       # pytest with coverage
+tsarina --help
+tsarina personalize --help
+tsarina panel --help
+tsarina hits --help
+tsarina data --help
 ```

--- a/docs/panel-design.md
+++ b/docs/panel-design.md
@@ -1,0 +1,270 @@
+# CTA panel design
+
+The panel workflow designs an off-the-shelf set of CTA peptide-MHC targets
+across a population HLA panel. It selects biologically suitable CTAs, finds
+evidence-supported peptides for each allele, and reports both the resulting
+matrix and estimated HLA coverage.
+
+Use this workflow for cohort-level vaccine or TCR-program design. For one
+patient with known tumor findings, use
+[Personalized target selection](personalized-targets.md) instead.
+
+## Quick start
+
+Build the default panel as a readable report:
+
+```bash
+tsarina panel
+```
+
+Write one row per selected pMHC for analysis:
+
+```bash
+tsarina panel --format long --output panel-long.csv
+```
+
+Write a CTA × HLA matrix whose cells contain selected peptides:
+
+```bash
+tsarina panel --format wide --output panel-wide.csv
+```
+
+The default run targets up to 25 non-empty CTAs across `global53_abc`, uses
+8–11mer CTA-exclusive peptides, requires public-MS evidence, scores with
+MHCflurry, and retains up to three peptides per CTA × HLA cell.
+
+## Selection pipeline
+
+Panel construction is intentionally staged. Early stages define and screen CTA
+sources; later stages select pMHCs without changing CTA definitions.
+
+### 1. Rank candidate CTAs
+
+Automatic selection begins with oncoref's canonical CTA universe. The default
+rank, `tumor_prevalence_panel_score`, combines:
+
+- HPA cancer RNA prevalence at pTPM ≥ 2.0;
+- cancer-type breadth using a 5% within-type sample-prevalence floor; and
+- HPA cancer IHC as a weak tie-breaker.
+
+These bundled prevalence features establish the scan order. Live public-MS
+support and safety are recalculated from the current observations index in a
+later stage.
+
+Change the initial ranking with:
+
+```bash
+tsarina panel \
+  --cta-rank-by tumor_prevalence_panel_score \
+  --cancer-rna-threshold 2.0 \
+  --cancer-type-prevalence-floor 0.05
+```
+
+### 2. Apply source-level safety gates
+
+Automatic selection keeps `HIGH` and `MODERATE` oncoref
+`restriction_confidence` by default. It also excludes:
+
+- CTAs with RNA above 2.0 nTPM in brain/CNS/cerebellum, heart, lung, liver, or
+  pancreas;
+- CTAs with peptide evidence that maps uniquely to that CTA in those healthy
+  vital tissues; and
+- MAGE-family CTAs other than MAGEA4.
+
+`PRAME`, `CTAG1A/CTAG1B`, and `MAGEA4` are allowlisted by default. The
+allowlist is applied explicitly and its members are placed ahead of
+lower-ranked automatic candidates.
+
+Explicit `--ctas` requests bypass the automatic family and source-selection
+gates. Aliases such as `NY-ESO-1` and `MAGE-A4` are normalized.
+
+### 3. Enumerate and group peptides
+
+The workflow enumerates 8–11mer CTA peptides and removes peptides that also
+occur in non-CTA human proteins. A single displayed target can expand to more
+than one Ensembl gene; for example, `CTAG1A/CTAG1B` and its `NY-ESO-1` alias
+expand to both genes while retaining one output label.
+
+Two forms of redundancy are grouped by default:
+
+- CTAs with identical enumerated peptide sets; and
+- CTAs with identical final selected pMHC panels.
+
+This prevents paralogs from consuming multiple automatic panel slots.
+
+### 4. Add MS evidence and score HLA presentation
+
+For each candidate batch, Tsarina queries the current hitlist observations
+index. It separates monoallelic, sample-allele/deconvolved, unrestricted, and
+prediction-only evidence, then applies an evidence-specific presentation
+percentile cutoff.
+
+Within each CTA × HLA cell, candidates are ordered by MS source count, MS hit
+count, prediction percentile, and deterministic tie-breakers.
+
+### 5. Backfill non-empty targets
+
+The default `--cta-count 25` means up to 25 downstream CTAs with at least one
+selected pMHC. When a highly ranked CTA becomes empty after peptide,
+exclusivity, MS, or prediction gates, Tsarina scans lower-ranked candidates to
+backfill the slot.
+
+Use `--show-empty-ctas` to inspect the original top-ranked candidates,
+including downstream failures. Explicit `--ctas` requests are always retained
+in the audit view, even when they produce no selected pMHCs.
+
+## Evidence tiers
+
+Lower presentation percentiles are better. The default pMHC evidence tiers
+are:
+
+| Evidence tier | Default cutoff | Interpretation |
+|---|---:|---|
+| `monoallelic_ms` | ≤ 2.0 | Peptide observed in monoallelic MS for the selected HLA |
+| `sample_allele_ms` | ≤ 1.0 | Multi-allelic MS with an exact restriction or donor allele set; the selected HLA is best predicted within that set |
+| `unrestricted_ms` | ≤ 0.5 | Class-I MS evidence without a usable allele assignment; prediction assigns the panel allele |
+| `predicted_only` | ≤ 0.1 | No MS support; disabled unless explicitly requested |
+
+Rows reported only as `HLA class I` can enter `sample_allele_ms` when a usable
+donor allele set is available. Otherwise they use the stricter unrestricted
+tier.
+
+Tune the cutoffs with:
+
+```bash
+tsarina panel \
+  --monoallelic-ms-max-percentile 2.0 \
+  --sample-allele-ms-max-percentile 1.0 \
+  --unrestricted-ms-max-percentile 0.5
+```
+
+Prediction-only candidates are opt-in:
+
+```bash
+tsarina panel \
+  --include-predicted-only \
+  --predicted-only-max-percentile 0.1
+```
+
+## Output and progress
+
+| Format | Intended use |
+|---|---|
+| `table` | Human-readable pMHC report plus coverage summary |
+| `long` | One row per selected peptide-HLA pair with evidence and score provenance |
+| `wide` | CTA rows × HLA columns, with selected peptides in each cell |
+
+The table summary orders CTAs by selected peptide count, HLA-hit count, and
+estimated population coverage. It reports monoallelic MS support separately
+from sample-genotype/deconvolved support.
+
+Progress messages cover peptide enumeration, MS loading, scoring, evidence-tier
+construction, and final selection. Interactive terminals also show a scoring
+bar. Control this behavior with:
+
+```bash
+tsarina panel --progress off
+tsarina panel --progress on
+```
+
+MHCflurry scores all alleles in one batch by default because chunking repeats
+allele-independent processing-model work. Use `--score-chunk-size` only when
+that tradeoff is desirable.
+
+## HLA panels
+
+| Panel | Alleles | Purpose |
+|---|---:|---|
+| `iedb27_ab` | 27 | IEDB global baseline for HLA-A/B |
+| `iedb36_abc` | 36 | IEDB baseline extended with HLA-C |
+| `global44_abc` | 44 | Adds representation for East Asia, South Asia, and Sub-Saharan Africa |
+| `global48_abc` | 48 | Adds representation for Latin America and MENA |
+| `global51_abc_ssa` | 51 | Legacy Global-48 extension for Sub-Saharan Africa |
+| `global51_abc` | 51 | Reference A/B backbone plus frequent HLA-C and common-A/B complements |
+| `global53_abc` | 53 | Default Global-51 extension with CTA-MS-supported alleles |
+
+Use a named panel or provide an explicit list:
+
+```bash
+tsarina panel --panel iedb27_ab
+tsarina panel --alleles 'HLA-A*02:01,HLA-A*24:02,HLA-B*07:02'
+```
+
+### Why Global-53 is the default
+
+`global51_abc` contains:
+
+- the 27 IEDB/TepiTool class-I HLA-A/B reference alleles;
+- 21 frequent HLA-C allotypes from the Sarkizova HLA-C peptidome coverage set;
+  and
+- `B*18:01`, `B*40:02`, and `B*46:01`, the highest-frequency calibrated
+  alleles needed to complement the IEDB/Paul common HLA-A/B set.
+
+`global53_abc` adds `A*29:02`, `B*15:02`, and `B*27:05`, which were the top
+missing alleles in a public CTA-MS audit. It keeps `C*14:02` but not
+`C*14:03`: MHCflurry uses the same pseudosequence and percentile calibration
+for both, while local CTA-MS support favored `C*14:02`.
+
+All 53 default alleles resolve through MHCflurry's calibrated
+percentile-rank lookup. `HLA-C*15:05` is not in the default panel because
+MHCflurry can score its raw affinity and presentation but lacks an affinity
+percentile-rank calibration.
+
+Panel references:
+
+- [IEDB allele frequencies and reference sets](https://help.iedb.org/hc/en-us/articles/114094151851-HLA-allele-frequencies-and-reference-sets-with-maximal-population-coverage)
+- [TepiTool allele-selection description](https://pmc.ncbi.nlm.nih.gov/articles/PMC4981331/)
+- [IEDB/Paul common HLA-A/B thresholds](https://help.iedb.org/hc/en-us/articles/114094151811-Selecting-thresholds-cut-offs-for-MHC-class-I-and-II-binding-predictions)
+- [Sarkizova et al. HLA-C peptidome study](https://doi.org/10.1038/s41587-019-0322-9)
+
+## Population coverage
+
+Regional allele frequencies from seven geographic regions support the coverage
+estimate. Subpopulation proxy rows remain separate from published global
+averages and use the same 0–1 allele-frequency scale.
+
+For each allele, Tsarina uses a regional weighted value when a numeric proxy is
+available and falls back to the published global average otherwise. For each
+CTA:
+
+1. sum covered allele frequencies within each HLA locus;
+2. convert each locus frequency \(f\) to carrier probability
+   \(1 - (1 - f)^2\); and
+3. combine carrier probabilities across loci.
+
+All default `global53_abc` alleles have source, proxy, resolution, and nonzero
+frequency provenance. The result is a panel-design estimate, not a
+clinical-grade population-genetics analysis.
+
+## Advanced selection controls
+
+### Source selection
+
+- `--ctas` supplies an explicit target list.
+- `--cta-count` changes the maximum automatic non-empty target count.
+- `--min-restriction-confidence` and `--restriction-levels` refine oncoref
+  restriction axes.
+- `--selection-allowlist` replaces the automatic safety allowlist.
+- `--no-vital-tissue-filter` or `--vital-tissue-max-ntpm` changes the vital
+  tissue gate.
+- `--allow-non-magea4-mage-family` permits other MAGE-family candidates during
+  automatic selection.
+
+### Peptides and grouping
+
+- `--lengths` changes enumerated peptide lengths.
+- `--no-require-cta-exclusive` permits peptide matches in non-CTA proteins.
+- `--peptides-per-cell` changes the maximum retained per CTA × HLA cell.
+- `--no-group-identical-cta-peptide-sets` keeps peptide-identical sources
+  separate.
+- `--no-group-identical-cta-pmhcs` keeps sources with duplicate final panels
+  separate.
+
+### Prediction
+
+- `--predictor` selects a supported presentation backend.
+- `--netmhcpan-affinity` adds NetMHCpan BA affinity nM and percentile
+  annotations in a second scoring pass. It requires the external NetMHCpan
+  backend.
+
+Run `tsarina panel --help` for the complete current option list.

--- a/docs/personalized-targets.md
+++ b/docs/personalized-targets.md
@@ -1,0 +1,189 @@
+# Personalized target selection
+
+The personalized workflow ranks shared peptide-MHC targets for one patient. It
+uses the patient's HLA type and tumor findings to choose candidates, removes
+known healthy-tissue risks by default, and returns explicit evidence tiers.
+
+Use this workflow when HLA typing is available and at least one of the
+following is known:
+
+- tumor CTA expression in TPM;
+- a supported recurrent hotspot mutation; or
+- the presence of a supported oncogenic virus.
+
+This is target prioritization from curated shared antigens. It is not
+whole-exome discovery of private neoantigens.
+
+## Inputs
+
+| Input | Required | Format | Effect |
+|---|---|---|---|
+| HLA class I alleles | Yes | HLA names such as `HLA-A*02:01` | Defines the presentation-scoring space |
+| CTA expression | No | Gene symbol → tumor RNA TPM | Retains expressed, restriction-qualified CTAs |
+| Mutations | No | Supported labels such as `KRAS G12D` | Adds mutation-spanning shared neoantigens |
+| Viruses | No | Keys such as `hpv16` or `ebv` | Adds peptides from the corresponding viral proteome |
+| IEDB/CEDAR data | Recommended | Registered dataset or explicit path | Adds public cancer and healthy-tissue MS evidence |
+
+At least one target source—CTA expression, mutations, or viruses—must produce
+candidates for the result to be non-empty.
+
+## Quick start
+
+### Command line
+
+```bash
+tsarina personalize \
+  --hla 'HLA-A*02:01,HLA-A*24:02,HLA-B*07:02,HLA-B*44:02' \
+  --cta 'MAGEA4=142.5,PRAME=87.3,CTAG1B=215.0' \
+  --mutations 'KRAS G12D,TP53 R175H' \
+  --viruses hpv16 \
+  --output patient-targets.csv
+```
+
+IEDB and CEDAR paths resolve from the data registry by default. For a dry run
+without public MS evidence, pass `--skip-ms-evidence`.
+
+### Python
+
+```python
+from tsarina import personalized_targets
+
+targets = personalized_targets(
+    hla_alleles=[
+        "HLA-A*02:01",
+        "HLA-A*24:02",
+        "HLA-B*07:02",
+        "HLA-B*44:02",
+    ],
+    cta_expression={
+        "MAGEA4": 142.5,
+        "PRAME": 87.3,
+        "CTAG1B": 215.0,
+    },
+    mutations=["KRAS G12D", "TP53 R175H"],
+    viruses=["hpv16"],
+)
+```
+
+## What the workflow does
+
+The default workflow applies the following stages in order:
+
+1. **Choose tumor-relevant sources.** CTAs must have at least 2.0 TPM and
+   `HIGH` or `MODERATE` oncoref restriction confidence. Mutations and viruses
+   must match supported identifiers.
+2. **Enumerate source peptides.** The default lengths are 8, 9, 10, and 11
+   amino acids.
+3. **Enforce source specificity.** CTA peptides must not occur in a non-CTA
+   human protein. Viral peptides must not occur anywhere in the human proteome.
+   Mutation peptides must span the altered residue and differ from wild type.
+4. **Attach public MS evidence.** Registered IEDB/CEDAR observations are
+   aggregated by peptide.
+5. **Apply the healthy-tissue gate.** Peptides observed on healthy,
+   non-reproductive tissue are removed by default.
+6. **Score HLA presentation.** Each peptide is scored against all supplied
+   alleles; the best allele and its score are retained.
+7. **Assign tiers and sort.** Results are ordered deterministically by tier, MS
+   support, presentation percentile, peptide, and best allele.
+
+See [Data and evidence](data-and-evidence.md) for the exact observation
+classification used by the MS and healthy-tissue stages.
+
+## Evidence tiers
+
+Lower presentation percentiles are better. The default MHCflurry-calibrated
+tiers are:
+
+| Tier | Label | Requirements |
+|---:|---|---|
+| 1 | `STRONG` | Percentile ≤ 0.25 and either cancer MS evidence or a viral/mutant source |
+| 2 | `MODERATE` | Percentile ≤ 0.50 and either any MS evidence or a viral/mutant source |
+| 3 | `CANDIDATE` | Percentile ≤ 1.0 |
+| 4 | `WEAK` | Does not meet the above, including unscored rows |
+
+Tier 4 is excluded by default. Use `--keep-weak-tier` or
+`drop_weak_tier=False` for diagnostics. The `tier_reason` column records which
+condition established each tier.
+
+## Output schema
+
+The result is one row per source peptide, annotated with its best patient HLA
+allele.
+
+| Column | Meaning |
+|---|---|
+| `peptide`, `length` | Peptide sequence and length |
+| `category` | `cta`, `viral`, or `mutant` |
+| `source` | CTA symbol, virus name, or mutation label |
+| `source_detail` | Ensembl gene ID, viral protein accession, or mutation string |
+| `source_tpm` | Patient tumor RNA expression for CTA rows |
+| `ms_hit_count` | Number of aggregated public MS observations |
+| `ms_alleles`, `ms_allele_count` | Observed HLA restrictions and their count |
+| `ms_in_cancer` | Whether public cancer MS evidence exists |
+| `ms_in_healthy_tissue` | Whether disallowed healthy-tissue MS evidence exists |
+| `best_allele` | Supplied patient allele with the best predicted presentation |
+| `presentation_percentile` | Best presentation percentile; lower is better |
+| `presentation_score` | Presentation score from the selected predictor |
+| `affinity_nm` | Predicted binding affinity in nM |
+| `tier`, `tier_label`, `tier_reason` | Prioritization result and provenance |
+
+## Supported shared targets
+
+### Cancer-testis antigens
+
+CTA definitions come directly from
+[oncoref](https://github.com/pirl-unc/oncoref). Tsarina does not maintain a
+second CTA list. The patient workflow starts from the canonical oncoref set,
+then applies expression, restriction-confidence, peptide-exclusivity, and
+downstream evidence gates.
+
+See [CTA ownership and downstream evidence](curation.md) for the definition
+boundary.
+
+### Oncogenic viruses
+
+| Virus | Associated cancers | Representative oncoproteins |
+|---|---|---|
+| HPV-16, HPV-18 | Cervical, oropharyngeal, anal | E6, E7 |
+| EBV/HHV-4 | Burkitt lymphoma, nasopharyngeal carcinoma, Hodgkin lymphoma | LMP1, EBNA1, LMP2A |
+| HTLV-1 | Adult T-cell leukemia/lymphoma | Tax, HBZ |
+| HBV | Hepatocellular carcinoma | HBx |
+| HCV | Hepatocellular carcinoma, B-cell lymphoma | Core, NS3, NS5A |
+| KSHV/HHV-8 | Kaposi sarcoma, primary effusion lymphoma | vFLIP, vCyclin, LANA |
+| MCPyV | Merkel cell carcinoma | Large T, small T |
+| HIV-1 | Kaposi sarcoma, non-Hodgkin lymphoma | Tat, Nef |
+
+The clinical helper uses human-exclusive viral peptides. For exploratory use,
+`cancer_specific_viral_peptides()` permits CTA overlaps while excluding
+non-CTA human overlaps.
+
+### Recurrent mutations
+
+| Gene | Supported hotspots | Common contexts |
+|---|---|---|
+| KRAS | G12C, G12D, G12V, G12R, G13D | Pancreatic, colorectal, NSCLC |
+| BRAF | V600E, V600K | Melanoma, colorectal, thyroid |
+| TP53 | R175H, R248W, R273H, G245S, R249S | Pan-cancer |
+| PIK3CA | H1047R, E545K | Breast, endometrial |
+| IDH1 | R132H | Glioma, AML |
+| NRAS | Q61R, Q61K | Melanoma |
+| EGFR | L858R, T790M | NSCLC |
+
+Use `HOTSPOT_MUTATIONS` for the executable list rather than parsing this table.
+
+## Advanced controls
+
+- Change CTA inclusion with `--min-cta-tpm` and
+  `--min-restriction-confidence`.
+- Add an mTEC expression gate with `--mtec-matrix-path` and
+  `--mtec-max-tpm`.
+- Change peptide lengths with `--lengths`.
+- Select another supported predictor with `--predictor`. Tier thresholds are
+  calibrated to MHCflurry, so interpret other predictors cautiously.
+- Retain healthy-tissue observations only for investigation with
+  `--no-enforce-tumor-specificity`.
+- Relax viral human exclusivity only for investigation with
+  `--no-require-human-exclusive-viral`.
+- Disable presentation scoring with `--no-score`.
+
+Run `tsarina personalize --help` for the complete current option list.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,3 +1,67 @@
+# PR — Reorganize Documentation from Overview to Reference (2026-07-24)
+
+## Goal
+
+Make the documentation readable in progressive layers: first explain what
+Tsarina does and which workflow a reader should choose, then present operational
+guidance, and only then expose schemas, flags, formulas, and edge cases.
+
+## Audit findings
+
+- Tracking issue:
+  [tsarina #144](https://github.com/pirl-unc/tsarina/issues/144).
+- `README.md` and `docs/index.md` duplicate nearly the same 400-line manual and
+  have already drifted in product naming and CLI examples.
+- The largest block, CTA × HLA panel internals, is embedded in both entry
+  documents instead of a focused workflow guide.
+- Workflow choice is implicit; users encounter target taxonomy before learning
+  whether they need personalized target selection or cohort panel design.
+- Data/evidence concepts, scoring, naming, and development reference are
+  separate top-level fragments rather than one coherent reference layer.
+- `docs/curation.md` is accurate but moves directly into implementation
+  ownership without an at-a-glance boundary and reader-oriented purpose.
+
+## Plan
+
+- [x] Make `README.md` a concise product overview with a workflow map, quick
+      start, target-category summary, documentation map, and development entry.
+- [x] Make `docs/index.md` a reader-oriented documentation hub: choose a
+      workflow first, understand the shared pipeline second, then navigate to
+      focused guides.
+- [x] Create a personalized-target guide organized as outcome → required
+      inputs → basic workflow → output/prioritization → advanced considerations.
+- [x] Create a panel-design guide organized as outcome → default pipeline →
+      selection stages → output controls → evidence tiers → HLA/coverage
+      reference → advanced options.
+- [x] Create a data-and-evidence reference organized as evidence model → source
+      classification → data setup → tissue/scoring helpers → output naming.
+- [x] Reorganize CTA ownership guidance as summary → ownership boundary →
+      evidence flow → API behavior → maintenance.
+- [x] Verify documented commands and flags against current CLI help, validate
+      Markdown links/headings, and remove stale duplicated wording.
+- [x] Bump the package version and run `./format.sh`, `./lint.sh`, and
+      `./test.sh`.
+- [ ] Open, merge, and deploy the PR.
+
+## Review
+
+- Replaced the duplicated 400-line README/index manuals with a 107-line
+  product overview and a 120-line workflow-oriented documentation hub.
+- Moved operational detail into focused personalized-target, panel-design, and
+  data/evidence guides, each ordered from purpose and defaults to advanced
+  reference material.
+- Reordered CTA curation guidance around an at-a-glance ownership boundary
+  before its schema, API, and maintenance details.
+- Corrected stale product naming, personalized output columns, panel progress
+  flags, the data discovery command, inclusive panel cutoffs, and the hotspot
+  registry's gene count.
+- Verified all local Markdown links and every documented CLI option against the
+  current parsers.
+- Released code version is prepared as 1.24.1.
+- Verification passed: `./format.sh`, `./lint.sh`, and `./test.sh` (423 tests).
+
+---
+
 # PR — Make oncoref the Sole CTA Definition Authority (2026-07-24)
 
 ## Goal

--- a/tsarina/version.py
+++ b/tsarina/version.py
@@ -10,4 +10,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "1.24.0"
+__version__ = "1.24.1"


### PR DESCRIPTION
## What changed

- replace the duplicated long-form README and docs index with concise orientation layers
- add focused guides for personalized target selection, CTA panel design, and data/evidence
- reorganize CTA ownership documentation from an at-a-glance boundary into evidence, API, and maintenance details
- correct stale product naming, CLI examples, output columns, panel cutoff notation, and hotspot gene count
- bump the package version to 1.24.1

## Why

The README and documentation index had each grown into a roughly 400-line
manual. Their duplication obscured workflow choice, buried high-level
explanations beneath reference details, and allowed examples to drift from the
implementation.

The new hierarchy uses progressive disclosure: product outcome → workflow
choice → shared pipeline → focused operational guide → advanced reference.

## User impact

Readers can now identify the relevant workflow immediately and encounter
defaults before advanced flags, schemas, formulas, and provenance. The focused
guides retain the detailed technical material without duplicating it across
entry pages.

## Validation

- local Markdown links resolve
- documented CLI options match current parser help
- `./format.sh`
- `./lint.sh`
- `./test.sh` (423 passed)

Closes #144
